### PR TITLE
Solve the issue due to certificate verification during build

### DIFF
--- a/common/config/common_config.cfg
+++ b/common/config/common_config.cfg
@@ -50,13 +50,13 @@ SCT_SRC_TAG=edk2-test-stable202108
 
 #Arm BSA source tag.
 #NOTE: If the value is NULL then the latest BSA source will be downloaded
-ARM_BSA_TAG="v21.09_REL1.0"
+ARM_BSA_TAG=""
 
 #Arm BBR source tag
 #NOTE: If the value is NULL then the latest BBR source will be downloaded
-ARM_BBR_TAG="v21.09_REL1.0"
+ARM_BBR_TAG=""
 
 #Arm LINUX ACS source tag
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded
-ARM_LINUX_ACS_TAG="v21.09_REL1.0"
+ARM_LINUX_ACS_TAG=""
 

--- a/common/scripts/get_source.sh
+++ b/common/scripts/get_source.sh
@@ -32,6 +32,8 @@ TOP_DIR=`pwd`
 . $TOP_DIR/../../common/config/common_config.cfg
 #The shell variables use in this file are defined in common_config.cfg
 
+export GIT_SSL_NO_VERIFY=1
+
 get_linux_src()
 {
     echo "Downloading Linux source code. Version : $LINUX_KERNEL_VERSION"


### PR DESCRIPTION
Solve the "SSL certificate problem: certificate has expired" issue
during build of BusyBox and grub. Fixed in get_source.sh

Updated common_config.cfg to get source from latest code for build