### PR TITLE
Check if PCR register entry is present in event log

### DIFF
--- a/common/ramdisk/secure_init.sh
+++ b/common/ramdisk/secure_init.sh
@@ -63,8 +63,13 @@ if [ -f /sys/kernel/security/tpm0/binary_bios_measurements ]; then
   tpm2_pcrread > /mnt/acs_results/SIE/tpm2/pcr.log
   echo "  PCRs: /mnt/acs_results/SIE/tpm2/pcr.log"
   rm /tmp/binary_bios_measurements
-   #TPM2 logs event log v/s tpm.log check
-  python3 /bin/verify_tpm_measurements.py /mnt/acs_results/SIE/tpm2/eventlog.log mnt/acs_results/SIE/tpm2/pcr.log > /mnt/acs_results/SIE/tpm2/eventlog_pcr_diff.log
+  if grep -q "pcrs:" "/mnt/acs_results/SIE/tpm2/eventlog.log"; then
+    echo "Comparing eventlog.log and pcr.log"
+    #TPM2 logs event log v/s tpm.log check
+    python3 /bin/verify_tpm_measurements.py /mnt/acs_results/SIE/tpm2/eventlog.log mnt/acs_results/SIE/tpm2/pcr.log > /mnt/acs_results/SIE/tpm2/eventlog_pcr_diff.log
+  else
+    echo "Info: PCR register entries not found at the end of event log, eventlog.log vs pcr.log, auto-comparison is not possible"
+  fi 
 else
    echo "TPM event log not found at /sys/kernel/security/tpm0/binary_bios_measurements"
 fi


### PR DESCRIPTION
-Check added to see if the PCR register entry is present at the end of eventlog before comparing PCR logs with the PCR entry in eventlog