### PR TITLE
Linux kernel version updated to 6.0 for the IR ACS

### DIFF
--- a/IR/Yocto/meta-woden/conf/distro/woden.conf
+++ b/IR/Yocto/meta-woden/conf/distro/woden.conf
@@ -34,5 +34,5 @@ EFI_PROVIDER = "grub-efi"
 
 # Suffixing the build directory with the libc is pointless
 TCLIBCAPPEND = ""
-PREFERRED_VERSION_linux-yocto = "5.15%"
+PREFERRED_VERSION_linux-yocto = "6.0%"
 PREFERRED_VERSION_fwts = "22.07.00"

--- a/IR/Yocto/meta-woden/conf/layer.conf
+++ b/IR/Yocto/meta-woden/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-woden = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-woden = "5"
 
 LAYERDEPENDS_meta-woden = "core meta-arm openembedded-layer"
-LAYERSERIES_COMPAT_meta-woden = "kirkstone"
+LAYERSERIES_COMPAT_meta-woden = "langdale"

--- a/IR/Yocto/meta-woden/kas/woden.yml
+++ b/IR/Yocto/meta-woden/kas/woden.yml
@@ -6,13 +6,13 @@ repos:
 
   poky:
     url: https://git.yoctoproject.org/git/poky
-    refspec: kirkstone-4.0.3
+    refspec: langdale
     layers:
       meta:
 
   meta-arm:
     url: https://git.yoctoproject.org/git/meta-arm
-    refspec: b086301d4621926cb8762c04b68ddffb295a7063
+    refspec: a590d6e1b88638f570ba5af7811c3b27f73e7cc2
     layers:
       meta-arm:
       meta-arm-bsp:
@@ -20,14 +20,14 @@ repos:
 
   meta-openembedded:
     url: https://git.openembedded.org/meta-openembedded
-    refspec: kirkstone
+    refspec: langdale
     layers:
       meta-oe:
       meta-perl:
 
   meta-secure-core:
     url: https://github.com/jiazhang0/meta-secure-core
-    refspec: 1a74be5b363ee61256093e0a3efaa78fd370a27c
+    refspec: d218a980afafcb2764cf900e0ec27a41546a20e3
     layers:
       meta:
       meta-efi-secure-boot:

--- a/IR/Yocto/meta-woden/recipes-kernel/linux/linux-yocto_6.0%.bbappend
+++ b/IR/Yocto/meta-woden/recipes-kernel/linux/linux-yocto_6.0%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:append:generic-arm64 = " file://systemready.cfg"

--- a/IR/Yocto/meta-woden/recipes-kernel/linux/linux-yocto_6.0.bb
+++ b/IR/Yocto/meta-woden/recipes-kernel/linux/linux-yocto_6.0.bb
@@ -1,0 +1,146 @@
+KBRANCH ?= "master"
+
+require recipes-kernel/linux/linux-yocto.inc
+
+# board specific branches
+KBRANCH:qemuarm  ?= "v5.15/standard/arm-versatile-926ejs"
+KBRANCH:qemuarm64 ?= "v5.15/standard/qemuarm64"
+KBRANCH:qemumips ?= "v5.15/standard/mti-malta32"
+KBRANCH:qemuppc  ?= "v5.15/standard/qemuppc"
+KBRANCH:qemuriscv64  ?= "v5.15/standard/base"
+KBRANCH:qemuriscv32  ?= "v5.15/standard/base"
+KBRANCH:qemux86  ?= "v5.15/standard/base"
+KBRANCH:qemux86-64 ?= "v5.15/standard/base"
+KBRANCH:qemumips64 ?= "v5.15/standard/mti-malta64"
+
+SRCREV_machine:qemuarm ?= "5a68f2d15d17f0f3c397e7f8c83f3f664f7037e5"
+SRCREV_machine:qemuarm64 ?= "00e666e6154fcdf52268f2a5a612b96afad073b0"
+SRCREV_machine:qemumips ?= "fb9e75076deade31754b7ad644952d63137e616b"
+SRCREV_machine:qemuppc ?= "49f6567f3b85a843e8b6042a79c58aab0bdbd0c9"
+SRCREV_machine:qemuriscv64 ?= "cc9695f5fd3b520464eb2ded66950734f308525c"
+SRCREV_machine:qemuriscv32 ?= "cc9695f5fd3b520464eb2ded66950734f308525c"
+SRCREV_machine:qemux86 ?= "cc9695f5fd3b520464eb2ded66950734f308525c"
+SRCREV_machine:qemux86-64 ?= "cc9695f5fd3b520464eb2ded66950734f308525c"
+SRCREV_machine:qemumips64 ?= "1ad01ab47ec056d4126798f6d57a33b65b2be49c"
+SRCREV_machine ?= "4fe89d07dcc2804c8b562f6c7896a45643d34b2f"
+SRCREV_meta ?= "4ed11ded922785d0b4fe4e1078f0ff2e8ddebf27"
+
+# set your preferred provider of linux-yocto to 'linux-yocto-upstream', and you'll
+# get the <version>/base branch, which is pure upstream -stable, and the same
+# meta SRCREV as the linux-yocto-standard builds. Select your version using the
+# normal PREFERRED_VERSION settings.
+BBCLASSEXTEND = "devupstream:target"
+SRCREV_machine:class-devupstream ?= "3fbf24b73f4a5bc8fd39a6b7a29145451c1039ce"
+PN:class-devupstream = "linux-yocto-upstream"
+KBRANCH:class-devupstream = "master"
+
+SRC_URI = "git://git.yoctoproject.org/linux-yocto.git;name=machine;branch=${KBRANCH}; \
+           git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.8;destsuffix=${KMETA} \
+           https://gitlab.arm.com/linux-arm/linux-acs/-/raw/master/kernel/src/0001-BSA-ACS-Linux-6.0.patch;patch=1;md5sum=952e79f61a9c29ada81182c15893b863 \
+           file://0002-Fix-for-CompuLab-IOT-GATE-iMX8-boot-issue.patch;patch=1 \
+"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+LINUX_VERSION ?= "6.0"
+
+DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
+DEPENDS += "openssl-native util-linux-native"
+DEPENDS += "gmp-native libmpc-native"
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+KMETA = "kernel-meta"
+KCONF_BSP_AUDIT_LEVEL = "1"
+
+KERNEL_DEVICETREE:qemuarmv5 = "versatile-pb.dtb"
+
+COMPATIBLE_MACHINE = "qemuarm|qemuarmv5|qemuarm64|qemux86|qemuppc|qemuppc64|qemumips|qemumips64|qemux86-64|qemuriscv64|qemuriscv32"
+
+# Functionality flags
+KERNEL_EXTRA_FEATURES ?= "features/netfilter/netfilter.scc"
+KERNEL_FEATURES:append = " ${KERNEL_EXTRA_FEATURES}"
+KERNEL_FEATURES:append:qemuall=" cfg/virtio.scc features/drm-bochs/drm-bochs.scc"
+KERNEL_FEATURES:append:qemux86=" cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append:qemux86-64=" cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("TUNE_FEATURES", "mx32", " cfg/x32.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " features/scsi/scsi-debug.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " features/gpio/mockup.scc", "", d)}"
+KERNEL_FEATURES:append:powerpc =" arch/powerpc/powerpc-debug.scc"
+KERNEL_FEATURES:append:powerpc64 =" arch/powerpc/powerpc-debug.scc"
+KERNEL_FEATURES:append:powerpc64le =" arch/powerpc/powerpc-debug.scc"
+
+INSANE_SKIP:kernel-vmlinux:qemuppc64 = "textrel"
+
+KBRANCH ?= "master"
+
+require recipes-kernel/linux/linux-yocto.inc
+
+# board specific branches
+KBRANCH:qemuarm  ?= "v5.15/standard/arm-versatile-926ejs"
+KBRANCH:qemuarm64 ?= "v5.15/standard/qemuarm64"
+KBRANCH:qemumips ?= "v5.15/standard/mti-malta32"
+KBRANCH:qemuppc  ?= "v5.15/standard/qemuppc"
+KBRANCH:qemuriscv64  ?= "v5.15/standard/base"
+KBRANCH:qemuriscv32  ?= "v5.15/standard/base"
+KBRANCH:qemux86  ?= "v5.15/standard/base"
+KBRANCH:qemux86-64 ?= "v5.15/standard/base"
+KBRANCH:qemumips64 ?= "v5.15/standard/mti-malta64"
+
+SRCREV_machine:qemuarm ?= "5a68f2d15d17f0f3c397e7f8c83f3f664f7037e5"
+SRCREV_machine:qemuarm64 ?= "00e666e6154fcdf52268f2a5a612b96afad073b0"
+SRCREV_machine:qemumips ?= "fb9e75076deade31754b7ad644952d63137e616b"
+SRCREV_machine:qemuppc ?= "49f6567f3b85a843e8b6042a79c58aab0bdbd0c9"
+SRCREV_machine:qemuriscv64 ?= "cc9695f5fd3b520464eb2ded66950734f308525c"
+SRCREV_machine:qemuriscv32 ?= "cc9695f5fd3b520464eb2ded66950734f308525c"
+SRCREV_machine:qemux86 ?= "cc9695f5fd3b520464eb2ded66950734f308525c"
+SRCREV_machine:qemux86-64 ?= "cc9695f5fd3b520464eb2ded66950734f308525c"
+SRCREV_machine:qemumips64 ?= "1ad01ab47ec056d4126798f6d57a33b65b2be49c"
+SRCREV_machine ?= "4fe89d07dcc2804c8b562f6c7896a45643d34b2f"
+SRCREV_meta ?= "4ed11ded922785d0b4fe4e1078f0ff2e8ddebf27"
+
+# set your preferred provider of linux-yocto to 'linux-yocto-upstream', and you'll
+# get the <version>/base branch, which is pure upstream -stable, and the same
+# meta SRCREV as the linux-yocto-standard builds. Select your version using the
+# normal PREFERRED_VERSION settings.
+BBCLASSEXTEND = "devupstream:target"
+SRCREV_machine:class-devupstream ?= "3fbf24b73f4a5bc8fd39a6b7a29145451c1039ce"
+PN:class-devupstream = "linux-yocto-upstream"
+KBRANCH:class-devupstream = "master"
+
+SRC_URI = "git://git.yoctoproject.org/linux-yocto.git;name=machine;branch=${KBRANCH}; \
+           git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-5.8;destsuffix=${KMETA} \
+           https://gitlab.arm.com/linux-arm/linux-acs/-/raw/master/kernel/src/0001-BSA-ACS-Linux-6.0.patch;patch=1;md5sum=952e79f61a9c29ada81182c15893b863 \
+           file://0002-Fix-for-CompuLab-IOT-GATE-iMX8-boot-issue.patch;patch=1 \
+"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+LINUX_VERSION ?= "6.0"
+
+DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
+DEPENDS += "openssl-native util-linux-native"
+DEPENDS += "gmp-native libmpc-native"
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+KMETA = "kernel-meta"
+KCONF_BSP_AUDIT_LEVEL = "1"
+
+KERNEL_DEVICETREE:qemuarmv5 = "versatile-pb.dtb"
+
+COMPATIBLE_MACHINE = "qemuarm|qemuarmv5|qemuarm64|qemux86|qemuppc|qemuppc64|qemumips|qemumips64|qemux86-64|qemuriscv64|qemuriscv32"
+
+# Functionality flags
+KERNEL_EXTRA_FEATURES ?= "features/netfilter/netfilter.scc"
+KERNEL_FEATURES:append = " ${KERNEL_EXTRA_FEATURES}"
+KERNEL_FEATURES:append:qemuall=" cfg/virtio.scc features/drm-bochs/drm-bochs.scc"
+KERNEL_FEATURES:append:qemux86=" cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append:qemux86-64=" cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("TUNE_FEATURES", "mx32", " cfg/x32.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " features/scsi/scsi-debug.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " features/gpio/mockup.scc", "", d)}"
+KERNEL_FEATURES:append:powerpc =" arch/powerpc/powerpc-debug.scc"
+KERNEL_FEATURES:append:powerpc64 =" arch/powerpc/powerpc-debug.scc"
+KERNEL_FEATURES:append:powerpc64le =" arch/powerpc/powerpc-debug.scc"
+
+INSANE_SKIP:kernel-vmlinux:qemuppc64 = "textrel"
+


### PR DESCRIPTION
Yocto version updated to langdale v4.1 from kirkstone Linux kernel version is customized to version 6.0

Signed-off-by: gurrev01 <gururaj.revankar@arm.com>
Co-authored-by: G Edhaya Chandran <edhaya.chandran@arm.com>