### PR TITLE
RESULTS partition in the ACS Image is retired

### DIFF
--- a/ES/README.md
+++ b/ES/README.md
@@ -64,10 +64,10 @@ Note: The image is generated in a compressed (.xz) format. The image must be unc
 
 ## Build output
 This image comprises of two FAT file system partitions recognized by UEFI: <br />
-- 'acs-results' <br />
-  Stores logs of the automated execution of ACS. (Approximate size: 128 MB) <br/>
 - 'boot' <br />
-  Contains bootable applications and test suites. (Approximate size: 500 MB)
+  Approximate size: 640 MB <br />
+  contains bootable applications and test suites.<br />
+  contains a 'acs_results' directory which stores logs of the automated execution of ACS.
 
 
 ## Verification

--- a/IR/Yocto/README.md
+++ b/IR/Yocto/README.md
@@ -63,12 +63,12 @@ Note: The image is generated in a compressed (.xz) format. The image must be unc
 
 ## Build output
 This image comprises of two FAT file system partitions recognized by UEFI: <br />
-- 'results' <br />
-  Stores logs of the automated execution of ACS. (Approximate size: 50 MB) <br/>
 - '/' <br />
   Root partition for Linux which contains test-suites to run in Linux environment. <br/>
 - 'boot' <br />
-  Contains bootable applications and test suites. (Approximate size: 100 MB)
+  Approximate size: 150 MB <br />
+  contains bootable applications and test suites. (Approximate size: 150MB) <br />
+  contains a 'acs_results' directory which stores logs of the automated execution of ACS.
 
 ## Verification
 

--- a/IR/Yocto/meta-woden/recipes-images/images/woden-image.bb
+++ b/IR/Yocto/meta-woden/recipes-images/images/woden-image.bb
@@ -71,7 +71,7 @@ do_dir_deploy() {
     # copying bbr directory to /boot partition
     wic cp ${DEPLOY_DIR_IMAGE}/bbr ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/EFI/BOOT/
     wic cp ${DEPLOY_DIR_IMAGE}/security-interface-extension-keys ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/
- 
+
     do_sign_images;
 
     wic rm ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/security-interface-extension-keys/*.crt
@@ -80,7 +80,7 @@ do_dir_deploy() {
 
     # create and copy empty acs_results directory to /results partition
     mkdir -p acs_results
-    wic cp acs_results ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:3/
+    wic cp acs_results ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/
 
     #add bsa/bbr bootloder entry and set it has default boot
 

--- a/IR/Yocto/meta-woden/wic/woden.wks.in
+++ b/IR/Yocto/meta-woden/wic/woden.wks.in
@@ -1,7 +1,5 @@
 bootloader --ptable gpt --timeout=10 --append="rootfstype=ext4"
 
-part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER}" --label boot --active --align 1024 --use-uuid --size 100M
+part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER}" --label boot --active --align 1024 --use-uuid --size 150M
 
 part / --source rootfs --fstype=ext4 --label root --align 1024 --use-uuid
-
-part /results --fstype=vfat --label results --align 1024 --use-uuid --size 50M

--- a/SR/README.md
+++ b/SR/README.md
@@ -63,10 +63,10 @@ Note: The image is generated in a compressed (.xz) format. The image must be unc
 
 ## Build output
 This image comprises two FAT file system partitions recognized by UEFI: <br />
-- 'acs-results' <br />
-  stores logs of the automated execution of ACS. (Approximate size: 128MB) <br/>
 - 'boot' <br />
-  contains bootable applications and test suites. (Approximate size: 500MB)
+  Approximate size: 640 MB <br />
+  contains bootable applications and test suites. <br />
+  contains a 'acs_results' directory which stores logs of the automated execution of ACS.
 
 
 ## Verification

--- a/common/scripts/framework.sh
+++ b/common/scripts/framework.sh
@@ -78,7 +78,7 @@ OUTDIR=${PLATDIR}
 LINUX_OUT_DIR=out
 LINUX_PATH=linux-${LINUX_KERNEL_VERSION}
 
-if [ $CLEAN_BUILD == "C" ]; then
+if [ -n "$CLEAN_BUILD" ] && [ "$CLEAN_BUILD" = "C" ]; then
     do_clean
 fi
 do_build


### PR DESCRIPTION
-Logs will be now saved in BOOT partition /acs_results directory. -Build scripts and READMEs are updated.
-This applies for images of all bands ES, SR and IR.