### PR TITLE
Add check for the existence of ramdisk-busybox.img before running FWT…

### DIFF
--- a/common/config/startup.nsh
+++ b/common/config/startup.nsh
@@ -86,8 +86,9 @@ endfor
 
 :Donebsa
 for %l in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
-    if exist FS%l:\Image then
+    if exist FS%l:\Image and exist FS%l:\ramdisk-busybox.img then
         FS%l:
+        cd FS%l:\
         Image initrd=\ramdisk-busybox.img systemd.log_target=null plymouth.ignore-serial-consoles debug crashkernel=512M,high log_buf_len=1M efi=debug acpi=on crashkernel=256M earlycon uefi_debug
     endif
 endfor


### PR DESCRIPTION
…S tests

There could be situations when Linux with file "Image" in root directory exists
on the file system with a lower number than the file system with ACS tests
(Linux is installed on eMMC, ACS tests - external storage).
So, the wrong Linux without ramdisk-busybox.img is booting and FWTS tests are not performed.

Signed-off-by: Nazarii Obukhovskyi <nazarii.obukhovskyi@globallogic.com>