### PR TITLE
Fix for FWTS last_attempt_status issue

### DIFF
--- a/IR/Yocto/build-scripts/get_source.sh
+++ b/IR/Yocto/build-scripts/get_source.sh
@@ -142,7 +142,7 @@ copy_recipes()
     popd
     # copy any patches to linux src files directory
     cp $COMMON_DIR_PATH/patches/tpm-tis-spi-Add-hardware-wait-polling.patch $TOP_DIR/meta-woden/recipes-kernel/linux/files
-
+    cp $COMMON_DIR_PATH/patches/fwts_last_attempt_status.patch $TOP_DIR/meta-woden/recipes-acs/fwts/files
 }
 
 copy_recipes

--- a/IR/Yocto/meta-woden/recipes-acs/fwts/fwts_23.07.00.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/fwts/fwts_23.07.00.bb
@@ -11,6 +11,7 @@ SRC_URI = "http://fwts.ubuntu.com/release/fwts-V${PV}.tar.gz;subdir=${BP} \
            file://0005-Undefine-PAGE_SIZE.patch \
            file://0006-use-intptr_t-to-fix-pointer-to-int-cast-issues.patch \
            file://0001-uefi-esrt-Added-esrt_test2-for-EBBR.patch \
+           file://fwts_last_attempt_status.patch \
            "
 SRC_URI[sha256sum] = "a15e11c42856e9dfcf7ac23ed370618d2777eb996dd7843accf12d45b21b551c"
 

--- a/common/patches/fwts_last_attempt_status.patch
+++ b/common/patches/fwts_last_attempt_status.patch
@@ -1,0 +1,32 @@
+checking the kernel drivers/firmware/efi/esrt.c, last_attempt_status value
+should be decimal.
+esre_attr_decl(last_attempt_status, 32, "%u");
+
+Signed-off-by: Ivan Hu <ivan.hu at canonical.com>
+---
+ src/uefi/esrt/esrt.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/uefi/esrt/esrt.c b/src/uefi/esrt/esrt.c
+index d3b1db85..cd2901eb 100644
+--- a/src/uefi/esrt/esrt.c
++++ b/src/uefi/esrt/esrt.c
+@@ -167,13 +167,13 @@ static void check_entries(fwts_framework *fw, bool *passed)
+ 						"Missing or failed to get LastAttemptStatus on %s.", entry->d_name);
+ 				*passed = false;
+ 			} else {
+-				uint32_t lastattemptst = strtoul(str, NULL, 16);
++				uint32_t lastattemptst = strtoul(str, NULL, 10);
+ 
+ 				if (lastattemptst > LAST_ATTEMPT_STATUS_ERR_UNSATISFIED_DEPENDENCIES &&
+ 					(lastattemptst < LAST_ATTEMPT_STATUS_ERR_UNSUCCESSFUL_VENDOR_RANGE_MIN ||
+ 					lastattemptst > LAST_ATTEMPT_STATUS_ERR_UNSUCCESSFUL_VENDOR_RANGE_MAX)) {
+ 					fwts_failed(fw, LOG_LEVEL_MEDIUM, "InvalidValue",
+-						"The LastAttemptStatus value on %s is 0x%" PRIx32
++						"The LastAttemptStatus value on %s is 0x%" PRIu32
+ 						", which is undefined on UEFI Spec."
+ 						, entry->d_name, lastattemptst);
+ 					*passed = false;
+-- 
+2.34.1
+

--- a/common/scripts/get_source.sh
+++ b/common/scripts/get_source.sh
@@ -238,6 +238,7 @@ get_buildroot_src()
     pushd $TOP_DIR/buildroot/package/fwts
         echo "Applying Buildroot FWTS patch..."
         git apply $TOP_DIR/../../common/patches/build_fwts_version_23.07.00.patch
+        git apply $TOP_DIR/../../common/patches/fwts_last_attempt_status.patch
     popd
 }
 


### PR DESCRIPTION
fwts uefi: esrt: fix the last_attempt_status wrongly interpretation of value