### PR TITLE
Linux kernel double print issue in ES and SR ACS Images

### DIFF
--- a/common/config/grub-buildroot.cfg
+++ b/common/config/grub-buildroot.cfg
@@ -7,7 +7,7 @@ set term="vt100"
 set timeout="5"
 
 menuentry 'Linux Boot' {
-    linux /Image rootwait  debug crashkernel=512M log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon console=tty0 console=ttyS0
+    linux /Image rootwait  debug crashkernel=512M log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon console=tty0 console=ttyS0  console=ttyAMA0
     initrd /ramdisk-buildroot.img
 }
 menuentry 'bbr/bsa' {
@@ -17,10 +17,10 @@ menuentry 'SCT for Security Interface Extension (optional)' {
     chainloader /EFI/BOOT/Shell.efi -nostartup sie_startup.nsh
 }
 menuentry 'Linux Boot for Security Interface Extension (optional)' {
-    linux /Image rootwait verbose debug secureboot
+    linux /Image rootwait verbose debug secureboot console=tty0 console=ttyS0  console=ttyAMA0
     initrd /ramdisk-buildroot.img
 }
 menuentry 'Linux Boot with SetVirtualAddressMap enabled' {
-    linux /Image rootwait verbose debug crashkernel=256M acsforcevamap
+    linux /Image rootwait verbose debug crashkernel=256M acsforcevamap console=tty0 console=ttyS0  console=ttyAMA0
     initrd /ramdisk-buildroot.img
 }

--- a/common/config/grub.cfg
+++ b/common/config/grub.cfg
@@ -7,7 +7,7 @@ set term="vt100"
 set timeout="5"
 
 menuentry 'Linux BusyBox' {
-    linux /Image rootwait debug crashkernel=512M log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon console=tty0 console=ttyS0
+    linux /Image rootwait debug crashkernel=512M log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon console=tty0 console=ttyS0  console=ttyAMA0
     initrd /ramdisk-busybox.img
 }
 menuentry 'bbr/bsa' {

--- a/common/config/startup.nsh
+++ b/common/config/startup.nsh
@@ -90,7 +90,7 @@ for %l in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%l:\Image and exist FS%l:\ramdisk-buildroot.img then
         FS%l:
         cd FS%l:\
-        Image initrd=\ramdisk-buildroot.img debug crashkernel=512M,high log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon systemd.log_target=null plymouth.ignore-serial-consoles console=tty0 console=ttyS0
+        Image initrd=\ramdisk-buildroot.img debug crashkernel=512M,high log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon systemd.log_target=null plymouth.ignore-serial-consoles console=tty0 console=ttyS0  console=ttyAMA0
     endif
     if exist FS%l:\Image and exist FS%l:\ramdisk-busybox.img then
         FS%l:


### PR DESCRIPTION
- Linux command line option added to suppress Linux kernel double print issue 