### PR TITLE
SR live image changes to run Bsa.efi and Sbsa.efi for SBSA 6.1 coverage

### DIFF
--- a/SR/patches/es_bsa.patch
+++ b/SR/patches/es_bsa.patch
@@ -1,0 +1,34 @@
+From d06c0865e5c5fcf4d28d9e2f220e7e985dabb3ad Mon Sep 17 00:00:00 2001
+From: Amrathesh <amrathesh@arm.com>
+Date: Wed, 22 Dec 2021 17:06:51 +0530
+Subject: [PATCH] EDK2 ES BSA Patch
+
+Signed-off-by: Amrathesh <amrathesh@arm.com>
+---
+ ShellPkg/ShellPkg.dsc | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/ShellPkg/ShellPkg.dsc b/ShellPkg/ShellPkg.dsc
+index a8b6de3..85dc2c0 100644
+--- a/ShellPkg/ShellPkg.dsc
++++ b/ShellPkg/ShellPkg.dsc
+@@ -60,6 +60,8 @@
+   DxeServicesTableLib|MdePkg/Library/DxeServicesTableLib/DxeServicesTableLib.inf
+   DxeServicesLib|MdePkg/Library/DxeServicesLib/DxeServicesLib.inf
+   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
++  BsaValLib|ShellPkg/Application/bsa-acs/val/BsaValLib.inf
++  BsaPalLib|ShellPkg/Application/bsa-acs/platform/pal_uefi_acpi/BsaPalLib.inf
+ 
+ [LibraryClasses.ARM,LibraryClasses.AARCH64]
+   #
+@@ -98,6 +100,7 @@
+   ShellPkg/Library/UefiShellDebug1CommandsLib/UefiShellDebug1CommandsLib.inf
+   ShellPkg/Library/UefiShellNetwork1CommandsLib/UefiShellNetwork1CommandsLib.inf
+   ShellPkg/Library/UefiShellNetwork2CommandsLib/UefiShellNetwork2CommandsLib.inf
++  ShellPkg/Application/bsa-acs/uefi_app/BsaAcs.inf
+ 
+   ShellPkg/Application/Shell/Shell.inf {
+     <PcdsFixedAtBuild>
+-- 
+2.17.1
+

--- a/SR/scripts/build-scripts/build-sr-live-image.sh
+++ b/SR/scripts/build-scripts/build-sr-live-image.sh
@@ -34,8 +34,10 @@ create_scripts_link()
 {
  ln -s $TOP_DIR/../../common/scripts/build-all.sh               $TOP_DIR/build-scripts/build-all.sh
  ln -s $TOP_DIR/../../common/scripts/build-uefi.sh              $TOP_DIR/build-scripts/build-uefi.sh
+ ln -s $TOP_DIR/../../common/scripts/build-bsaefi.sh            $TOP_DIR/build-scripts/build-bsaefi.sh
  ln -s $TOP_DIR/../../common/scripts/build-sbsaefi.sh           $TOP_DIR/build-scripts/build-sbsaefi.sh
  ln -s $TOP_DIR/../../common/scripts/build-linux.sh             $TOP_DIR/build-scripts/build-linux.sh
+ ln -s $TOP_DIR/../../common/scripts/build-linux-bsa.sh         $TOP_DIR/build-scripts/build-linux-bsa.sh
  ln -s $TOP_DIR/../../common/scripts/build-linux-sbsa.sh        $TOP_DIR/build-scripts/build-linux-sbsa.sh
  ln -s $TOP_DIR/../../common/scripts/build-grub.sh              $TOP_DIR/build-scripts/build-grub.sh
  ln -s $TOP_DIR/../../common/scripts/build-busybox.sh           $TOP_DIR/build-scripts/build-busybox.sh

--- a/common/config/bsa.nsh
+++ b/common/config/bsa.nsh
@@ -38,26 +38,21 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
         for %j in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             if exist FS%j:\EFI\BOOT\bsa\Bsa.efi then
                 #BSA_VERSION_PRINT_PLACEHOLDER
+                if exist FS%i:\acs_results\uefi\BsaResults.log then
+                    echo "BSA ACS is already run"
+                    goto Done
+                endif
                 if exist FS%j:\EFI\BOOT\bsa\ir_bsa.flag then
                     #Executing for BSA IR. Execute only OS tests
                     FS%j:\EFI\BOOT\bsa\Bsa.efi -os -skip 900 -dtb BsaDevTree.dtb -f BsaResults.log
-                    goto Done
+                    reset
                 endif
                 FS%j:\EFI\BOOT\bsa\Bsa.efi -skip 900 -f BsaResults.log
-                goto Done
-            endif
-            if exist FS%j:\EFI\BOOT\bsa\sbsa\Sbsa.efi then
-                if exist FS%i:\acs_results\uefi\SbsaResults.log then
-		    echo "SBSA ACS is already run"
-		    goto Done
-		endif
-	        FS%j:\EFI\BOOT\bsa\sbsa\Sbsa.efi -skip 800 -f SbsaResults.log
                 reset
-		goto Done
             endif
         endfor
         echo "Bsa.efi not found"
     endif
 endfor
-echo "BsaResults not found"
+echo "acs_results not found"
 :Done

--- a/common/config/startup.nsh
+++ b/common/config/startup.nsh
@@ -66,6 +66,10 @@ endfor
 :DoneDebug
 
 for %j in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+    if exist FS%j:\EFI\BOOT\bsa\sr_bsa.flag then
+        FS%j:\EFI\BOOT\bsa\sbsa.nsh
+        goto Donebsa
+    endif
     if exist FS%j:\EFI\BOOT\bsa\bsa.nsh then
         FS%j:\EFI\BOOT\bsa\bsa.nsh
         goto Donebsa

--- a/common/ramdisk/init.sh
+++ b/common/ramdisk/init.sh
@@ -41,7 +41,7 @@ echo "init.sh"
 sleep 5
 mdev -s
 
-if [ -f  /lib/modules/sbsa_acs.ko ]; then
+if [ -f /bin/sr_bsa.flag ]; then
   #Case of SR
   echo "Starting drivers for SR"
   insmod /lib/modules/xhci-pci-renesas.ko
@@ -117,13 +117,20 @@ if [ ! -f  /bin/ir_bbr_fwts_tests.ini ]; then
   insmod /lib/modules/bsa_acs.ko
   /bin/bsa > /mnt/acs_results/linux/BsaResultsApp.log
   dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/BsaResultsKernel.log
- elif [ -f /lib/modules/sbsa_acs.ko ]; then
-  #Case of SR
-  insmod /lib/modules/sbsa_acs.ko
-  /bin/sbsa > /mnt/acs_results/linux/SbsaResultsApp.log
-  dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/SbsaResultsKernel.log
  else
-  echo "Error : BSA or SBSA Kernel Driver is not found. Linux BSA or SBSA  Tests cannot be run."
+  echo "Error: BSA kernel Driver is not found. Linux BSA tests cannot be run."
+ fi
+
+ if [ -f /bin/sr_bsa.flag ]; then
+  echo "Running Linux SBSA tests"
+  if [ -f  /lib/modules/sbsa_acs.ko ]; then
+   #Case of SR
+   insmod /lib/modules/sbsa_acs.ko
+   /bin/sbsa > /mnt/acs_results/linux/SbsaResultsApp.log
+   dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/SbsaResultsKernel.log
+  else
+   echo "Error: SBSA kernel Driver is not found. Linux SBSA tests cannot be run."
+  fi
  fi
 fi
 

--- a/common/scripts/build-bsaefi.sh
+++ b/common/scripts/build-bsaefi.sh
@@ -59,6 +59,8 @@ CROSS_COMPILE=$TOP_DIR/$GCC
 UEFI_LIBC_PATH=edk2-libc
 PATCH_DIR=$TOP_DIR/../patches
 COMMON_PATCH_DIR=$TOP_DIR/../../common/patches
+OUTDIR=${TOP_DIR}/output
+BSA_EFI_PATH=edk2/Build/Shell/DEBUG_GCC49/AARCH64/
 
 do_build()
 {
@@ -70,6 +72,15 @@ do_build()
        if git apply --check $PATCH_DIR/es_bsa.patch; then
          echo "Applying ES BSA Patch ..."
          git apply $PATCH_DIR/es_bsa.patch
+       else
+         echo "Error while applying ES BSA Patch"
+         exit_fun
+       fi
+    elif [ "$BUILD_PLAT" = "SR" ]; then
+       if git apply --check $PATCH_DIR/es_bsa.patch; then
+         echo "Applying ES BSA Patch ..."
+         git apply $PATCH_DIR/es_bsa.patch
+         touch $TOP_DIR/build-scripts/sr_bsa.flag
        else
          echo "Error while applying ES BSA Patch"
          exit_fun
@@ -128,7 +139,8 @@ do_package ()
 {
     echo "Packaging BSA... $VARIANT";
     # Copy binaries to output folder
-    pushd $TOP_DIR
+    mkdir -p $OUTDIR
+    cp $TOP_DIR/$BSA_EFI_PATH/Bsa.efi $OUTDIR/Bsa.efi
 }
 
 exit_fun() {

--- a/common/scripts/build-busybox.sh
+++ b/common/scripts/build-busybox.sh
@@ -107,14 +107,16 @@ do_package ()
     pushd $TOP_DIR/$BUSYBOX_RAMDISK_PATH
     pwd
     if [ $BAND == "SR" ]; then
-        bsa_count=`grep -w bsa files.txt | wc -l`
-        if [ $bsa_count -gt 0 ]; then
-           sed -i 's/bsa/sbsa/g' files.txt
+        touch $TOP_DIR/$BUSYBOX_RAMDISK_PATH/sr_bsa.flag
+    fi
+    if [ $BAND == "SR" ]; then
+           echo "file /bin/sr_bsa.flag                   ./sr_bsa.flag                                         755 0 0"  >> files.txt
+           echo "file /bin/sbsa                          ./linux-sbsa/sbsa                                         755 0 0"  >> files.txt
+           echo "file /lib/modules/sbsa_acs.ko           ./linux-sbsa/sbsa_acs.ko                                  755 0 0"  >> files.txt
            echo "file /lib/modules/nvme.ko               ./drivers/nvme.ko                                         755 0 0"  >> files.txt
            echo "file /lib/modules/nvme-core.ko          ./drivers/nvme-core.ko                                    755 0 0"  >> files.txt
            echo "file /lib/modules/xhci-pci.ko           ./drivers/xhci-pci.ko                                     755 0 0"  >> files.txt
            echo "file /lib/modules/xhci-pci-renesas.ko   ./drivers/xhci-pci-renesas.ko                             755 0 0"  >> files.txt
-        fi
     fi
     cp $TOP_DIR/$BUSYBOX_RAMDISK_BUSYBOX_PATH/busybox .
     $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/$LINUX_CONFIG_DEFAULT/usr/gen_init_cpio files.txt \

--- a/common/scripts/build-grub.sh
+++ b/common/scripts/build-grub.sh
@@ -41,6 +41,7 @@
 # BUSYBOX_BUILD_ENABLED - Building Busybox
 #
 
+
 TOP_DIR=`pwd`
 arch=$(uname -m)
 BAND=$1

--- a/common/scripts/build-sbsaefi.sh
+++ b/common/scripts/build-sbsaefi.sh
@@ -59,6 +59,8 @@ CROSS_COMPILE=$TOP_DIR/$GCC
 UEFI_LIBC_PATH=edk2-libc
 PATCH_DIR=$TOP_DIR/../patches
 COMMON_PATCH_DIR=$TOP_DIR/../../common/patches
+OUTDIR=${TOP_DIR}/output
+SBSA_EFI_PATH=edk2/Build/Shell/DEBUG_GCC49/AARCH64/
 
 do_build()
 {
@@ -105,8 +107,9 @@ do_clean()
 
 do_package ()
 {
-#packaging is taken care in make_image.sh
-  : 
+   echo "Packaging SBSA...";
+    # Copy binaries to output folder
+   cp $TOP_DIR/$SBSA_EFI_PATH/Sbsa.efi $OUTDIR/Sbsa.efi
 }
 
 exit_fun() {

--- a/common/scripts/get_source.sh
+++ b/common/scripts/get_source.sh
@@ -220,11 +220,10 @@ if [ $TARGET_ARCH == "arm" ]; then
 fi
 
 get_uefi_src
+get_bsa_src
 
 if [ $BAND == "SR" ]; then
     get_sbsa_src
-else
-    get_bsa_src
 fi
 
 get_bbr_acs_src


### PR DESCRIPTION
* Defined new sbsa.nsh for SR live image
* fetch and build bsa-acs and linux-acs by default
* Saving output of bsa and sbsa uefi binary to output folder
* Added es_bsa.patch to SR patches folder for bsa uefi build
* Defined sr_flag to run sbsa linux app from init.sh for sr live image