### PR TITLE
Add README for LS

### DIFF
--- a/LS/README.md
+++ b/LS/README.md
@@ -1,0 +1,22 @@
+# SystemReady LS
+
+## Introduction to SystemReady LS
+ 
+SystemReady LS is tailored to meet the needs of many hyperscalers on systems based on server Arm SoCs.
+
+SystemReady LS-certified platforms implement a minimum set of hardware and standard firmware interfaces. Allowing for highly customizable firmware that targets the hyperscaler’s Linux environment.
+
+* [Server Base System Architecture (SBSA) specification](https://developer.arm.com/documentation/den0029/d/?lang=en)
+* LBBR recipe of the [Base Boot Requirements (BBR) specification](https://developer.arm.com/documentation/den0044/latest)
+* The SystemReady LS certification and testing requirements are specified in the [Arm SystemReady Requirements Specification (SRS)](https://developer.arm.com/documentation/den0109/latest)
+
+**Note: SystemReady LS ACS is not presently available, this readme contains instructions for testing and certifying systems for SystemReady LS using the SystemReady SR ACS.**
+
+
+## Testing SystemReady LS using SystemReady SR ACS
+
+The SystemReady SR Architecture Compliance Suite [SR ACS](https://github.com/ARM-software/arm-systemready/tree/main/SR) is designed to test compliance to the SBSA and SBBR requirements for SystemReady SR certification. At this time, the SR ACS tests are also leveraged to for [SystemReady LS v0.9](https://www.arm.com/architecture/system-architectures/systemready-certification-program/ls) certification. This includes testing compliance to the SBSA and LBBR requirements for SystemReady LS.
+
+For full details on certifying systems using SystemReady LS band visit: [SystemReady LS template](https://gitlab.arm.com/systemready/systemready-ls-template)
+ 
+

--- a/LS/README.md
+++ b/LS/README.md
@@ -6,7 +6,7 @@ SystemReady LS is tailored to meet the needs of many hyperscalers on systems bas
 
 SystemReady LS-certified platforms implement a minimum set of hardware and standard firmware interfaces. Allowing for highly customizable firmware that targets the hyperscaler’s Linux environment.
 
-* [Server Base System Architecture (SBSA) specification](https://developer.arm.com/documentation/den0029/d/?lang=en)
+* [Server Base System Architecture (SBSA) specification](https://developer.arm.com/documentation/den0029/latest)
 * LBBR recipe of the [Base Boot Requirements (BBR) specification](https://developer.arm.com/documentation/den0044/latest)
 * The SystemReady LS certification and testing requirements are specified in the [Arm SystemReady Requirements Specification (SRS)](https://developer.arm.com/documentation/den0109/latest)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Navigate to the ES, IR, or SR band for further details on specific scripts and p
 * [ES](./ES)
 * [IR](./IR)
 * [SR](./SR)
+* [LS](./LS)
 
 ## SystemReady Security Interface Extension:
 The SystemReady Security Interface Extension certifies that firmware meets the requirements specified by the Arm [Base Boot Security Requirements specification](https://developer.arm.com/documentation/den0107/latest) (BBSR). The Security Interface Extension is optionally applicable to SystemReady SR, ES and IR bands, but not the LS band.


### PR DESCRIPTION
Points out SR-ACS  is used for LS at this time
Points to LS-template repo for instructions on certification 