### PR TITLE
Mount logic improved in init.sh

### DIFF
--- a/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
@@ -37,7 +37,7 @@ do_configure() {
     git apply --ignore-whitespace --ignore-space-change ${S}/bbr-acs/common/patches/edk2-test-bbr-build.patch
     # Copy sbbr-test cases from bbr-acs to uefi-sct
     cp -r ${SBBR_TEST_DIR}/SbbrBootServices uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/
-    cp -r ${SBBR_TEST_DIR}/SbbrEfiSpecVerLvl ${SBBR_TEST_DIR}/SbbrRequiredUefiProtocols ${SBBR_TEST_DIR}/SbbrSmbios ${SBBR_TEST_DIR}/SbbrSysEnvConfig uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/
+    cp -r ${SBBR_TEST_DIR}/SbbrEfiSpecVerLvl ${SBBR_TEST_DIR}/SbbrRequiredUefiProtocols ${SBBR_TEST_DIR}/SbbrSysEnvConfig uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/
     cp -r ${SBBR_TEST_DIR}/SBBRRuntimeServices uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/
     cp ${SBBR_TEST_DIR}/BBR_SCT.dsc uefi-sct/SctPkg/UEFI/
     cp ${SBBR_TEST_DIR}/build_bbr.sh uefi-sct/SctPkg/

--- a/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -40,36 +40,13 @@ ADDITIONAL_CMD_OPTION="";
 ADDITIONAL_CMD_OPTION=`cat /proc/cmdline | awk '{ print $NF}'`
 
 if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
- echo "Attempting to mount the results partition ..."
- RESULT_DEVICE="";
- 
+ echo "Attempting to mount the results partition ..." 
  #mount result partition
- cat /proc/partitions | tail -n +3 > partition_table.lst
- while read -r line
- do
-    # do something with $line here
-    MAJOR=`echo $line | awk '{print $1}'`
-    MINOR=`echo $line | awk '{print $2}'`
-    DEVICE=`echo $line | awk '{print $4}'`
-    echo "$MAJOR $MINOR $DEVICE"
-    mknod /dev/$DEVICE b $MAJOR $MINOR
-    mount /dev/$DEVICE /mnt
-    if [ -d /mnt/acs_results ]; then
-         #Partition is mounted. Break from loop
-         RESULT_DEVICE="/dev/$DEVICE"
-         echo "Setting RESULT_DEVICE to $RESULT_DEVICE"
-         break;
-         #Note: umount must be done from the calling function
-    else
-         #acs_results is not found, so move to next
-         umount /mnt
-    fi
- done < partition_table.lst
- 
- rm partition_table.lst
- 
- if [ ! -z "$RESULT_DEVICE" ]; then
-  echo "Mounted the results partition on device $RESULT_DEVICE"
+ BLOCK_DEVICE_NAME=$(blkid | grep "BOOT" | awk -F: '{print $1}')
+
+ if [ ! -z "$BLOCK_DEVICE_NAME" ]; then
+  mount $BLOCK_DEVICE_NAME /mnt
+  echo "Mounted the results partition on device $BLOCK_DEVICE_NAME"
  else
   echo "Warning: the results partition could not be mounted. Logs may not be saved correctly"
  fi

--- a/IR/Yocto/meta-woden/wic/woden.wks.in
+++ b/IR/Yocto/meta-woden/wic/woden.wks.in
@@ -1,5 +1,5 @@
 bootloader --ptable gpt --timeout=10 --append="rootfstype=ext4"
 
-part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER}" --label boot --active --align 1024 --use-uuid --size 150M
+part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER}" --label BOOT --active --align 1024 --use-uuid --size 150M
 
 part / --source rootfs --fstype=ext4 --label root --align 1024 --use-uuid

--- a/common/ramdisk/init.sh
+++ b/common/ramdisk/init.sh
@@ -55,41 +55,17 @@ insmod /lib/modules/nvme.ko
 
 sleep 5
 
-RESULT_DEVICE="";
 #Skip running of ACS Tests if the grub option is added
 ADDITIONAL_CMD_OPTION="";
 ADDITIONAL_CMD_OPTION=`cat /proc/cmdline | awk '{ print $NF}'`
 
 if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
  #mount result partition
- cat /proc/partitions | tail -n +3 > partition_table.lst
- while read -r line
- do
-    # do something with $line here
-    MAJOR=`echo $line | awk '{print $1}'`
-    MINOR=`echo $line | awk '{print $2}'`
-    DEVICE=`echo $line | awk '{print $4}'`
-    echo "$MAJOR $MINOR $DEVICE"
-    mknod /dev/$DEVICE b $MAJOR $MINOR
-    mount /dev/$DEVICE /mnt
-    if [ -d /mnt/acs_results ]; then
-         #Partition is mounted. Break from loop
-         RESULT_DEVICE="/dev/$DEVICE"
-         echo "Setting RESULT_DEVICE to $RESULT_DEVICE"
-         break;
-         #Note: umount must be done from the calling function
-    else
-         #acs_results is not found, so move to next
-         umount /mnt
-    fi
- done < partition_table.lst
- 
- rm partition_table.lst
- 
- 
- 
- if [ ! -z "$RESULT_DEVICE" ]; then
-  echo "Mounted the results partition on device $RESULT_DEVICE"
+ BLOCK_DEVICE_NAME=$(blkid | grep "BOOT" | awk -F: '{print $1}')
+
+ if [ ! -z "$BLOCK_DEVICE_NAME" ]; then
+  mount $BLOCK_DEVICE_NAME /mnt
+  echo "Mounted the results partition on device $BLOCK_DEVICE_NAME"
  else
   echo "Warning: the results partition could not be mounted. Logs may not be saved correctly"
  fi


### PR DESCRIPTION
-blkid used to find the current partition with label "BOOT". 
-mount the current partition on /mnt.
-Label name changed from "boot" to "BOOT" for IR band.