### PR TITLE
common: build FWTS on arm 32b

### DIFF
--- a/common/ramdisk/files-arm.txt
+++ b/common/ramdisk/files-arm.txt
@@ -15,3 +15,13 @@ dir /usr/sbin 755 0 0
 file /init ./init.sh 777 0 0
 dir /lib 777 0 0
 dir /lib/modules 777 0 0
+
+file /bin/fwts                          ./fwts_output/bin/fwts                                    755 0 0
+
+file /lib/libc.so.6                     ./fwts_build_dep-arm/cross_libs/libc.so.6                 755 0 0
+file /lib/ld-linux-armhf.so.3           ./fwts_build_dep-arm/cross_libs/ld-linux-armhf.so.3       755 0 0
+file /lib/libpthread.so.0               ./fwts_build_dep-arm/cross_libs/libpthread.so.0           755 0 0
+file /lib/libm.so.6                     ./fwts_build_dep-arm/cross_libs/libm.so.6                 755 0 0
+
+file /lib/libfwts.so.1                  ./fwts_output/lib/fwts/libfwts.so.1                       755 0 0
+file /lib/libfwts.so.1.0.0              ./fwts_output/lib/fwts/libfwts.so.1.0.0                   755 0 0

--- a/common/scripts/build-all-arm.sh
+++ b/common/scripts/build-all-arm.sh
@@ -33,10 +33,5 @@ source ./build-scripts/build-sct-arm.sh
 source ./build-scripts/build-linux-arm.sh
 source ./build-scripts/build-grub-arm.sh
 source ./build-scripts/build-uefi-apps-arm.sh
-
-echo "[build-all-arm.sh] Skip FWTS"
-# Skip fwts: build issue "G_STATIC_ASSERT(sizeof (unsigned long long) == sizeof (guint64))"
-# due to conflict between pkg-config and cross-compilation toolchain.
-#source ./build-scripts/build-fwts-arm.sh
-
+source ./build-scripts/build-fwts-arm.sh
 source ./build-scripts/build-busybox-arm.sh


### PR DESCRIPTION
Modify the build script for arm 32b to build FWTS. Adapt the list of files installed on arm 32b to install fwts and its dependencies.

Signed-off-by: Vincent Stehlé <vincent.stehle@arm.com>