### PR TITLE
Updates to optionally boot ACS Linux with SetVirtualAddressMap mode

### DIFF
--- a/common/config/grub-buildroot.cfg
+++ b/common/config/grub-buildroot.cfg
@@ -6,7 +6,7 @@ set debug="loader,mm"
 set term="vt100"
 set timeout="5"
 
-menuentry 'Linux Buildroot' {
+menuentry 'Linux Boot' {
     linux /Image rootwait  debug crashkernel=512M log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon console=tty0 console=ttyS0
     initrd /ramdisk-buildroot.img
 }
@@ -18,5 +18,9 @@ menuentry 'SCT for Security Interface Extension (optional)' {
 }
 menuentry 'Linux Boot for Security Interface Extension (optional)' {
     linux /Image rootwait verbose debug secureboot
+    initrd /ramdisk-buildroot.img
+}
+menuentry 'Linux Boot with SetVirtualAddressMap enabled' {
+    linux /Image rootwait verbose debug crashkernel=256M acsforcevamap
     initrd /ramdisk-buildroot.img
 }

--- a/common/ramdisk/init.sh
+++ b/common/ramdisk/init.sh
@@ -87,6 +87,18 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
   sleep 3
   exec sh +m
  fi
+
+ if [ $ADDITIONAL_CMD_OPTION == "acsforcevamap" ]; then
+  echo "Linux Boot with SetVirtualMap enabled"
+  mkdir -p /mnt/acs_results/SetVAMapMode/fwts
+  echo "Executing FWTS"
+  fwts  -r stdout -q --uefi-set-var-multiple=1 --uefi-get-mn-count-multiple=1 --sbbr esrt uefibootpath > /mnt/acs_results/SetVAMapMode/fwts/FWTSResults.log
+  sync /mnt
+  sleep 3
+  echo "The ACS test suites are completed."
+  exec sh +m
+ fi
+
  #linux debug dump
  mkdir -p /mnt/acs_results/linux_dump
  lspci -vvv &> /mnt/acs_results/linux_dump/lspci.log
@@ -164,5 +176,6 @@ fi
 
 sync /mnt
 sleep 3
+echo "The ACS test suites are completed."
 
 exec sh +m


### PR DESCRIPTION
A new grub option is provided to ACS Linux in SetVirtualAddressMap on. Related updates in init.sh to run FWTS post boot of this option.