### PR TITLE
Automatically boot Linux after SIE-SCT

### DIFF
--- a/IR/Yocto/meta-woden/recipes-acs/bootfs-files/files/sie_startup.nsh
+++ b/IR/Yocto/meta-woden/recipes-acs/bootfs-files/files/sie_startup.nsh
@@ -45,7 +45,13 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             endif
         endfor
         echo "SIE SCT test suite execution is complete. Resetting the system"
-        reset
+        for %l in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+            if exist FS%l:\Image and exist FS%l:\yocto_image.flag then
+                FS%l:
+                cd FS%l:\
+                Image LABEL=Boot root=partuid rootfstype=ext4 secureboot
+            endif
+        endfor
     endif
 endfor
 

--- a/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -110,7 +110,7 @@ mkdir -p /mnt/acs_results/linux_acs/bsa_acs_app
 echo "Loading BSA ACS Linux Driver"
 insmod /lib/modules/*/kernel/bsa_acs/bsa_acs.ko
 echo "Executing BSA ACS Application "
-echo $'SystemReady IR ACS v2.0.0 Beta-1\nBSA v1.0.1' > /mnt/acs_results/linux_acs/bsa_acs_app/BSALinuxResults.log
+echo $'SystemReady IR ACS v2.0.0 Beta-1\nBSA v1.0.2' > /mnt/acs_results/linux_acs/bsa_acs_app/BSALinuxResults.log
 bsa >> /mnt/acs_results/linux_acs/bsa_acs_app/BSALinuxResults.log
 dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux_acs/bsa_acs_app/BsaResultsKernel.log
 

--- a/IR/Yocto/meta-woden/recipes-acs/process-schema/process-schema.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/process-schema/process-schema.bb
@@ -4,7 +4,7 @@ S = "${WORKDIR}"
 
 DEPENDS = "python3-native python3-dtschema-native"
 
-SRC_URI = "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.19.10.tar.xz"
+SRC_URI = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.1.2.tar.xz"
 SRC_URI[sha256sum] = "67dab932e85f9b9062ced666c8ea888230a1dadfd624b05aead6b6ebc6d3bdd5"
 
 do_install(){


### PR DESCRIPTION
Updated to boot Linux automatically after SIE-SCT run is complete. 
Linux kernel DT bindings have upgraded to version 6.1.2

Signed-off-by: gurrev01 <gururaj.revankar@arm.com>