### PR TITLE
Update source URL for FWTS

### DIFF
--- a/common/config/common_config.cfg
+++ b/common/config/common_config.cfg
@@ -45,7 +45,7 @@ EDK2_SRC_TAG=ba91d0292e593df8528b66f99c1b0b14fadc8e16
 LINARO_TOOLS_MAJOR_VERSION=7.5-2019.12
 LINARO_TOOLS_VERSION=7.5.0-2019.12
 
-#FWTS source tag from  https://git.launchpad.net/fwts
+#FWTS source tag from  git://kernel.ubuntu.com/hwe/fwts.git
 FWTS_SRC_VERSION=v22.09.00
 FWTS_SRC_TAG=330af50dbb33420188835e40a4873971dbeabbe0
 

--- a/common/scripts/get_source.sh
+++ b/common/scripts/get_source.sh
@@ -179,7 +179,7 @@ get_grub_src()
 get_fwts_src()
 {
     echo "Downloading FWTS source code. TAG : ${FWTS_SRC_TAG}"
-    git clone --single-branch https://git.launchpad.net/fwts
+    git clone --single-branch git://kernel.ubuntu.com/hwe/fwts.git
     pushd $TOP_DIR/fwts
     git checkout $FWTS_SRC_TAG
     git submodule update --init


### PR DESCRIPTION
FWTS source URL updated from https://git.launchpad.net/fwts to git://kernel.ubuntu.com/hwe/fwts.git