### PR TITLE
IR : Ship ethernet kernel modules and run ethtool based dump.

### DIFF
--- a/IR/Yocto/meta-woden/conf/distro/woden.conf
+++ b/IR/Yocto/meta-woden/conf/distro/woden.conf
@@ -11,6 +11,80 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED = "pulseaudio gobject-introspection-data"
 DISTRO_EXTRA_RDEPENDS += "packagegroup-core-boot"
 DISTRO_EXTRA_RRECOMMENDS += "kernel-module-af-packet"
 
+# shipping wired-network drivers
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS  += "kernel-module-ipa \
+                                     kernel-module-tap \
+                                     kernel-module-pegasus \
+                                     kernel-module-smsc75xx \
+                                     kernel-module-usbnet \
+                                     kernel-module-asix \
+                                     kernel-module-rtl8150 \
+                                     kernel-module-cdc_ncm \
+                                     kernel-module-cdc_subset \
+                                     kernel-module-cdc_ether \
+                                     kernel-module-smsc95xx \
+                                     kernel-module-plusb \
+                                     kernel-module-sr9800 \
+                                     kernel-module-r8153_ecm \
+                                     kernel-module-mcs7830 \
+                                     kernel-module-zaurus \
+                                     kernel-module-dm9601 \
+                                     kernel-module-net1080 \
+                                     kernel-module-lan78xx \
+                                     kernel-module-ax88179_178a \
+                                     kernel-module-r8152 \
+                                     kernel-module-mdio \
+                                     kernel-module-macvlan \
+                                     kernel-module-marvell10g \
+                                     kernel-module-bcm7xxx \
+                                     kernel-module-smsc \
+                                     kernel-module-ax88796b \
+                                     kernel-module-broadcom \
+                                     kernel-module-bcm-phy-lib \
+                                     kernel-module-marvell \
+                                     kernel-module-meson-gxl \
+                                     kernel-module-bcm54140 \
+                                     kernel-module-microchip \
+                                     kernel-module-mdio-bcm-unimac \
+                                     kernel-module-mdio-mux-meson-g12a \
+                                     kernel-module-flexcan \
+                                     kernel-module-rcar_can \
+                                     kernel-module-rcar_canfd \
+                                     kernel-module-can-dev \
+                                     kernel-module-mcp251xfd \
+                                     kernel-module-macvtap \
+                                     kernel-module-mlx4_en \
+                                     kernel-module-mlx4_core \
+                                     kernel-module-mlx5_core \
+                                     kernel-module-bnx2x \
+                                     kernel-module-bcmsysport \
+                                     kernel-module-genet \
+                                     kernel-module-qcom-emac \
+                                     kernel-module-rmnet \
+                                     kernel-module-r8169 \
+                                     kernel-module-mscc_ocelot_switch_lib \
+                                     kernel-module-dwmac-meson \
+                                     kernel-module-dwmac-ipq806x \
+                                     kernel-module-dwmac-generic \
+                                     kernel-module-stmmac \
+                                     kernel-module-dwmac-imx \
+                                     kernel-module-dwmac-altr-socfpga \
+                                     kernel-module-dwmac-qcom-ethqos \
+                                     kernel-module-dwmac-meson8b \
+                                     kernel-module-dwmac-sun8i \
+                                     kernel-module-dwmac-rk \
+                                     kernel-module-dwmac-visconti \
+                                     kernel-module-dwmac-sunxi \
+                                     kernel-module-stmmac-platform \
+                                     kernel-module-atl1c \
+                                     kernel-module-veth \
+                                     kernel-module-pcs_xpcs \
+                                     kernel-module-bcm-sf2 \
+                                     kernel-module-b53_common \
+                                     kernel-module-b53_srab \
+                                     kernel-module-mscc_felix \
+"
+
 PREMIRRORS ??= "\
 bzr://.*/.*   https://downloads.yoctoproject.org/mirror/sources/ \n \
 cvs://.*/.*   https://downloads.yoctoproject.org/mirror/sources/ \n \

--- a/IR/Yocto/meta-woden/recipes-acs/install-files/files/ethtool-test.py
+++ b/IR/Yocto/meta-woden/recipes-acs/install-files/files/ethtool-test.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script parses for ethernet interfaces using ip tool and runs ethtool
+# self-test if the interface supports.
+
+import subprocess
+
+def print_color(text, color="default"):
+    colors = {
+        "default": "\033[0m",
+        "red": "\033[91m",
+        "green": "\033[92m",
+        "yellow": "\033[93m",
+    }
+
+    color_code = colors.get(color, colors["default"])
+    color_default = colors["default"]
+    print(color_code + text + color_default)
+
+if __name__ == "__main__":
+
+    try:
+        # Run ip link command to list all network interfaces
+        ip_command = "ip -o link"
+        output = subprocess.check_output(ip_command, shell=True).decode("utf-8").split('\n')
+
+        ether_interfaces = []
+
+        # Iterate through the reported interfaces
+        for line in output:
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+
+            interface_name = parts[1].rstrip(':')
+            # Check if the line contains "ether"
+            if "ether" in line:
+                ether_interfaces.append(interface_name)
+
+        print("\n****************************************************************\n")
+        print_color("                         Running ethtool\n", "green")
+        print("****************************************************************")
+
+        # print the the ethernet interfaces if available.
+        if len(ether_interfaces) == 0:
+            print_color("INFO: No ethernet interfaces detected via ip linux command, Exiting ...", "yellow")
+            exit(1)
+        else:
+            print_color("INFO: Detected following ethernet interfaces via ip command :", "green")
+            for index, intrf in enumerate(ether_interfaces):
+                print_color(f"{index}: {intrf}", "yellow")
+
+        print("\n****************************************************************\n")
+        for index, intrf in enumerate(ether_interfaces):
+            # Dump ethtool prints for each ethernet interface reported
+            print_color(f"INFO: Running \"ethtool {intrf} \" :", "green")
+            command = f"ethtool {intrf}"
+            result = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+            print(result.stdout)
+            print(result.stderr)
+
+            # Run ethernet self-test if the drivers supports it
+            command = f"ethtool -i {intrf}"
+            result = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+            if "supports-test: yes" in result.stdout:
+                print_color(f"INFO: Ethernet interface {intrf} supports ethtool self test.", "green")
+                command = f"ethtool -t {intrf}"
+                print_color(f"INFO: Running {command} :", "green")
+                result = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+                print(result.stdout)
+                print(result.stderr)
+            else:
+                print_color(f"INFO: Ethernet interface {intrf} doesn't supports ethtool self test", "green")
+            print("\n****************************************************************\n")
+            exit(0)
+    except Exception as e:
+        print_color(f"Error occurred: {e}", "red")
+        exit(1)

--- a/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -1,32 +1,19 @@
 #!/bin/sh
 
-# Copyright (c) 2022-2023, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Redistributions of source code must retain the above copyright notice, this
-# list of conditions and the following disclaimer.
+#  http://www.apache.org/licenses/LICENSE-2.0
 #
-# Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# Neither the name of ARM nor the names of its contributors may be used
-# to endorse or promote products derived from this software without specific
-# prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 echo "init.sh"
 
@@ -130,6 +117,12 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
  else
      echo "SCT result does not exist, cannot run edk2-test-parser tool cannot run"
  fi
+
+ # run ethtool-test.py, dump ethernet information and run self-tests if supported
+ python3 /bin/ethtool-test.py | tee ethtool-test.log
+ # remove color characters from log and save
+ awk '{gsub(/\x1B\[[0-9;]*[JKmsu]/, "")}1' ethtool-test.log > /mnt/acs_results/linux_tools/ethtool-test.log
+
 else
  echo ""
  echo "Additional option set to not run ACS Tests. Skipping ACS tests on Linux"

--- a/IR/Yocto/meta-woden/recipes-acs/install-files/systemd-init-install.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/install-files/systemd-init-install.bb
@@ -8,7 +8,8 @@ SRC_URI:append = " file://acs_run-before-login-prompt.service \
                    file://init.sh \
                    file://secure_init.sh \
                    file://verify_tpm_measurements.py \
-		            "
+                   file://ethtool-test.py \
+		 "
 
 FILES:${PN} += "${systemd_unitdir}/system"
 
@@ -23,4 +24,6 @@ do_install:append() {
   install -m 0770 ${WORKDIR}/../../ebbr-sct/1.0-r0/bbr-acs/bbsr/config/bbsr_fwts_tests.ini   ${D}/bin
   install -m 0644 ${WORKDIR}/acs_run-before-login-prompt.service ${D}${systemd_unitdir}/system
   install -m 0770 ${WORKDIR}/verify_tpm_measurements.py          ${D}/bin
+  install -m 0770 ${WORKDIR}/ethtool-test.py                     ${D}/bin
+
 }


### PR DESCRIPTION
- added all ethernet drivers built default by arm64/defconfig to MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS, so its shipped in rootfs.
- added ethtool-test.py to parse and dump ethernet info for IR.