### PR TITLE
Add patch to Linux Kernel for ESRT print values

### DIFF
--- a/common/patches/0001-Linux-5.13.patch
+++ b/common/patches/0001-Linux-5.13.patch
@@ -1,0 +1,32 @@
+--- a/drivers/firmware/efi/esrt.c
++++ b/drivers/firmware/efi/esrt.c
+@@ -214,9 +214,16 @@ static struct attribute *esrt_attrs[] = {
+ static inline int esrt_table_exists(void)
+ {
+ 	if (!efi_enabled(EFI_CONFIG_TABLES))
+-		return 0;
++	{
++		pr_info("Check esrt table exist, issue of efi enabled");
++			return 0;
++	}
++	
+ 	if (efi.esrt == EFI_INVALID_TABLE_ADDR)
++	{
++		pr_info("Check esrt table exist, efi invalid table addr");
+ 		return 0;
++	}
+ 	return 1;
+ }
+ 
+@@ -344,6 +351,8 @@ static int __init register_entries(void)
+ 
+ 	if (!esrt_table_exists())
+ 		return 0;
++	pr_info("ESRT value of fw_resource_count=%d\n",esrt->fw_resource_count);
++	pr_info("ESRT value of fw_resource_count_max=%d\n",esrt->fw_resource_count_max);
+ 
+ 	for (i = 0; i < le32_to_cpu(esrt->fw_resource_count); i++) {
+ 		void *esre = NULL;
+-- 
+2.25.1
+

--- a/common/scripts/build-linux.sh
+++ b/common/scripts/build-linux.sh
@@ -69,6 +69,11 @@ do_build ()
     echo "Building using defconfig..."
     cp arch/arm64/configs/defconfig $LINUX_OUT_DIR/.config
     arch=$(uname -m)
+
+    if ! patch -R -p1 -s -f --dry-run < $COMMON_PATCH_DIR/0001-Linux-${LINUX_KERNEL_VERSION}.patch; then
+         echo "Applying Linux Kernel ESRT print values of ESRT Patch ..."
+         patch  -p1  < $COMMON_PATCH_DIR/0001-Linux-${LINUX_KERNEL_VERSION}.patch
+    fi
     if [[ $arch = "aarch64" ]]
     then
         echo "arm64"


### PR DESCRIPTION
    There could be situations when didn`t create ESRT entries in linux system (sysfs),
    because ESRT values do not exist or are incorrect in the firmware

Signed-off-by: vladyslav Kryzhanovskiy <v.s.kryzhanovskyi@globallogic.com>