### PR TITLE
Upgraded the Linux DT schema bindings to version 6.1.2

### DIFF
--- a/IR/Yocto/meta-woden/recipes-acs/process-schema/process-schema.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/process-schema/process-schema.bb
@@ -5,11 +5,11 @@ S = "${WORKDIR}"
 DEPENDS = "python3-native python3-dtschema-native"
 
 SRC_URI = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.1.2.tar.xz"
-SRC_URI[sha256sum] = "67dab932e85f9b9062ced666c8ea888230a1dadfd624b05aead6b6ebc6d3bdd5"
+SRC_URI[sha256sum] = "ee41f3c4f599b2f46f08aae428c9243db403e7292eb2c9f04ee34909b038d1ae"
 
 do_install(){
     install -d ${D}${bindir}
-    cp -r ${S}/linux-5.19.10/Documentation/devicetree/bindings ${D}/${bindir}/
+    cp -r ${S}/linux-6.1.2/Documentation/devicetree/bindings ${D}/${bindir}/
     dt-mk-schema -j ${D}/${bindir}/bindings > processed_schema.json
     cp -r ${S}/processed_schema.json ${D}/${bindir}/
 }


### PR DESCRIPTION
Upgraded the Linux DT schema bindings to version 6.1.2 for IR ACS image