### PR TITLE
Systemready 1.0 Changes 

### DIFF
--- a/common/config/common_config.cfg
+++ b/common/config/common_config.cfg
@@ -50,13 +50,13 @@ SCT_SRC_TAG=edk2-test-stable202108
 
 #Arm BSA source tag.
 #NOTE: If the value is NULL then the latest BSA source will be downloaded
-ARM_BSA_TAG="v21.09_1.0"
+ARM_BSA_TAG="v21.09_REL1.0"
 
 #Arm BBR source tag
 #NOTE: If the value is NULL then the latest BBR source will be downloaded
-ARM_BBR_TAG="v21.09_1.0"
+ARM_BBR_TAG="v21.09_REL1.0"
 
 #Arm LINUX ACS source tag
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded
-ARM_LINUX_ACS_TAG="v21.09_1.0"
+ARM_LINUX_ACS_TAG="v21.09_REL1.0"
 


### PR DESCRIPTION
Upadate tag names of BBR,BSA,Linux-ACS to v21.09_REL1.0 in common_config

Signed-off-by: jisjos01 <jiss.jose@arm.com>