### PR TITLE
Automatic dump the dtb for IR image

### DIFF
--- a/common/config/bsa.nsh
+++ b/common/config/bsa.nsh
@@ -39,7 +39,7 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             if exist FS%j:\EFI\BOOT\bsa\Bsa.efi then
                 if exist FS%j:\EFI\BOOT\bsa\ir_bsa.flag then
                     #Executing for BSA IR. Execute only OS tests
-                    FS%j:\EFI\BOOT\bsa\Bsa.efi -os -skip 900 -f BsaResults.log
+                    FS%j:\EFI\BOOT\bsa\Bsa.efi -os -skip 900 -dtb BsaDevTree.dtb -f BsaResults.log
                     goto Done
                 endif
                 FS%j:\EFI\BOOT\bsa\Bsa.efi -skip 900 -f BsaResults.log


### PR DESCRIPTION
Changes to automatically dump dtb to a file for SystemReady IR image under acs_results folder