### PR TITLE
Updated IR ACS image automation to generate new debug logs

### DIFF
--- a/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -86,6 +86,16 @@ fi
 #linux debug dump
 mkdir -p /mnt/acs_results/linux_dump
 lspci -vvv &> /mnt/acs_results/linux_dump/lspci.log
+lsusb > /mnt/acs_results/linux_dump/lsusb.log
+uname -a > /mnt/acs_results/linux_dump/uname.log
+cat /proc/interrupts > /mnt/acs_results/linux_dump/interrupts.log
+cat /proc/cpuinfo > /mnt/acs_results/linux_dump/cpuinfo.log
+cat /proc/meminfo > /mnt/acs_results/linux_dump/meminfo.log
+cat /proc/iomem > /mnt/acs_results/linux_dump/iomem.log
+ls -lR /sys/firmware > /mnt/acs_results/linux_dump/firmware.log
+cp -r /sys/firmware /mnt/acs_results/linux_dump/
+dmidecode > /mnt/acs_results/linux_dump/dmidecode.log
+efibootmgr > /mnt/acs_results/linux_dump/efibootmgr.log
 
 mkdir -p /mnt/acs_results/fwts
 echo "Executing FWTS for EBBR"

--- a/IR/Yocto/meta-woden/recipes-images/images/woden-image.bb
+++ b/IR/Yocto/meta-woden/recipes-images/images/woden-image.bb
@@ -138,6 +138,8 @@ IMAGE_INSTALL:append = "systemd-init-install \
                         pciutils \
                         python3-dtschema \
                         process-schema \
+                        dmidecode \
+                        efibootmgr \
 "
 
 addtask dir_deploy before do_populate_lic_deploy after do_image_complete


### PR DESCRIPTION
UEFI: pci, drivers, devices, dmpstore, dh, memmap, bcfg, map, devtree, ver, ifconfig, dmem

Linux: lsusb, uname, interrupts, cpuinfo, meminfo, iomem, firmware, dmidecode, efibootmgr logs

New tools dmidecode and efibootmgr added to the IR image

Signed-off-by: gurrev01 <gururaj.revankar@arm.com>