### PR TITLE
Add github action for CI flow

### DIFF
--- a/.github/workflows/IR_ACS_2.0.yml
+++ b/.github/workflows/IR_ACS_2.0.yml
@@ -1,0 +1,37 @@
+name: Build IR 2.0 ACS image
+
+on: [push, pull_request]
+
+jobs:
+  build_image:
+    name: Build IR 2.0 ACS image
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        env:
+        - ARCH: x86_64
+    steps:
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
+      with:
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Start building
+      run:
+        sudo -s;
+        cd IR/Yocto;
+        ./build-scripts/get_source.sh;
+        sed -i 's/if 0 == os.getuid/if 1 == os.getuid/' meta-woden/poky/meta/classes-global/sanity.bbclass;
+        ./build-scripts/build-ir-live-image.sh
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ir-acs-live-image-generic-arm64.wic.xz
+        path: IR/Yocto/meta-woden/build/tmp/deploy/images/generic-arm64/ir-acs-live-image-generic-arm64.wic.xz
+        if-no-files-found: error
+


### PR DESCRIPTION
Add github action to automate SR IR 2.0 ACS building workflow. After this CI flow, we can get the built ACS image or check issues in the latest version.
For an example of a complete workflow, see here: https://github.com/ownia/arm-systemready/actions/runs/5958726464
