### PR TITLE
Updates for SystemReady IR ACS v2.0.0 release

### DIFF
--- a/IR/README.md
+++ b/IR/README.md
@@ -77,6 +77,16 @@ Note: UEFI EDK2 setting for "Console Preference": The default is "Graphical". In
 ### Verification of the IR image on Qemu arm machine
 
 #### Follow the Build instructions mentioned in [qemu download page](https://www.qemu.org/download/#source) to build latest qemu model.
+NOTE: For qemu versions >= 7.2.0, perform the steps listed below to support user-mode networking.
+- Install libslirp-dev
+
+`sudo apt install libslirp-dev`
+
+- Enable slirp during the Qemu build
+
+`./configure --enable-slirp`
+
+For more information visit https://wiki.qemu.org/ChangeLog/7.2#SLIRP_module_(user-mode_networking)
 
 #### To build the firmware image, follow below steps
 
@@ -86,6 +96,13 @@ cd working_directory
 repo init -u https://github.com/glikely/u-boot-manifest
 repo sync
 export CROSS_COMPILE=<path to gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf/bin/aarch64-none-elf->
+
+# The upstream u-boot code has issue in boot flow. The below steps are temprorary steps to avoid the issue.
+cd u-boot
+git checkout v2023.01
+cd ..
+# End of u-boot steps
+
 make qemu_arm64_defconfig
 make
 ```

--- a/IR/Yocto/README.md
+++ b/IR/Yocto/README.md
@@ -11,10 +11,10 @@ SystemReady IR-certified platforms implement a minimum set of hardware and firmw
 This section of the repository contains the build scripts and the live-images for the SystemReady IR Band.
 
 ## Release details
- - Code Quality: IR ACS v2.0.0 Beta-1
- - The latest pre-built release of IR ACS is available for download here: [v22.10_2.0.0_BETA-1](https://github.com/ARM-software/arm-systemready/tree/main/IR/prebuilt_images/v22.10_2.0.0_BETA-1)
+ - Code Quality: IR ACS v2.0.0
+ - The latest pre-built release of IR ACS is available for download here: [v23.03_2.0.0](https://github.com/ARM-software/arm-systemready/tree/main/IR/prebuilt_images/v23.03_2.0.0)
  - The BSA tests are written for version 1.0 of the BSA specification.
- - The BBR tests are written for version 1.0 of the BBR specification.
+ - The BBR tests are written for version 2.0 of the BBR specification.
  - The compliance suite is not a substitute for design verification.
  - To review the ACS logs, Arm licensees can contact Arm directly through their partner managers.
 
@@ -37,7 +37,7 @@ This section of the repository contains the build scripts and the live-images fo
 
 ### Prerequisites
 Before starting the ACS build, ensure that the following requirements are met:
- - Ubuntu 18.04 or 20.04 LTS with at least 32GB of free disk space.
+ - Ubuntu 18.04, 20.04 or 22.04 LTS with at least 32GB of free disk space.
  - Availability of the Bash shell.
  - **sudo** privilege to install tools required for the build.
  - `git` installed using `sudo apt install git`.
@@ -77,6 +77,16 @@ Note: The default UEFI EDK2 setting for "Console Preference" is "Graphical". In 
 ### Verification of the IR image on QEMU Arm machine
 
 #### Follow the Build instructions mentioned in [qemu download page](https://www.qemu.org/download/#source) to build latest QEMU model.
+NOTE: For qemu versions >= 7.2.0, perform the steps listed below to support user-mode networking.
+- Install libslirp-dev
+
+`sudo apt install libslirp-dev`
+
+- Enable slirp during the Qemu build
+
+`./configure --enable-slirp`
+
+For more information visit https://wiki.qemu.org/ChangeLog/7.2#SLIRP_module_(user-mode_networking)
 
 NOTE: Download the toolchain from [arm developer page](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-a/downloads/10-2-2020-11) <br />
 NOTE: If repo sync fails due to incorrect repo version , please update repo using the below steps.<br />
@@ -95,6 +105,13 @@ cd working_directory
 repo init -u https://github.com/glikely/u-boot-manifest
 repo sync
 export CROSS_COMPILE=<path to gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf/bin/aarch64-none-elf->
+
+# The upstream u-boot code has issue in boot flow. The below steps are temprorary steps to avoid the issue.
+cd u-boot
+git checkout v2023.01
+cd ..
+# End of u-boot steps
+
 make qemu_arm64_defconfig
 make
 ```
@@ -122,13 +139,13 @@ For the verification steps of SIE ACS on QEMU with TPM support, refer to the [SI
 
 ## Baselines for Open Source Software in this release:
 
-- [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git) TAG: v22.07.00
+- [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git) TAG: v23.01.00
 
-- [Base System Architecture (BSA)](https://github.com/ARM-software/bsa-acs) TAG: v22.06_IR_2.0.0_BETA-1
+- [Base System Architecture (BSA)](https://github.com/ARM-software/bsa-acs) TAG: v23.03_REL1.0.4
 
-- [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs) TAG: v22.06_IR_2.0.0_BETA-1
+- [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs) TAG: v23.03_IR_2.0.0
 
-- [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test) TAG: 4a25c3b3c79f63bd9f98b4fffcb21b5c66dd14bb
+- [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test) TAG: 8713740892bdb857e970a2841de9800b2c6b5552
 
 
 

--- a/IR/Yocto/build-scripts/get_source.sh
+++ b/IR/Yocto/build-scripts/get_source.sh
@@ -138,7 +138,7 @@ copy_recipes()
     # remove connect -r from startup.nsh, since it is not required for IR systems
     sed -i 's/connect -r//g' startup.nsh
     cp $TOP_DIR/../../common/ramdisk/secure_init.sh $TOP_DIR/meta-woden/recipes-acs/install-files/files
-    cp $TOP_DIR/../../common/config/sie_startup.nsh $TOP_DIR/meta-woden/recipes-acs/install-files/files
+    cp $TOP_DIR/../../common/config/verify_tpm_measurements.py $TOP_DIR/meta-woden/recipes-acs/install-files/files
     popd
 
 }

--- a/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/files/sctversion.patch
+++ b/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/files/sctversion.patch
@@ -7,7 +7,7 @@ index 94cae289..21eec3b7 100644
  #include "StandardTest.h"
  #include <Library/EntsLib.h>
 +
-+#define ACS_VERSION "SystemReady IR ACS v2.0.0 Beta-1\nBBR ACS 1.0.2 (EBBR)"
++#define ACS_VERSION "SystemReady IR ACS v2.0.0\nBBR ACS 1.0.4 (EBBR)"
 +
  
  static EFI_TIME Epoch = { .Year = 1970, .Month = 1, .Day = 1 };

--- a/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -86,7 +86,7 @@ fi
 #linux debug dump
 mkdir -p /mnt/acs_results/linux_dump
 lspci -vvv &> /mnt/acs_results/linux_dump/lspci.log
-lsusb > /mnt/acs_results/linux_dump/lsusb.log
+#lsusb > /mnt/acs_results/linux_dump/lsusb.log
 uname -a > /mnt/acs_results/linux_dump/uname.log
 cat /proc/interrupts > /mnt/acs_results/linux_dump/interrupts.log
 cat /proc/cpuinfo > /mnt/acs_results/linux_dump/cpuinfo.log
@@ -101,7 +101,7 @@ mkdir -p /mnt/acs_results/fwts
 echo "Executing FWTS for EBBR"
 test_list=`cat /usr/bin/ir_bbr_fwts_tests.ini | grep -v "^#" | awk '{print $1}' | xargs`
 echo "Test Executed are $test_list"
-echo $'SystemReady IR ACS v2.0.0 Beta-1\nFWTS v23.01.00' > /mnt/acs_results/fwts/FWTSResults.log
+echo $'SystemReady IR ACS v2.0.0 \nFWTS v23.01.00' > /mnt/acs_results/fwts/FWTSResults.log
 /usr/bin/fwts --ebbr `echo $test_list` -r /mnt/acs_results/fwts/FWTSResults.log
 echo -e -n "\n"
 
@@ -110,7 +110,7 @@ mkdir -p /mnt/acs_results/linux_acs/bsa_acs_app
 echo "Loading BSA ACS Linux Driver"
 insmod /lib/modules/*/kernel/bsa_acs/bsa_acs.ko
 echo "Executing BSA ACS Application "
-echo $'SystemReady IR ACS v2.0.0 Beta-1\nBSA v1.0.2' > /mnt/acs_results/linux_acs/bsa_acs_app/BSALinuxResults.log
+echo $'SystemReady IR ACS v2.0.0 \nBSA v1.0.4' > /mnt/acs_results/linux_acs/bsa_acs_app/BSALinuxResults.log
 bsa >> /mnt/acs_results/linux_acs/bsa_acs_app/BSALinuxResults.log
 dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux_acs/bsa_acs_app/BsaResultsKernel.log
 
@@ -133,12 +133,12 @@ if [ -f /sys/firmware/fdt ]; then
  echo "Running dt-validate tool "
  dt-validate -s /usr/bin/processed_schema.json -m /home/root/fdt/fdt 2>> /mnt/acs_results/linux_tools/dt-validate.log
 
- sed -i '1s/^/DeviceTree bindings of Linux kernel version: 5.19.10 \ndtschema version: 2022.9 \n\n/' /mnt/acs_results/linux_tools/dt-validate.log
+ sed -i '1s/^/DeviceTree bindings of Linux kernel version: 6.1.2 \ndtschema version: 2022.9 \n\n/' /mnt/acs_results/linux_tools/dt-validate.log
  if [ ! -s /mnt/acs_results/linux_tools/dt-validate.log ]; then
   echo $'The FDT is compliant according to schema ' >> /mnt/acs_results/linux_tools/dt-validate.log
  fi
 else
- echo  $'Error: The FDT devicetree file ,fdt , does not exist at /sys/firmware/fdt. Cannot run dt-schema tool ' | tee /mnt/acs_results/linux_tools/dt-validate.log
+ echo  $'Error: The FDT devicetree file, fdt, does not exist at /sys/firmware/fdt. Cannot run dt-schema tool ' | tee /mnt/acs_results/linux_tools/dt-validate.log
 fi
 
 echo "ACS run is completed"

--- a/IR/Yocto/meta-woden/recipes-acs/install-files/systemd-init-install.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/install-files/systemd-init-install.bb
@@ -7,6 +7,7 @@ SYSTEMD_SERVICE:${PN} = "acs_run-before-login-prompt.service"
 SRC_URI:append = " file://acs_run-before-login-prompt.service \
                    file://init.sh \
                    file://secure_init.sh \
+                   file://verify_tpm_measurements.py \
 		            "
 
 FILES:${PN} += "${systemd_unitdir}/system"
@@ -21,5 +22,5 @@ do_install:append() {
   install -m 0770 ${WORKDIR}/secure_init.sh                      ${D}${bindir}
   install -m 0770 ${WORKDIR}/../../ebbr-sct/1.0-r0/bbr-acs/bbsr/config/bbsr_fwts_tests.ini   ${D}/bin
   install -m 0644 ${WORKDIR}/acs_run-before-login-prompt.service ${D}${systemd_unitdir}/system
-
+  install -m 0770 ${WORKDIR}/verify_tpm_measurements.py          ${D}/bin
 }

--- a/IR/Yocto/meta-woden/recipes-images/images/woden-image.bb
+++ b/IR/Yocto/meta-woden/recipes-images/images/woden-image.bb
@@ -124,7 +124,7 @@ do_dir_deploy() {
     wic cp ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/EFI/BOOT/sie_startup.nsh sie_startup.nsh
 
     sed  -i -E 's/Image.*LABEL.*=.*/'"${LINUX_BOOT_CMD}"'/g' startup.nsh
-    sed  -i -E 's/Image.*LABEL.*=.*/'"${LINUX_BOOT_CMD}"'/g' sie_startup.nsh
+    sed  -i -E 's/Image.*LABEL.*=.*/'"${LINUX_BOOT_CMD} secureboot"'/g' sie_startup.nsh
 
     wic cp startup.nsh ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/EFI/BOOT/startup.nsh
     wic cp sie_startup.nsh ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/EFI/BOOT/sie_startup.nsh

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For the legacy SystemReady SR ACS, refer to the [Arm Enterprise ACS repository](
 ## SystemReady bands:
 Navigate to the ES, IR, or SR band for further details on specific scripts and prebuilt images through the directories below:
 * [ES](./ES)
-* [IR](./IR)
+* [IR](./IR/Yocto/)
 * [SR](./SR)
 * [LS](./LS)
 

--- a/common/config/common_config.cfg
+++ b/common/config/common_config.cfg
@@ -55,21 +55,21 @@ SCT_SRC_TAG=8713740892bdb857e970a2841de9800b2c6b5552
 # GRUB2 source from https://github.com/rhboot/grub2.git
 GRUB_SRC_TAG=grub-2.06
 
+ARM_BSA_VERSION=v1.0.4
 #Arm BSA source tag.
 #NOTE: If the value is NULL then the latest BSA source will be downloaded
-ARM_BSA_VERSION=v1.0.2
-ARM_BSA_TAG=""
+ARM_BSA_TAG="ec8be39202e3433d58a76497c365758de1cd6d36"
 
 #Arm BBR source tag
 #NOTE: If the value is NULL then the latest BBR source will be downloaded
-ARM_BBR_TAG=""
+ARM_BBR_TAG="e5759a3a7865d77ec8bba5d89cc3f6844cd89020"
 
 #Arm LINUX ACS source tag
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded
-ARM_LINUX_ACS_TAG=""
+ARM_LINUX_ACS_TAG="2f2b1c4536f0b27e3c4cf158e98f510ee0e610cd"
 
 #Linux kernel version for Yocto build. Used only for the IR Band
-YOCTO_LINUX_KERNEL_VERSION=5.15
+YOCTO_LINUX_KERNEL_VERSION=6.0
 
 # EDK2-LIBC source tag from https://github.com/tianocore/edk2-libc
 EDK2_LIBC_SRC_TAG=c32222fed9927420fc46da503dea1ebb874698b6

--- a/common/config/debug_dump.nsh
+++ b/common/config/debug_dump.nsh
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2021,2023, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -25,9 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-
 echo -off
-
 for %m in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%m:\acs_results then
         FS%m:
@@ -45,16 +43,16 @@ for %m in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
         dh -d > dh.log
         memmap > memmap.log
         bcfg boot dump > bcfg.log
-        map -r > map.log
         devtree > devtree.log
         ver > uefi_version.log
         ifconfig -l > ifconfig.log
         dmem > dmem.log
-
         for %n in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                 if exist FS%n:\EFI\BOOT\bsa\ir_bsa.flag then
                     #IR Specific ->DT
                 else
+                    echo "" > map.log
+                    map -r >> map.log
                     smbiosview > smbiosview.log
                     acpiview -l  > acpiview_l.log
                     acpiview -r 2 > acpiview_r.log

--- a/common/config/sie_startup.nsh
+++ b/common/config/sie_startup.nsh
@@ -44,23 +44,8 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                 endif
             endif
         endfor
-        for %l in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
-            if exist FS%l:\Image and exist FS%l:\ramdisk-buildroot.img then
-                FS%l:
-                cd FS%l:\
-                Image initrd=\ramdisk-buildroot.img systemd.log_target=null plymouth.ignore-serial-consoles debug crashkernel=512M,high log_buf_len=1M efi=debug acpi=on crashkernel=256M earlycon uefi_debug
-            endif
-            if exist FS%l:\Image and exist FS%l:\ramdisk-busybox.img then
-                FS%l:
-                cd FS%l:\
-                Image initrd=\ramdisk-busybox.img systemd.log_target=null plymouth.ignore-serial-consoles debug crashkernel=512M,high log_buf_len=1M efi=debug acpi=on crashkernel=256M earlycon uefi_debug
-            endif
-            if exist FS%l:\Image and exist FS%l:\yocto_image.flag then
-                FS%l:
-                cd FS%l:\
-                Image LABEL=Boot root=partuid rootfstype=ext4
-            endif
-        endfor
-    endif
+     echo "SIE SCT test suite execution is complete. Resetting the system"
+     reset
+     endif
 endfor
 

--- a/common/docs/SIE_ACS_Verification.md
+++ b/common/docs/SIE_ACS_Verification.md
@@ -50,9 +50,10 @@ export PACKAGES_PATH=$PWD/edk2:$PWD/edk2-platforms:$PWD/edk2-non-osi
 . edk2/edksetup.sh
 make -C edk2/BaseTools
 NUM_CPUS=$((`getconf _NPROCESSORS_ONLN` + 2))
-GCC5_AARCH64_PREFIX=<set compiler prefix path for aarch64-linux-gnu->
+export GCC5_AARCH64_PREFIX=<set compiler prefix path for aarch64-linux-gnu->
 build -n $NUM_CPUS -a AARCH64 -t GCC5 -p ArmVirtPkg/ArmVirtQemu.dsc -b RELEASE -D TTY_TERMINAL -D SECURE_BOOT_ENABLE -D TPM2_ENABLE -D TTY_TERMINAL all
 ```
+NOTE: Download the toolchain from [tool chain](https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/aarch64-linux-gnu/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu.tar.xz) <br />
 
 3. Create the required flash images
 ```


### PR DESCRIPTION
Updated version strings
Updated the IR/Yocto/README.md
Updated the QEMU and u-boot test firmware build instructions in the README Minor enhancements