### PR TITLE
Upgraded the edk2 version to edk2-stable202305

### DIFF
--- a/common/config/common_config.cfg
+++ b/common/config/common_config.cfg
@@ -38,8 +38,8 @@ LINUX_KERNEL_VERSION=6.0
 BUSYBOX_SRC_VERSION=1_34_stable
 
 #EDK2 source tag from https://github.com/tianocore/edk2.git
-EDK2_SRC_VERSION=edk2-stable202211
-EDK2_SRC_TAG=fff6d81270b57ee786ea18ad74f43149b9f03494
+EDK2_SRC_VERSION=edk2-stable202305
+EDK2_SRC_TAG=ba91d0292e593df8528b66f99c1b0b14fadc8e16
 
 #Cross compiler tools from https://releases.linaro.org/components/toolchain/binaries
 LINARO_TOOLS_MAJOR_VERSION=7.5-2019.12

--- a/common/config/sr_es_common_config.cfg
+++ b/common/config/sr_es_common_config.cfg
@@ -31,7 +31,7 @@
 LINUX_KERNEL_VERSION=6.0
 
 #EDK2 source tag from https://github.com/tianocore/edk2.git
-EDK2_SRC_VERSION=edk2-stable202208
+EDK2_SRC_VERSION=edk2-stable202305
 
 # EDK2-TEST source tag from  https://github.com/tianocore/edk2-test
 SCT_SRC_TAG=06f84debb796b2f6ac893b130e90ab5599195b29


### PR DESCRIPTION
The edk2 upgrade is also necessary as part of the solution for https://github.com/ARM-software/bbr-acs/issues/41