### PR TITLE
Adding BF rshim support to ACS

### DIFF
--- a/common/scripts/build-linux.sh
+++ b/common/scripts/build-linux.sh
@@ -101,6 +101,8 @@ do_build ()
     sed -i 's/# CONFIG_TCG_FTPM_TEE is not set/CONFIG_TCG_FTPM_TEE=y/g' $LINUX_OUT_DIR/.config
     sed -i 's/# CONFIG_TEE is not set/CONFIG_TEE=y/g' $LINUX_OUT_DIR/.config
     sed -i 's/# CONFIG_OPTEE is not set/CONFIG_OPTEE=y/g' $LINUX_OUT_DIR/.config
+    #Configurations to enable rshim support in ES/SR ACS images
+    echo "CONFIG_MLXBF_TMFIFO=y" >> $LINUX_OUT_DIR/.config
 
     if [[ $arch = "aarch64" ]]
     then


### PR DESCRIPTION
For BF DPU SoC, accessing UART's on DPU is very unfeasible, adding RSHIM config to enable access via BMC or from x86 host.