### PR TITLE
Add --keep-baud to systemd serial getty service

### DIFF
--- a/IR/Yocto/build-scripts/get_source.sh
+++ b/IR/Yocto/build-scripts/get_source.sh
@@ -57,7 +57,7 @@ popd
 customise_image()
 {
     #Remove the root login prompt after the startup
-    sed -i 's/ExecStart=.*/ExecStart=\-\/sbin\/agetty \-a root \-8 \-L \%I \@BAUDRATE\@ \$TERM/' $TOP_DIR/meta-woden/poky/meta/recipes-core/systemd/systemd-serialgetty/serial-getty@.service
+    sed -i 's/ExecStart=.*/ExecStart=\-\/sbin\/agetty \-a root \-8 \-L \--keep-baud \%I \@BAUDRATE\@ \$TERM/' $TOP_DIR/meta-woden/poky/meta/recipes-core/systemd/systemd-serialgetty/serial-getty@.service
 
 }
 


### PR DESCRIPTION
In this [commit](https://git.yoctoproject.org/poky/commit/?id=9be3fb25609a1bbf8aabadd67088e92097727c60), yocto poky disabled --keep-baud in order to use SERIAL_CONSOLES to override the baud rate. But ACS IR will be deployed on different platforms with a non-standard baud rate probably (in my case is 1500000), so we can use --keep-baud to keep the current baud rate the same way as the [official](https://github.com/systemd/systemd/blob/main/units/serial-getty%40.service.in).