### PR TITLE
SR ES buildroot  rebuild issue resolved

### DIFF
--- a/common/scripts/build-buildroot.sh
+++ b/common/scripts/build-buildroot.sh
@@ -71,8 +71,9 @@ do_build ()
     mkdir -p root_fs_overlay/bin
     mkdir -p root_fs_overlay/lib/modules
     mkdir -p root_fs_overlay/usr/bin
-
-    cp -r $TOP_DIR/edk2-test-parser root_fs_overlay/usr/bin/ 
+    if [ ! -d root_fs_overlay/usr/bin/edk2-test-parser ]; then
+        cp -r $TOP_DIR/edk2-test-parser root_fs_overlay/usr/bin/ 
+    fi    
     cp  $TOP_DIR/ramdisk/linux-bsa/bsa root_fs_overlay/bin/
     cp  $TOP_DIR/ramdisk/linux-bsa/bsa_acs.ko root_fs_overlay/lib/modules/
     cp  $TOP_DIR/ramdisk/drivers/* root_fs_overlay/lib/modules/


### PR DESCRIPTION
-Check added before copying edk2-test-parser to root_fs_overlay/usr/bin