### PR TITLE
Secureboot variable added the end of SIE linux boot command

### DIFF
--- a/common/config/grub-buildroot.cfg
+++ b/common/config/grub-buildroot.cfg
@@ -17,7 +17,7 @@ menuentry 'SCT for Security Interface Extension (optional)' {
     chainloader /EFI/BOOT/Shell.efi -nostartup sie_startup.nsh
 }
 menuentry 'Linux Boot for Security Interface Extension (optional)' {
-    linux /Image rootwait verbose debug secureboot console=tty0 console=ttyS0  console=ttyAMA0
+    linux /Image rootwait verbose debug console=tty0 console=ttyS0  console=ttyAMA0 secureboot
     initrd /ramdisk-buildroot.img
 }
 menuentry 'Linux Boot with SetVirtualAddressMap enabled' {


### PR DESCRIPTION
- As per the SIE linux boot logic it reads the last command line parameter
- Only if the last parameter is secureboot it'll boot into SIE linux