### PR TITLE
Add "console=ttyS0 console=tty0" to linux boot command.

### DIFF
--- a/common/config/grub-buildroot.cfg
+++ b/common/config/grub-buildroot.cfg
@@ -7,7 +7,7 @@ set term="vt100"
 set timeout="5"
 
 menuentry 'Linux Buildroot' {
-    linux /Image rootwait  debug crashkernel=512M log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon
+    linux /Image rootwait  debug crashkernel=512M log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon console=tty0 console=ttyS0
     initrd /ramdisk-buildroot.img
 }
 menuentry 'bbr/bsa' {

--- a/common/config/grub.cfg
+++ b/common/config/grub.cfg
@@ -7,7 +7,7 @@ set term="vt100"
 set timeout="5"
 
 menuentry 'Linux BusyBox' {
-    linux /Image rootwait debug crashkernel=512M log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon 
+    linux /Image rootwait debug crashkernel=512M log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon console=tty0 console=ttyS0
     initrd /ramdisk-busybox.img
 }
 menuentry 'bbr/bsa' {

--- a/common/config/startup.nsh
+++ b/common/config/startup.nsh
@@ -89,7 +89,7 @@ for %l in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%l:\Image and exist FS%l:\ramdisk-buildroot.img then
         FS%l:
         cd FS%l:\
-        Image initrd=\ramdisk-buildroot.img debug crashkernel=512M,high log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon systemd.log_target=null plymouth.ignore-serial-consoles
+        Image initrd=\ramdisk-buildroot.img debug crashkernel=512M,high log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon systemd.log_target=null plymouth.ignore-serial-consoles console=tty0 console=ttyS0
     endif
     if exist FS%l:\Image and exist FS%l:\ramdisk-busybox.img then
         FS%l:


### PR DESCRIPTION
Add "console=ttyS0 console=tty0" to GRUB and UEFI Linux boot command option for getting output to video and serial console both.
This is added for ES and SR images