### PR TITLE
Updates in common_config

### DIFF
--- a/common/config/common_config.cfg
+++ b/common/config/common_config.cfg
@@ -30,23 +30,23 @@
 
 
 #Linux kernel version. Source downloaded from https://github.com/torvalds/linux.git
-LINUX_KERNEL_VERSION=5.13
+LINUX_KERNEL_VERSION=5.15
 
 #BusyBox source tag : https://git.busybox.net/busybox/
-BUSYBOX_SRC_VERSION=1_31_stable
+BUSYBOX_SRC_VERSION=1_34_stable
 
 #EDK2 source tag from https://github.com/tianocore/edk2.git
-EDK2_SRC_VERSION=edk2-stable202102
+EDK2_SRC_VERSION=edk2-stable202111
 
 #Cross compiler tools from https://releases.linaro.org/components/toolchain/binaries
 LINARO_TOOLS_MAJOR_VERSION=7.5-2019.12
 LINARO_TOOLS_VERSION=7.5.0-2019.12
 
 #FWTS source tag from  https://git.launchpad.net/fwts
-FWTS_SRC_TAG=V21.08.00
+FWTS_SRC_TAG=1228f0412a6c76b437cfa3078d5dc1fb5ca102c6
 
 # EDK2-TEST source tag from  https://github.com/tianocore/edk2-test
-SCT_SRC_TAG=edk2-test-stable202108
+SCT_SRC_TAG=d919c4a5d9fe2681de4d11a0bbfb07373fe6f9c7
 
 #Arm BSA source tag.
 #NOTE: If the value is NULL then the latest BSA source will be downloaded

--- a/common/config/sr_common_config.cfg
+++ b/common/config/sr_common_config.cfg
@@ -55,13 +55,13 @@ ARM_BSA_TAG=""
 
 #Arm SBSA source tag. Applicable only for SR build.
 #NOTE: If the value is NULL then the latest SBSA source will be downloaded
-ARM_SBSA_TAG="v22.02_SR_REL1.0"
+ARM_SBSA_TAG=""
 
 #Arm BBR source tag
 #NOTE: If the value is NULL then the latest BBR source will be downloaded
-ARM_BBR_TAG="v22.02_SR_REL1.0"
+ARM_BBR_TAG=""
 
 #Arm LINUX ACS source tag
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded
-ARM_LINUX_ACS_TAG="v22.02_SR_REL1.0"
+ARM_LINUX_ACS_TAG=""
 


### PR DESCRIPTION
Updated common_config.cfg for IR and ES images to build with the latest
dependent software
Updated sr_common_config.cfg to remove the release tag to build with the
latest code.