### PR TITLE
SystemReady 1.0 Rel Changes

### DIFF
--- a/ES/README.md
+++ b/ES/README.md
@@ -12,8 +12,8 @@ SystemReady ES-certified platforms implement a minimum set of hardware and firmw
 This section contains the build scripts and the live-images for the SystemReady ES Band.
 
 ## Release details
- - Code Quality: v0.9 BETA
- - **The latest pre-built release of ACS is available for download here: [v21.07_0.9_BETA](prebuilt_images/v21.07_0.9_BETA)**
+ - Code Quality: v1.0
+ - **The latest pre-built release of ACS is available for download here: [v21.09_1.0](prebuilt_images/v21.09_1.0)**
  - The BSA tests are written for version 1.0 of the BSA specification.
  - The BBR tests are written for version 1.0 of the BBR specification.
  - The compliance suite is not a substitute for design verification.
@@ -31,12 +31,12 @@ This section contains the build scripts and the live-images for the SystemReady 
 ### Prebuilt images
 - Prebuilt images for each release are available in the prebuilt_images folder. You can either choose to use these images or build your own image by following the build steps.
 - To access the prebuilt_images, click : [prebuilt_images](prebuilt_images/)
-- If you choose to use the prebuilt image, skip the build steps, and jump to the "Verification" section below.
+- If you choose to use the prebuilt image, skip the build steps, and navigate to the "Verification" section below.
 
 ### Prerequisites
 Before starting the ACS build, ensure that the following requirements are met:
  - Ubuntu 18.04 or 20.04 LTS with at least 32GB of free disk space.
- - Must use Bash shell.
+ - Use bash shell.
  - You must have **sudo** privilege to install tools required for build.
  - Install `git` using `sudo apt install git`
  - `git config --global user.name "Your Name"` and `git config --global user.email "Your Email"` must be configured.
@@ -56,7 +56,7 @@ Before starting the ACS build, ensure that the following requirements are met:
 
 5. If all the above steps are successful, then the  bootable image will be available at **/path-to-arm-systemready/ES/scripts/output/es_acs_live_image.img.xz**
 
-Note: The image is generated in a compressed (.xz) format. The image must be uncompressed before they are used.<br />
+Note: The image is generated in a compressed (.xz) format. The image must be uncompressed before it is used.<br />
 
 ## Build output
 This image comprises of two FAT file system partitions recognized by UEFI: <br />
@@ -70,11 +70,24 @@ This image comprises of two FAT file system partitions recognized by UEFI: <br /
 
 Note: UEFI EDK2 setting for "Console Preference": The default is "Graphical". When that is selected, Linux output will go only to the graphical console (HDMI monitor). To force serial console output, you may change the "Console Preference" to "Serial".
 
-### Verification of the ES Image on Neoverse N2 reference design (RD-N2)
+### Verification of the ES image on the Arm Neoverse N2 reference design (RD-N2)
 
-#### Install RD-N2 platform FVP
+#### Prerequisites
+- If the system supports LPIs (Interrupt ID > 8192) then Firmware should support installation of handler for LPI interrupts.
+    - If you are using edk2, change the ArmGic driver in the ArmPkg to support installation of handler for LPIs.
+    - Add the following in \<path to RDN2 software stack\>/uefi/edk2/ArmPkg/Drivers/ArmGic/GicV3/ArmGicV3Dxe.c
+>        - After [#define ARM_GIC_DEFAULT_PRIORITY  0x80]
+>          +#define ARM_GIC_MAX_NUM_INTERRUPT 16384
+>        - Change this in GicV3DxeInitialize function.
+>          -mGicNumInterrupts      = ArmGicGetMaxNumInterrupts (mGicDistributorBase);
+>          +mGicNumInterrupts      = ARM_GIC_MAX_NUM_INTERRUPT;
 
-Follow the steps mentioned in [RD-N2 platform software user guide](https://gitlab.arm.com/arm-reference-solutions/arm-reference-solutions-docs/-/tree/master/docs/infra/rdn2) to build and install the RD-N2 platform FVP
+#### Follow the steps mentioned in [RD-N2 platform software user guide](https://gitlab.arm.com/arm-reference-solutions/arm-reference-solutions-docs/-/tree/master/docs/infra/rdn2) to obtain RD-N2 FVP.
+
+### For software stack build instructions follow Busybox Boot link under Supported Features by RD-N2 platform software stack section in the same guide.
+
+Note: RD-N2 should be built with the GIC Changes mentioned in Prerequisites.<br />
+Note: sudo permission will be required by building software stack.
 
 
 #### Verifying the ACS-ES pre-built image
@@ -91,7 +104,7 @@ cd /path to RD-N2_FVP platform software/model-scripts/rdinfra/platforms/rdn2
 This will start the ACS live image automation and run the test suites in sequence.
 
 Known Limitations:<br />
-On FVP models, during the execution of the UEFI-SCT suite, the following behavior is observed:
+On FVP models, with versions previous to 11.15.23, during the execution of the UEFI-SCT suite, the following behavior is observed:
 
 1. Execution of “UEFIRuntimeServices” tests may cause the test execution on FVP to stall and become non-responsive.
 The message displayed prior to this stall would be either “System may reset after 1 second…” or a print associated with “SetTime” tests.
@@ -100,7 +113,7 @@ The FVP execution must be terminated and restarted by running the run_model.sh s
 The execution will continue from the test that is next in sequence of the test prior to FVP stall.
 
 2. It may appear that the test execution has stalled with the message “Waiting for few seconds for signal …” displayed on the console.
-This is expected behavior and the forward progress of tests will continue after a 20 minute delay.
+This is expected behavior and the forward progress of tests will continue after a 20-minute delay.
 
 
 ### Automation
@@ -114,13 +127,13 @@ The live image boots to UEFI Shell. The different test applications can be run i
 
 ## Baselines for Open Source Software in this release:
 
-- [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git) TAG: 08378441d14c0c28b51f9843906582a81a9c1659
+- [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git) TAG: V21.08.00 
 
-- [Base System Architecture (BSA)](https://github.com/ARM-software/bsa-acs) TAG: v21.07_0.9_BETA
+- [Base System Architecture (BSA)](https://github.com/ARM-software/bsa-acs) TAG: v21.09_1.0
 
-- [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs) TAG: : v21.07_0.9_BETA
+- [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs) TAG: : v21.09_1.0
 
-- [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test) TAG: 61dddf12db3d17cf19134089db45fbefb29ed004
+- [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test) TAG: edk2-test-stable202108
 
 
 

--- a/ES/prebuilt_images/README.md
+++ b/ES/prebuilt_images/README.md
@@ -1,0 +1,11 @@
+## Uncompression of the prebuilt_images
+The prebuilt images are archived after compression to the .xz format.
+The images must be uncompressed before they are used.
+
+### Linux
+On Linux, use the xz utility to uncompress the image 
+`xz -d es_acs_live_image.img.xz`
+
+### Windows
+On Windows, use the 7zip or similar utility
+

--- a/IR/README.md
+++ b/IR/README.md
@@ -4,6 +4,7 @@
 SystemReady IoT Ready (IR) is a band of system certification in the Arm SystemReady program. This certification is for devices in the IoT edge sector that are built around SoCs based on the Arm A-profile architecture. It ensures interoperability with embedded Linux and other embedded operating systems.
 
 SystemReady IR-certified platforms implement a minimum set of hardware and firmware features that an operating system can depend on to deploy the operating system image. Compliant systems must conform to the:
+* [Base System Architecture (BSA) specification](https://developer.arm.com/documentation/den0094/latest)
 * [Embedded Base Boot Requirements (EBBR)](https://developer.arm.com/architectures/platform-design/embedded-systems)
 * EBBR recipe of the [Arm Base Boot Requirements (BBR) specification](https://developer.arm.com/documentation/den0044/latest)
 * SystemReady IR certification and testing requirements are specified in the [Arm SystemReady Requirements Specification (SRS)](https://developer.arm.com/documentation/den0109/latest)
@@ -11,8 +12,8 @@ SystemReady IR-certified platforms implement a minimum set of hardware and firmw
 This section of the repository contains the build scripts and the live-images for the SystemReady IR Band.
 
 ## Release details
- - Code Quality: v0.9 BETA
- - **The latest pre-built release of IR ACS is available for download here: [v21.07_0.9_BETA](prebuilt_images/v21.07_0.9_BETA)**
+ - Code Quality: v1.0
+ - **The latest pre-built release of IR ACS is available for download here: [v21.09_1.0](prebuilt_images/v21.09_1.0)**
  - The BSA tests are written for version 1.0 of the BSA specification.
  - The BBR tests are written for version 1.0 of the BBR specification.
  - The compliance suite is not a substitute for design verification.
@@ -30,7 +31,7 @@ This section of the repository contains the build scripts and the live-images fo
 ### Prebuilt images
 - Prebuilt images for each release are available in the prebuilt_images folder. You can either choose to use these images or build your own image by following the build steps.
 - To access the prebuilt_images, click : [prebuilt_images](prebuilt_images/)
-- If you choose to use the prebuilt image, skip the build steps, and jump to the "Verification" section below.
+- If you choose to use the prebuilt image, skip the build steps, and navigate to the "Verification" section below.
 
 ### Prerequisites
 Before starting the ACS build, ensure that the following requirements are met:
@@ -68,142 +69,38 @@ This image comprises of two FAT file system partitions recognized by UEFI: <br /
 
 Note: UEFI EDK2 setting for "Console Preference": The default is "Graphical". In this default setting, Linux output will go only to the graphical console (HDMI monitor). To force serial console output, you may change the "Console Preference" to "Serial".
 
-### Verification of the IR Image on arm Base FVP Models
+### Verification of the IR image on Qemu arm machine
 
-#### Base FVP Models can be obtained from [arm developer page](https://developer.arm.com/tools-and-software/simulation-models/fixed-virtual-platforms)
+#### Follow the Build instructions mentioned in [qemu download page](https://www.qemu.org/download/#source) to build latest qemu model.
 
-#### Software stack for models can be built following steps mentioned in [linaro arm-reference-platforms user guide](https://git.linaro.org/landing-teams/working/arm/arm-reference-platforms.git/about/docs/user-guide.rst)
-- To use Yocto for building  Board Support Package, refer [linaro basefvp user guide](https://git.linaro.org/landing-teams/working/arm/arm-reference-platforms.git/about/docs/basefvp/user-guide.rst)
+#### To build the firmware image, follow below steps
 
-- Following changes needs to be enabled in the u-boot.
 ```
---- a/arch/arm/Kconfig
-+++ b/arch/arm/Kconfig
-@@ -1188,6 +1188,7 @@ config TARGET_VEXPRESS64_BASE_FVP
-        select ARM64
-        select PL01X_SERIAL
-        select SEMIHOSTING
-+       select OF_CONTROL
+mkdir working_directory
+cd working_directory
+repo init -u https://github.com/glikely/u-boot-manifest
+repo sync
+export CROSS_COMPILE=<path to gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf/bin/aarch64-none-elf->
+make qemu_arm64_defconfig
+make
 ```
-```
---- a/arch/arm/dts/Makefile
-+++ b/arch/arm/dts/Makefile
-@@ -4,6 +4,7 @@ dtb-$(CONFIG_TARGET_SMARTWEB) += at91sam9260-smartweb.dtb
- dtb-$(CONFIG_TARGET_TAURUS) += at91sam9g20-taurus.dtb
- dtb-$(CONFIG_TARGET_CORVUS) += at91sam9g45-corvus.dtb
- dtb-$(CONFIG_TARGET_GURNARD) += at91sam9g45-gurnard.dtb
-+dtb-y += fvp-base-aemv8a-aemv8a.dtb
-```
-NOTE: If using Base RevC FVP Model, use the device tree file for that model.
+nor_flash.bin will be generated once build is completed.
 
-- Change the bootcmd to
-```
-+#define CONFIG_BOOTCOMMAND     "fdt addr ${fdtcontroladdr};" \
-+                               "  virtio scan; " \
-+                               "  virtio info; " \
-+                               "  fatload virtio 0 ${kernel_addr} EFI/BOOT/bootaa64.efi; " \
-+                               "  bootefi $kernel_addr  $fdtcontroladdr; "
-```
+NOTE: If sync fails due repo version , please update repo using below steps.<br />
+NOTE: Toolchain can be downloaded from [arm developer page](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads/10-2-2020-11)
 
-- Enable below configs via menuconfig
-```
-Device Drivers → Support block devices
-Device Drivers → VirtIO drivers → Platform bus driver for memory mapped virtio devices
-Device Drivers → VirtIO drivers → Platform driver for virtio devices
-Device Drivers → VirtIO drivers → Platform block driver
-Device Tree Control → Default Device Tree for DT Control → fvp-base-aemv8a-aemv8a
-```
-If the Model supports PCIe, enable below configs also
-```
-Device Drivers → PCI support
-Device Drivers → PCI support → Enable driver model for PCI
-Device Drivers → PCI support → Generic ECAM-based PCI host controller support
-```
 
+```
+mkdir -p ~/.bin
+PATH="${HOME}/.bin:${PATH}"
+curl https://storage.googleapis.com/git-repo-downloads/repo > ~/.bin/repo
+chmod a+rx ~/.bin/repo
+```
 #### Verifying the ACS-IR pre-built image
-1. Set the enviroment variable 'MODEL'
+Launch model with below command
+
 ```
-export MODEL=<absolute path to the Base FVP bianry>
-```
-2. Set the enviroment variable 'BL1'
-```
-export BL1=<absolute path to the BL1 binary>
-```
-3. Set the enviroment variable 'FIP'
-```
-export FIP=<absolute path to the FIP binary>
-```
-4. Set the enviroment variable 'DISK'
-```
-export DISK=<absolute path to the ACS-IR image>
-```
-5. Launch model with below command
-```
-$MODEL \
--C pctl.startup=0.0.0.0 \
--C bp.secure_memory=0 \
--C cluster0.NUM_CORES=4 \
--C cluster1.NUM_CORES=4 \
--C cache_state_modelled=0 \
--C bp.pl011_uart0.untimed_fifos=1 \
--C bp.pl011_uart0.unbuffered_output=1 \
--C bp.pl011_uart0.out_file=uart0.log \
--C bp.pl011_uart1.out_file=uart1.log \
--C bp.secureflashloader.fname=${BL1} \
--C bp.flashloader0.fname=${FIP} \
--C bp.ve_sysregs.mmbSiteDefault=0 \
--C bp.ve_sysregs.exit_on_shutdown=1 \
--C bp.virtioblockdevice.image_path=${DISK} \
--C cluster0.has_fp16=2 \
--C cluster1.has_fp16=2 \
--C cluster0.has_arm_v8-1=1 \
--C cluster0.has_arm_v8-2=1 \
--C cluster0.has_arm_v8-3=1 \
--C cluster0.has_arm_v8-4=1 \
--C cluster0.has_arm_v8-5=1 \
--C cluster0.has_arm_v8-6=1 \
--C cluster1.has_arm_v8-1=1 \
--C cluster1.has_arm_v8-2=1 \
--C cluster1.has_arm_v8-3=1 \
--C cluster1.has_arm_v8-4=1 \
--C cluster1.has_arm_v8-5=1 \
--C cluster1.has_arm_v8-6=1 \
--C cluster0.restriction_on_speculative_execution=2 \
--C cluster1.restriction_on_speculative_execution=2 \
--C cluster0.pstate_ssbs_type=2 \
--C cluster1.pstate_ssbs_type=2 \
--C cluster0.cpu0.number-of-breakpoints=16 \
--C cluster0.cpu1.number-of-breakpoints=16 \
--C cluster0.cpu2.number-of-breakpoints=16 \
--C cluster0.cpu3.number-of-breakpoints=16 \
--C cluster0.cpu4.number-of-breakpoints=16 \
--C cluster0.cpu5.number-of-breakpoints=16 \
--C cluster0.cpu6.number-of-breakpoints=16 \
--C cluster0.cpu7.number-of-breakpoints=16 \
--C cluster1.cpu0.number-of-breakpoints=16 \
--C cluster1.cpu1.number-of-breakpoints=16 \
--C cluster1.cpu2.number-of-breakpoints=16 \
--C cluster1.cpu3.number-of-breakpoints=16 \
--C cluster1.cpu4.number-of-breakpoints=16 \
--C cluster1.cpu5.number-of-breakpoints=16 \
--C cluster1.cpu6.number-of-breakpoints=16 \
--C cluster1.cpu7.number-of-breakpoints=16 \
--C cluster0.cpu0.number-of-context-breakpoints=16 \
--C cluster0.cpu1.number-of-context-breakpoints=16 \
--C cluster0.cpu2.number-of-context-breakpoints=16 \
--C cluster0.cpu3.number-of-context-breakpoints=16 \
--C cluster0.cpu4.number-of-context-breakpoints=16 \
--C cluster0.cpu5.number-of-context-breakpoints=16 \
--C cluster0.cpu6.number-of-context-breakpoints=16 \
--C cluster0.cpu7.number-of-context-breakpoints=16 \
--C cluster1.cpu0.number-of-context-breakpoints=16 \
--C cluster1.cpu1.number-of-context-breakpoints=16 \
--C cluster1.cpu2.number-of-context-breakpoints=16 \
--C cluster1.cpu3.number-of-context-breakpoints=16 \
--C cluster1.cpu4.number-of-context-breakpoints=16 \
--C cluster1.cpu5.number-of-context-breakpoints=16 \
--C cluster1.cpu6.number-of-context-breakpoints=16 \
--C cluster1.cpu7.number-of-context-breakpoints=16 \
+<path to qemu-system-aarch64> -bios <path to nor_flash.bin>  -drive file=<path to ir_acs_live_image.img>,if=virtio,format=raw  -cpu cortex-a57 -smp 2 -m 2048 -M virt,secure=on -monitor null -no-acpi -nodefaults -nographic -rtc base=utc,clock=host -serial stdio -d unimp,guest_errors -machine virtualization=on
 ```
 ### Automation
 The test suite execution can be automated or manual. Automated execution is the default execution method when no key is pressed during boot. <br />
@@ -215,13 +112,13 @@ The live image boots to UEFI Shell. The different test applications can be run i
 
 ## Baselines for Open Source Software in this release:
 
-- [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git) TAG: 08378441d14c0c28b51f9843906582a81a9c1659
+- [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git) TAG: V21.08.00 
 
-- [Base System Architecture (BSA)](https://github.com/ARM-software/bsa-acs) TAG: v21.07_0.9_BETA
+- [Base System Architecture (BSA)](https://github.com/ARM-software/bsa-acs) TAG: v21.09_1.0
 
-- [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs) TAG: : v21.07_0.9_BETA
+- [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs) TAG: : v21.09_1.0
 
-- [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test) TAG: 61dddf12db3d17cf19134089db45fbefb29ed004
+- [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test) TAG: edk2-test-stable202108
 
 
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Navigate to the ES or IR band for further details on specific scripts and prebui
 * [ES](./ES)
 * [IR](./IR)
 
+## Limitations
+
+Validating the compliance of certain PCIe rules defined in the BSA specification require the PCIe end-point generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
+The details of the hardware or Verification IP which enable these exerciser tests platform specific and are beyond the scope of this document.
+
+The Live image does not allow customizations, hence, the exerciser module is not included in the Live image. To enable exerciser tests for greater coverage of PCIe rules, please refer to [BSA](https://github.com/ARM-software/bsa-acs) Or contact your Arm representative for details.
+
 ## License
 
 Arm SystemReady ACS is distributed under Apache v2.0 License.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,20 @@
+v21.09_1.0
+**SystemReady IR**
+* BSA: Increased peripheral rules coverage
+* SystemReady IR README.md updates (Reference platform)
+
+**SystemReady ES**
+* BSA: Increased ITS tests coverage for systems presenting firmware which is SBBR complaint
+* SystemReady ES README.md updates
+
+**Common**
+* Upgrading ACS image to v5.13 kernel
+* BBR: Refinement of UEFI-SCT Sequence files for IR  verification
+* BBR: Migrate to the version V21.08.00 of FWTS
+* BBR: Migrate to edk2-test-stable202108 tag of SCT
+* General improvements in scripts
+* Bug Fixes
+
 v21.07_0.9_BETA
 **SystemReady IR**
 * BSA: Increased PCIe rules coverage
@@ -20,9 +37,8 @@ v21.07_0.9_BETA
 * Bug Fixes
 
 
-
 v21.05_0.8_BETA-0
-**SystemReady IR** 
+**SystemReady IR**
 * BSA: BSA Tests for IR based on BSA specifications v1.0
 * BSA: Modules: PE, Memory map, GIC, Timer, SMMU, Watchdog, Peripheral, PCIe, Power and wakeup
   For the complete list of tests refer to the bsa-acs repository

--- a/common/config/bsa.nsh
+++ b/common/config/bsa.nsh
@@ -39,10 +39,10 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             if exist FS%j:\EFI\BOOT\bsa\Bsa.efi then
                 if exist FS%j:\EFI\BOOT\bsa\ir_bsa.flag then
                     #Executing for BSA IR. Execute only OS tests
-                    FS%j:\EFI\BOOT\bsa\Bsa.efi -os -f BsaResults.log
+                    FS%j:\EFI\BOOT\bsa\Bsa.efi -os -skip 900 -f BsaResults.log
                     goto Done
                 endif
-                FS%j:\EFI\BOOT\bsa\Bsa.efi -f BsaResults.log
+                FS%j:\EFI\BOOT\bsa\Bsa.efi -skip 900 -f BsaResults.log
                 goto Done
             endif
         endfor

--- a/common/config/common_config.cfg
+++ b/common/config/common_config.cfg
@@ -30,7 +30,7 @@
 
 
 #Linux kernel version. Source downloaded from https://github.com/torvalds/linux.git
-LINUX_KERNEL_VERSION=5.11
+LINUX_KERNEL_VERSION=5.13
 
 #BusyBox source tag : https://git.busybox.net/busybox/
 BUSYBOX_SRC_VERSION=1_31_stable
@@ -43,20 +43,20 @@ LINARO_TOOLS_MAJOR_VERSION=7.5-2019.12
 LINARO_TOOLS_VERSION=7.5.0-2019.12
 
 #FWTS source tag from  https://git.launchpad.net/fwts
-FWTS_SRC_TAG=08378441d14c0c28b51f9843906582a81a9c1659
+FWTS_SRC_TAG=V21.08.00
 
-# EDK2-TEST source tag from  https://github.com/tianocore/edk2-test 
-SCT_SRC_TAG=61dddf12db3d17cf19134089db45fbefb29ed004
+# EDK2-TEST source tag from  https://github.com/tianocore/edk2-test
+SCT_SRC_TAG=edk2-test-stable202108
 
 #Arm BSA source tag.
 #NOTE: If the value is NULL then the latest BSA source will be downloaded
-ARM_BSA_TAG="v21.07_0.9_BETA"
+ARM_BSA_TAG="v21.09_1.0"
 
 #Arm BBR source tag
 #NOTE: If the value is NULL then the latest BBR source will be downloaded
-ARM_BBR_TAG="v21.07_0.9_BETA"
+ARM_BBR_TAG="v21.09_1.0"
 
 #Arm LINUX ACS source tag
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded
-ARM_LINUX_ACS_TAG="v21.07_0.9_BETA"
+ARM_LINUX_ACS_TAG="v21.09_1.0"
 

--- a/common/config/startup.nsh
+++ b/common/config/startup.nsh
@@ -31,19 +31,6 @@ echo -off
 for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%i:\EFI\BOOT\bbr\SctStartup.nsh then
         FS%i:\EFI\BOOT\bbr\SctStartup.nsh
-        for %k in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
-            if  exist FS%k:\acs_results\sct_results\ then
-                if  exist FS%i:\EFI\BOOT\bbr\SCT\Overall then
-                    cp -r FS%i:\EFI\BOOT\bbr\SCT\Overall FS%k:\acs_results\sct_results\
-                endif
-                if  exist FS%i:\EFI\BOOT\bbr\SCT\Dependency\EfiCompliantBBTest then
-                    cp -r FS%i:\EFI\BOOT\bbr\SCT\Dependency\EfiCompliantBBTest FS%k:\acs_results\sct_results\
-                endif
-                if  exist FS%i:\EFI\BOOT\bbr\SCT\Sequence then
-                    cp -r FS%i:\EFI\BOOT\bbr\SCT\Sequence FS%k:\acs_results\sct_results\
-                endif
-            endif
-        endfor
         goto Donebbr
     endif
 endfor

--- a/common/ramdisk/init.sh
+++ b/common/ramdisk/init.sh
@@ -68,7 +68,7 @@ if [ -f  /bin/ir_bbr_fwts_tests.ini ]; then
  /bin/fwts `echo $test_list` -f -r /mnt/acs_results/fwts/FWTSResults.log
 else
  #SBBR Execution
- /bin/fwts  -r stdout -q --sbbr > /mnt/acs_results/fwts/FWTSResults.log
+ /bin/fwts  -r stdout -q --sbbr esrt uefibootpath > /mnt/acs_results/fwts/FWTSResults.log
 fi
 
 sleep 2

--- a/common/scripts/build-bsaefi.sh
+++ b/common/scripts/build-bsaefi.sh
@@ -99,7 +99,7 @@ do_build()
     arch=$(uname -m)
     if [[ $arch = "aarch64" ]]
     then
-	echo "arm64 native compile"
+        echo "arm64 native compile"
     else
         CROSS_COMPILE_DIR=$(dirname $CROSS_COMPILE)
         PATH="$PATH:$CROSS_COMPILE_DIR"

--- a/common/scripts/build-busybox.sh
+++ b/common/scripts/build-busybox.sh
@@ -54,8 +54,7 @@ BUSYBOX_ARCH=arm64
 BUSYBOX_PATH=busybox
 BUSYBOX_OUT_DIR=output
 BUSYBOX_RAMDISK_PATH=ramdisk
-GCC=tools/gcc-linaro-${LINARO_TOOLS_VERSION}-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
-CROSS_COMPILE=$TOP_DIR/$GCC
+
 BUSYBOX_RAMDISK_BUSYBOX_PATH=$BUSYBOX_PATH/$BUSYBOX_OUT_DIR/_install/bin
 
 do_build()

--- a/common/scripts/build-linux-bsa.sh
+++ b/common/scripts/build-linux-bsa.sh
@@ -28,12 +28,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-
 TOP_DIR=`pwd`
 . $TOP_DIR/../../common/config/common_config.cfg
 
-GCC=tools/gcc-linaro-${LINARO_TOOLS_VERSION}-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
-export CROSS_COMPILE=$TOP_DIR/$GCC
 export KERNEL_SRC=$TOP_DIR/linux-${LINUX_KERNEL_VERSION}/out
 LINUX_PATH=$TOP_DIR/linux-${LINUX_KERNEL_VERSION}
 BSA_PATH=$TOP_DIR/edk2/ShellPkg/Application/bsa-acs
@@ -41,17 +38,17 @@ BSA_PATH=$TOP_DIR/edk2/ShellPkg/Application/bsa-acs
 build_bsa_kernel_driver()
 {
  pushd $TOP_DIR/linux-acs/bsa-acs-drv/files
- ./setup.sh $TOP_DIR/edk2/ShellPkg/Application/bsa-acs
-    cmd=$(uname -m)
-    echo $cmd
-    if [[ $cmd = "aarch64" ]]
+    arch=$(uname -m)
+    echo $arch
+    if [[ $arch = "aarch64" ]]
     then
-	echo "arm64 native build"
+        echo "arm64 native build"
         export CROSS_COMPILE=''
     else
         GCC=tools/gcc-linaro-${LINARO_TOOLS_VERSION}-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
         export CROSS_COMPILE=$TOP_DIR/$GCC
     fi
+ ./setup.sh $TOP_DIR/edk2/ShellPkg/Application/bsa-acs
  ./linux_bsa_acs.sh
  popd
 }

--- a/common/scripts/build-linux.sh
+++ b/common/scripts/build-linux.sh
@@ -59,8 +59,6 @@ TOP_DIR=`pwd`
 
 LINUX_ARCH=arm64
 LINUX_IMAGE_TYPE=Image
-GCC=tools/gcc-linaro-${LINARO_TOOLS_VERSION}-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
-CROSS_COMPILE=$TOP_DIR/$GCC
 
 do_build ()
 {
@@ -70,27 +68,27 @@ do_build ()
     mkdir -p $LINUX_OUT_DIR
     echo "Building using defconfig..."
     cp arch/arm64/configs/defconfig $LINUX_OUT_DIR/.config
-    machine=$(uname -m)
-    if [[ $machine = "aarch64" ]]
+    arch=$(uname -m)
+    if [[ $arch = "aarch64" ]]
     then
-	echo "arm64"
+        echo "arm64"
         make ARCH=arm64 O=$LINUX_OUT_DIR olddefconfig
     else
-	echo "x86 cross compile"
+        echo "x86 cross compile"
         GCC=tools/gcc-linaro-${LINARO_TOOLS_VERSION}-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-
         CROSS_COMPILE=$TOP_DIR/$GCC
         make ARCH=arm64 CROSS_COMPILE=$TOP_DIR/$GCC O=$LINUX_OUT_DIR olddefconfig
     fi
-    #Configurations needed for FWTS 
+    #Configurations needed for FWTS
     sed -i 's/# CONFIG_EFI_TEST is not set/CONFIG_EFI_TEST=y/g' $LINUX_OUT_DIR/.config
     sed -i 's/# CONFIG_DMI_SYSFS is not set/CONFIG_DMI_SYSFS=y/g' $LINUX_OUT_DIR/.config
     sed -i 's/# CONFIG_CGROUP_FREEZER is not set/CONFIG_CGROUP_FREEZER=y/g' $LINUX_OUT_DIR/.config
     sed -i 's/# CONFIG_COMMON_CLK_ZYNQMP is not set/CONFIG_COMMON_CLK_ZYNQMP=y/g' $LINUX_OUT_DIR/.config
     sed -i 's/# CONFIG_EFI_GENERIC_STUB_INITRD_CMDLINE_LOADER is not set/CONFIG_EFI_GENERIC_STUB_INITRD_CMDLINE_LOADER=y/g' $LINUX_OUT_DIR/.config
 
-    if [[ $machine = "aarch64" ]]
+    if [[ $arch = "aarch64" ]]
     then
-	echo "arm64 machine"
+        echo "arm64 machine"
         make ARCH=arm64 O=$LINUX_OUT_DIR -j$PARALLELISM
     else
         make ARCH=arm64 CROSS_COMPILE=$TOP_DIR/$GCC O=$LINUX_OUT_DIR -j$PARALLELISM

--- a/common/scripts/build-uefi.sh
+++ b/common/scripts/build-uefi.sh
@@ -69,7 +69,7 @@ do_build()
     arch=$(uname -m)
     if [[ $arch = "aarch64" ]]
     then
-	echo "arm64 native build"
+        echo "arm64 native build"
     else
         CROSS_COMPILE_DIR=$(dirname $CROSS_COMPILE)
         PATH="$PATH:$CROSS_COMPILE_DIR"


### PR DESCRIPTION
 1. Support to build IR ACS live image : build scripts and build instructions in documentation
 2. Upgrading ACS image to v5.13 kernel
 3. Refinement of UEFI-SCT Sequence files for IR and ES and verification
 4. Migrate to the version V21.08.00 of FWTS
 5. BBR: Migrate to edk2-test-stable202108 tag of SCT
 6. General improvements in scripts
 7. Bug Fixes

Co-authored-by: Edhaya Chandran <edhaya.chandran@arm.com>
Co-authored-by: Chetan Rathore <chetan.rathore@arm.com>
Co-authored-by: Jiss Jose <jiss.jose@arm.com>

Signed-off-by: jisjos01 <jiss.jose@arm.com>