### PR TITLE
Fix uefi_demp log location error

### DIFF
--- a/common/config/debug_dump.nsh
+++ b/common/config/debug_dump.nsh
@@ -41,7 +41,8 @@ for %m in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             endif
         else
             mkdir uefi_dump
-:DEBUG_DUMP cd uefi_dump
+:DEBUG_DUMP
+            cd uefi_dump
             echo "Starting UEFI Debug dump"
             connect -r
             pci > pci.log


### PR DESCRIPTION
The latest code leads `/acs_results/uefi_dump/` emtpy and uefi_dump logs are stored in the `/acs_results/`.
Root case is that the script didn't change directory to `uefi_dump/`. 
According to chapter 5.3 "goto Description" of UEFI Specification Version 2.10, it said "If a label is encountered but there is no goto command executed, the label lines are ignored".
So we should move cd command to the next line.