### PR TITLE
Updates for SystemReady ES, SR and SIE version 1.1.0 release

### DIFF
--- a/ES/README.md
+++ b/ES/README.md
@@ -12,8 +12,8 @@ SystemReady ES-certified platforms implement a minimum set of hardware and firmw
 This section contains the build scripts and the live-images for the SystemReady ES Band.
 
 ## Release details
- - Code Quality: v1.0
- - **The latest pre-built release of ACS is available for download here: [v21.09_1.0](prebuilt_images/v21.09_1.0)**
+ - Code Quality: v1.1.0
+ - **The latest pre-built release of ACS is available for download here: [v22.10_1.1.0](prebuilt_images/v22.10_1.1.0)**
  - The BSA tests are written for version 1.0 of the BSA specification.
  - The BBR tests are written for version 1.0 of the BBR specification.
  - The compliance suite is not a substitute for design verification.
@@ -65,9 +65,9 @@ Note: For the build instructions of the Security Interface Extension ACS, refer 
 ## Build output
 This image comprises of two FAT file system partitions recognized by UEFI: <br />
 - 'acs-results' <br />
-  Stores logs of the automated execution of ACS. (Approximate size: 120 MB) <br/>
+  Stores logs of the automated execution of ACS. (Approximate size: 128 MB) <br/>
 - 'boot' <br />
-  Contains bootable applications and test suites. (Approximate size: 400 MB)
+  Contains bootable applications and test suites. (Approximate size: 500 MB)
 
 
 ## Verification
@@ -124,20 +124,22 @@ This is expected behavior and the forward progress of tests will continue after 
 The test suite execution can be automated or manual. Automated execution is the default execution method when no key is pressed during boot. <br />
 The live image boots to UEFI Shell. The different test applications can be run in the following order:
 
-1. [SCT tests](https://github.com/ARM-software/bbr-acs/blob/master/README.md) for BBR compliance.
-2. [UEFI Shell application](https://github.com/ARM-software/bsa-acs/blob/master/README.md) for BSA compliance.
-3. [FWTS tests](https://github.com/ARM-software/bbr-acs/blob/master/README.md) for BBR compliance.
-4. [OS tests](https://github.com/ARM-software/bsa-acs/blob/master/README.md) for Linux BSA compliance.
+1. [SCT tests](https://github.com/ARM-software/bbr-acs/blob/main/README.md) for BBR compliance.
+2. [UEFI Shell application](https://github.com/ARM-software/bsa-acs/blob/main/README.md) for BSA compliance.
+3. [FWTS tests](https://github.com/ARM-software/bbr-acs/blob/main/README.md) for BBR compliance.
+4. [OS tests](https://github.com/ARM-software/bsa-acs/blob/main/README.md) for Linux BSA compliance. <br />
+Note: To skip FWTS and OS tests for debugging, append "noacs" to the Linux command by editing the "Linux Boot" option in the grub menu during image boot.<br />
+To start an extended run of UEFI-SCT append "-nostartup startup.nsh sct_extd" to the shell.efi command by editing the "bbr/bsa" option in the grub menu during image boot.<br />
 
 ## Baselines for Open Source Software in this release:
 
-- [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git) TAG: V21.08.00 
+- [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git) TAG: v22.09.00
 
-- [Base System Architecture (BSA)](https://github.com/ARM-software/bsa-acs) TAG: v21.09_1.0
+- [Base System Architecture (BSA)](https://github.com/ARM-software/bsa-acs) TAG: v22.10_REL1.0.2
 
-- [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs) TAG: : v21.09_1.0
+- [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs) TAG: : v22.10_REL1.1.0
 
-- [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test) TAG: edk2-test-stable202108
+- [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test) TAG: f628bec2193da1f9402ef749fbca50f61c812d6f
 
 
 

--- a/SIE/README.md
+++ b/SIE/README.md
@@ -13,8 +13,8 @@ The Security Interface Extension ACS tests the following security related interf
 This section describes the steps to build the ACS or obtain the pre-built live image.
 
 ## Release details
- - Code Quality: v1.0
- - **The latest pre-built release of the Security Interface Extension ACS is available for download here: [v21.10_SIE_REL1.0](./prebuilt_images/v21.10_SIE_REL1.0)**
+ - Code Quality: v1.1.0
+ - **The latest pre-built release of the Security Interface Extension ACS is available for download here: [v22.10_SIE_REL1.1.0](./prebuilt_images/v22.10_SIE_REL1.1.0)**
  - The Security Interface Extension tests are written for version 1.1 of the BBSR specification.
  - The compliance suite is not a substitute for design verification.
  - To review the ACS logs, Arm licensees can contact Arm directly through their partner managers.
@@ -27,13 +27,13 @@ This section describes the steps to build the ACS or obtain the pre-built live i
 ## Steps to build SystemReady Security Inteface Extension ACS live image
 
 ## GitHub branch
-- To pick up the release version of the code, checkout the release tag v21.10_SIE_REL1.0
+- To pick up the release version of the code, checkout the release tag v22.10_SIE_REL1.1.0
 
 ## ACS build steps
 
 ### Pre-built images
 - Pre-built images for each release are available in the prebuilt_images folder. You can either choose to use these images or build your own image by following the steps below.
-- To access the prebuilt_images, click this link : [prebuilt_images](./prebuilt_images/v21.10_SIE_REL1.0)
+- To access the prebuilt_images, click this link : [prebuilt_images](./prebuilt_images/v22.10_SIE_REL1.1.0)
 - If you choose to use the pre-built image, skip the build steps and jump to the test suite execution section below.
 
 ### Prerequisites

--- a/SIE/scripts/build-scripts/get_source.sh
+++ b/SIE/scripts/build-scripts/get_source.sh
@@ -109,7 +109,13 @@ get_buildroot_src()
 
 get_bbr_acs_src()
 {
-   git clone --depth 1 https://github.com/ARM-software/bbr-acs.git bbr-acs
+  echo "Downloading Arm BBR source code."
+  git clone https://github.com/ARM-software/bbr-acs.git bbr-acs
+  if [ -n "$ARM_BBR_TAG" ]; then
+    #TAG provided.
+    echo "Checking out Arm BBR TAG: $ARM_BBR_TAG"
+    git -C bbr-acs checkout $ARM_BBR_TAG
+  fi
 }
 
 sudo apt install git curl mtools gdisk gcc\

--- a/SR/README.md
+++ b/SR/README.md
@@ -5,7 +5,7 @@
 SystemReady SR is a band of system certification in the Arm SystemReady program that ensures interoperability of Arm based servers with standard operating systems and hypervisors.
 
 SystemReady SR-certified platforms implement a minimum set of hardware and firmware features that an operating system can depend on to deploy the operating system image. Compliant systems must conform to the:
-* [Server Base System Architecture (SBSA) specification](https://developer.arm.com/documentation/den0029/d/?lang=en)
+* [Server Base System Architecture (SBSA) specification](https://developer.arm.com/documentation/den0029/e/?lang=en)
 * SBBR recipe of the [Base Boot Requirements (BBR) specification](https://developer.arm.com/documentation/den0044/latest)
 * The SystemReady SR certification and testing requirements are specified in the [Arm SystemReady Requirements Specification (SRS)](https://developer.arm.com/documentation/den0109/latest)
 
@@ -15,8 +15,8 @@ This section contains the build scripts and the live-images for the SystemReady 
 
 ## Release details
  - Code quality: v1.0
- - **The latest pre-built release of ACS is available for download here: [v22.02_1.0](prebuilt_images/v22.02_1.0)**
- - The SBSA tests are written for version 6.0 of the SBSA specification.
+ - **The latest pre-built release of ACS is available for download here: [v22.10_1.1.0](prebuilt_images/v22.10_1.1.0)**
+ - The SBSA tests are written for version 6.1 of the SBSA specification.
  - The BBR tests are written for the SBBR section in version 1.0 of the BBR specification.
  - The compliance suite is not a substitute for design verification.
  - To review the ACS logs, Arm licensees can contact Arm directly through their partner managers.
@@ -64,9 +64,9 @@ Note: For the build instructions of the Security Interface Extension ACS, refer 
 ## Build output
 This image comprises two FAT file system partitions recognized by UEFI: <br />
 - 'acs-results' <br />
-  stores logs of the automated execution of ACS. (Approximate size: 120MB) <br/>
+  stores logs of the automated execution of ACS. (Approximate size: 128MB) <br/>
 - 'boot' <br />
-  contains bootable applications and test suites. (Approximate size: 400MB)
+  contains bootable applications and test suites. (Approximate size: 500MB)
 
 
 ## Verification
@@ -124,20 +124,25 @@ This is expected behavior and the progress of tests will continue after a 20-min
 The test suite execution can be automated or manual. Automated execution is the default execution method when no key is pressed during boot. <br />
 The live image boots to UEFI Shell. The different test applications can run in the following order:
 
-1. [SCT tests](https://github.com/ARM-software/bbr-acs/blob/master/README.md) for BBR compliance.
+1. [SCT tests](https://github.com/ARM-software/bbr-acs/blob/main/README.md) for BBR compliance.
 2. [UEFI Shell application](https://github.com/ARM-software/sbsa-acs/blob/master/README.md) for SBSA compliance.
-3. [FWTS tests](https://github.com/ARM-software/bbr-acs/blob/master/README.md) for BBR compliance.
-4. [OS tests](https://github.com/ARM-software/sbsa-acs/blob/master/README.md) for Linux SBSA compliance.
+                           (https://github.com/ARM-software/bsa-acs/blob/main/README.md)    for BSA compliance.
+3. [FWTS tests](https://github.com/ARM-software/bbr-acs/blob/main/README.md) for BBR compliance.
+4. [OS tests](https://github.com/ARM-software/sbsa-acs/blob/master/README.md) for Linux SBSA compliance.<br />
+Note: To skip FWTS and OS tests for debugging, append "noacs" to the Linux command by editing the "Linux Boot" option in the grub menu during image boot.<br />
+To start an extended run of UEFI-SCT append "-nostartup startup.nsh sct_extd" to the shell.efi command by editing the "bbr/bsa" option in the grub menu during image boot.<br />
 
 ## Baselines for Open Source Software in this release:
 
-- [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git) TAG: 1228f0412a6c76b437cfa3078d5dc1fb5ca102c6
+- [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git) TAG: v22.09.00
 
-- [Base System Architecture (SBSA)](https://github.com/ARM-software/sbsa-acs) TAG: v22.02_SR_REL1.0
+- [Base System Architecture (SBSA)](https://github.com/ARM-software/sbsa-acs) TAG: v22.10_REL6.1.0
 
-- [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs) TAG: v22.02_SR_REL1.0
+- [Base System Architecture (BSA)](https://github.com/ARM-software/bsa-acs) TAG: v22.10_REL1.0.2
 
-- [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test) TAG: 01d9d24efdedb30ff6b0e1f1c47c6c3b0c5a7093
+- [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs) TAG: v22.10_REL1.1.0
+
+- [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test) TAG: f628bec2193da1f9402ef749fbca50f61c812d6f
 
 
 

--- a/common/config/bsa.nsh
+++ b/common/config/bsa.nsh
@@ -35,6 +35,9 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             mkdir uefi
         endif
         cd uefi
+        if not exist temp then
+            mkdir temp
+        endif
         for %j in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             if exist FS%j:\EFI\BOOT\bsa\Bsa.efi then
                 #BSA_VERSION_PRINT_PLACEHOLDER
@@ -47,7 +50,16 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                     FS%j:\EFI\BOOT\bsa\Bsa.efi -os -skip 900 -dtb BsaDevTree.dtb -f BsaResults.log
                     reset
                 endif
-                FS%j:\EFI\BOOT\bsa\Bsa.efi -skip 900 -f BsaResults.log
+                FS%j:\EFI\BOOT\bsa\Bsa.efi -skip 900 -f BsaTempResults.log
+                if exist FS%i:\acs_results\uefi\BsaTempResults.log then
+                    echo " SystemReady ES ACS v1.1.0" > BsaResults.log
+                    stall 200000
+                    type BsaTempResults.log >> BsaResults.log
+                    cp BsaTempResults.log temp/
+                    rm BsaTempResults.log
+                else
+                    echo "There may be issues in writing of BSA logs . Please save the console output"
+                endif
                 reset
             endif
         endfor

--- a/common/config/buildroot/rootfs-overlay/etc/init.d/S90systemready-security-interface-extension
+++ b/common/config/buildroot/rootfs-overlay/etc/init.d/S90systemready-security-interface-extension
@@ -46,4 +46,7 @@ then
      echo "TPM event log not found at /sys/kernel/security/tpm0/binary_bios_measurements"
     fi
 
+    # sync changes to storage
+    sync
+
 fi

--- a/common/config/common_config.cfg
+++ b/common/config/common_config.cfg
@@ -29,16 +29,16 @@
 # Common configurations
 
 #SystemReady ACS version
-ACS_VERSION="SystemReady IR ACS v2.0.0 Beta-1"
+ACS_VERSION=""
 
 #Linux kernel version. Source downloaded from https://github.com/torvalds/linux.git
-LINUX_KERNEL_VERSION=5.15
+LINUX_KERNEL_VERSION=6.0
 
 #BusyBox source tag : https://git.busybox.net/busybox/
 BUSYBOX_SRC_VERSION=1_34_stable
 
 #EDK2 source tag from https://github.com/tianocore/edk2.git
-EDK2_SRC_VERSION=edk2-stable202205
+EDK2_SRC_VERSION=edk2-stable202208
 EDK2_SRC_TAG=16779ede2d366bfc6b702e817356ccf43425bcc8
 
 #Cross compiler tools from https://releases.linaro.org/components/toolchain/binaries
@@ -46,27 +46,27 @@ LINARO_TOOLS_MAJOR_VERSION=7.5-2019.12
 LINARO_TOOLS_VERSION=7.5.0-2019.12
 
 #FWTS source tag from  https://git.launchpad.net/fwts
-FWTS_SRC_VERSION=v22.07.00
-FWTS_SRC_TAG=d82204d836a6e6bf1ce491224923ea5072bed967
+FWTS_SRC_VERSION=v22.09.00
+FWTS_SRC_TAG=330af50dbb33420188835e40a4873971dbeabbe0
 
 # EDK2-TEST source tag from  https://github.com/tianocore/edk2-test
-SCT_SRC_TAG=4a25c3b3c79f63bd9f98b4fffcb21b5c66dd14bb
+SCT_SRC_TAG=f628bec2193da1f9402ef749fbca50f61c812d6f
 
 # GRUB2 source from https://github.com/rhboot/grub2.git
 GRUB_SRC_TAG=grub-2.06
 
 #Arm BSA source tag.
 #NOTE: If the value is NULL then the latest BSA source will be downloaded
-ARM_BSA_VERSION=v1.0.1
-ARM_BSA_TAG=""
+ARM_BSA_VERSION=v1.0.2
+ARM_BSA_TAG="v22.10_REL1.0.2"
 
 #Arm BBR source tag
 #NOTE: If the value is NULL then the latest BBR source will be downloaded
-ARM_BBR_TAG="v22.10_IR_32b_0.7_BETA-0"
+ARM_BBR_TAG="v22.10_SR_ES_SIE_REL1.1.0"
 
 #Arm LINUX ACS source tag
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded
-ARM_LINUX_ACS_TAG=""
+ARM_LINUX_ACS_TAG="v22.10_REL1.1.0"
 
 #Linux kernel version for Yocto build. Used only for the IR Band
 YOCTO_LINUX_KERNEL_VERSION=5.15

--- a/common/config/debug_dump.nsh
+++ b/common/config/debug_dump.nsh
@@ -37,6 +37,7 @@ for %m in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
         endif
         cd uefi_dump
         echo "Starting UEFI Debug dump"
+        connect -r
         pci > pci.log
         drivers > drivers.log
         devices > devices.log
@@ -44,6 +45,11 @@ for %m in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
         dh -d > dh.log
         memmap > memmap.log
         bcfg boot dump > bcfg.log
+        map -r > map.log
+        devtree > devtree.log
+        ver > uefi_version.log
+        ifconfig -l > ifconfig.log
+        dmem > dmem.log
 
         for %n in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                 if exist FS%n:\EFI\BOOT\bsa\ir_bsa.flag then

--- a/common/config/sbsa.nsh
+++ b/common/config/sbsa.nsh
@@ -35,6 +35,9 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             mkdir uefi
         endif
         cd uefi
+        if not exist temp then
+            mkdir temp
+        endif
         for %j in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             #BSA_VERSION_PRINT_PLACEHOLDER
             if exist FS%j:\EFI\BOOT\bsa\Bsa.efi then
@@ -42,7 +45,16 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                     echo "BSA ACS is already run"
                     goto SbsaRun
                 endif
-                FS%j:\EFI\BOOT\bsa\Bsa.efi -sbsa -skip 900 -f BsaResults.log
+                FS%j:\EFI\BOOT\bsa\Bsa.efi -sbsa -skip 900 -f BsaTempResults.log
+                if exist FS%i:\acs_results\uefi\BsaTempResults.log then
+                    echo " SystemReady SR ACS v1.1.0" > BsaResults.log
+                    stall 200000
+                    type BsaTempResults.log >> BsaResults.log
+                    cp BsaTempResults.log temp/
+                    rm BsaTempResults.log
+                else
+                    echo "There may be issues in writing of BSA logs. Please save the console output"
+                endif
             endif
 :SbsaRun
             if exist FS%j:\EFI\BOOT\bsa\sbsa\Sbsa.efi then
@@ -50,7 +62,16 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                     echo "SBSA ACS is already run"
                     goto Done
                 endif
-                FS%j:\EFI\BOOT\bsa\sbsa\Sbsa.efi -skip 800 -f SbsaResults.log
+                FS%j:\EFI\BOOT\bsa\sbsa\Sbsa.efi -skip 800 -f SbsaTempResults.log
+                if exist FS%i:\acs_results\uefi\SbsaTempResults.log then
+                    echo " SystemReady SR ACS v1.1.0" > SbsaResults.log
+                    stall 200000
+                    type SbsaTempResults.log >> SbsaResults.log
+                    cp SbsaTempResults.log temp/
+                    rm SbsaTempResults.log
+                else
+                    echo "There may be issues in writing of SBSA logs. Please save the console output"
+                endif
                 reset
             endif
             echo "Sbsa.efi not present"

--- a/common/config/sr_common_config.cfg
+++ b/common/config/sr_common_config.cfg
@@ -31,40 +31,40 @@
 # Note: This file shall be discarded once ES and IR bands move to latest versions
 
 #Linux kernel version. Source downloaded from https://github.com/torvalds/linux.git
-LINUX_KERNEL_VERSION=5.15
+LINUX_KERNEL_VERSION=6.0
 
 #BusyBox source tag : https://git.busybox.net/busybox/
 BUSYBOX_SRC_VERSION=1_34_stable
 
 #EDK2 source tag from https://github.com/tianocore/edk2.git
-EDK2_SRC_VERSION=edk2-stable202111
+EDK2_SRC_VERSION=edk2-stable202208
 
 #Cross compiler tools from https://releases.linaro.org/components/toolchain/binaries
 LINARO_TOOLS_MAJOR_VERSION=7.5-2019.12
 LINARO_TOOLS_VERSION=7.5.0-2019.12
 
 #FWTS source tag from  https://git.launchpad.net/fwts
-FWTS_SRC_TAG=1228f0412a6c76b437cfa3078d5dc1fb5ca102c6
+FWTS_SRC_TAG=330af50dbb33420188835e40a4873971dbeabbe0
 
 # EDK2-TEST source tag from  https://github.com/tianocore/edk2-test
-SCT_SRC_TAG=d919c4a5d9fe2681de4d11a0bbfb07373fe6f9c7
+SCT_SRC_TAG=f628bec2193da1f9402ef749fbca50f61c812d6f
 
 # GRUB2 source from https://github.com/rhboot/grub2.git
 GRUB_SRC_TAG=grub-2.06
 
 #Arm BSA source tag.
 #NOTE: If the value is NULL then the latest BSA source will be downloaded
-ARM_BSA_TAG=""
+ARM_BSA_TAG="v22.10_REL1.0.2"
 
 #Arm SBSA source tag. Applicable only for SR build.
 #NOTE: If the value is NULL then the latest SBSA source will be downloaded
-ARM_SBSA_TAG=""
+ARM_SBSA_TAG="v22.10_REL6.1.0"
 
 #Arm BBR source tag
 #NOTE: If the value is NULL then the latest BBR source will be downloaded
-ARM_BBR_TAG=""
+ARM_BBR_TAG="v22.10_SR_ES_SIE_REL1.1.0"
 
 #Arm LINUX ACS source tag
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded
-ARM_LINUX_ACS_TAG=""
+ARM_LINUX_ACS_TAG="v22.10_REL1.1.0"
 

--- a/common/config/startup.nsh
+++ b/common/config/startup.nsh
@@ -31,7 +31,7 @@ connect -r
 
 for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%i:\EFI\BOOT\bbr\SctStartup.nsh then
-        FS%i:\EFI\BOOT\bbr\SctStartup.nsh
+        FS%i:\EFI\BOOT\bbr\SctStartup.nsh %1
         goto Donebbr
     endif
 endfor

--- a/common/scripts/build-busybox.sh
+++ b/common/scripts/build-busybox.sh
@@ -113,11 +113,12 @@ do_package ()
            echo "file /bin/sr_bsa.flag                   ./sr_bsa.flag                                         755 0 0"  >> files.txt
            echo "file /bin/sbsa                          ./linux-sbsa/sbsa                                         755 0 0"  >> files.txt
            echo "file /lib/modules/sbsa_acs.ko           ./linux-sbsa/sbsa_acs.ko                                  755 0 0"  >> files.txt
-           echo "file /lib/modules/nvme.ko               ./drivers/nvme.ko                                         755 0 0"  >> files.txt
-           echo "file /lib/modules/nvme-core.ko          ./drivers/nvme-core.ko                                    755 0 0"  >> files.txt
-           echo "file /lib/modules/xhci-pci.ko           ./drivers/xhci-pci.ko                                     755 0 0"  >> files.txt
-           echo "file /lib/modules/xhci-pci-renesas.ko   ./drivers/xhci-pci-renesas.ko                             755 0 0"  >> files.txt
     fi
+    echo "file /lib/modules/nvme.ko               ./drivers/nvme.ko                                         755 0 0"  >> files.txt
+    echo "file /lib/modules/nvme-core.ko          ./drivers/nvme-core.ko                                    755 0 0"  >> files.txt
+    echo "file /lib/modules/xhci-pci.ko           ./drivers/xhci-pci.ko                                     755 0 0"  >> files.txt
+    echo "file /lib/modules/xhci-pci-renesas.ko   ./drivers/xhci-pci-renesas.ko                             755 0 0"  >> files.txt
+
     cp $TOP_DIR/$BUSYBOX_RAMDISK_BUSYBOX_PATH/busybox .
     $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/$LINUX_CONFIG_DEFAULT/usr/gen_init_cpio files.txt \
     > ramdisk.img

--- a/common/scripts/build-linux.sh
+++ b/common/scripts/build-linux.sh
@@ -125,13 +125,11 @@ do_package ()
     ${OUTDIR}/$LINUX_IMAGE_TYPE
 
     #Copy drivers for packaging into Ramdisk
-    if [ $BAND == "SR" ]; then
-        mkdir -p $TOP_DIR/ramdisk/drivers
-        cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/nvme/host/nvme.ko $TOP_DIR/ramdisk/drivers
-        cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/nvme/host/nvme-core.ko $TOP_DIR/ramdisk/drivers
-        cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/usb/host/xhci-pci-renesas.ko $TOP_DIR/ramdisk/drivers
-        cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/usb/host/xhci-pci.ko $TOP_DIR/ramdisk/drivers
-    fi
+    mkdir -p $TOP_DIR/ramdisk/drivers
+    cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/nvme/host/nvme.ko $TOP_DIR/ramdisk/drivers
+    cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/nvme/host/nvme-core.ko $TOP_DIR/ramdisk/drivers
+    cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/usb/host/xhci-pci-renesas.ko $TOP_DIR/ramdisk/drivers
+    cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/usb/host/xhci-pci.ko $TOP_DIR/ramdisk/drivers
 
 }
 

--- a/common/scripts/make_image.sh
+++ b/common/scripts/make_image.sh
@@ -156,7 +156,7 @@ prepare_disk_image ()
     pushd $TOP_DIR/$GRUB_PATH/output
 
     local FAT_SIZE_MB=512
-    local FAT2_SIZE_MB=50
+    local FAT2_SIZE_MB=128
     local PART_START=$((1*SEC_PER_MB))
     local FAT_SIZE=$((FAT_SIZE_MB*SEC_PER_MB))
     local FAT2_SIZE=$((FAT2_SIZE_MB*SEC_PER_MB))


### PR DESCRIPTION
UEFI-SCT for EBBR and SBBR Upgraded the Linux kernel version to 6.0
Added a "noacs" developer option to optionally skip ACS run after linux boot Support for optional extended run, extd_run, for 
Upgraded edk2, UEFI-SCT and FWTS version to v22.09.00. Please see the ES and SR README for details Increased the partition size of acs_results to 128 GB ACS version print updates
Added additional debug dumps in UEFI and Linux shells. General enhancements and bug fixes

Signed-off-by: G Edhaya Chandran <edhaya.chandran@arm.com>

Co-authored-by: Gururaj Revankar <gururaj.revankar@arm.com>
Co-authored-by: Amrathesh <amrathesh@arm.com>