### PR TITLE
BOOT partition renamed to BOOT_ACS

### DIFF
--- a/ES/README.md
+++ b/ES/README.md
@@ -64,7 +64,7 @@ Note: The image is generated in a compressed (.xz) format. The image must be unc
 
 ## Build output
 This image comprises of single FAT file system partition recognized by UEFI: <br />
-- 'boot' <br />
+- 'BOOT_ACS' <br />
   Approximate size: 640 MB <br />
   contains bootable applications and test suites.<br />
   contains a 'acs_results' directory which stores logs of the automated execution of ACS.

--- a/IR/Yocto/README.md
+++ b/IR/Yocto/README.md
@@ -62,12 +62,12 @@ Before starting the ACS build, ensure that the following requirements are met:
 Note: The image is generated in a compressed (.xz) format. The image must be uncompressed before using the same for verification.<br />
 
 ## Build output
-This image comprises of single FAT file system partition recognized by UEFI: <br />
+This image comprises of 2 FAT file system partition recognized by UEFI: <br />
 - '/' <br />
   Root partition for Linux which contains test-suites to run in Linux environment. <br/>
-- 'boot' <br />
+- 'BOOT_ACS' <br />
   Approximate size: 150 MB <br />
-  contains bootable applications and test suites. (Approximate size: 150MB) <br />
+  contains bootable applications and test suites. <br />
   contains a 'acs_results' directory which stores logs of the automated execution of ACS.
 
 ## Verification

--- a/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2023-2024, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ ADDITIONAL_CMD_OPTION=`cat /proc/cmdline | awk '{ print $NF}'`
 if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
  echo "Attempting to mount the results partition ..." 
  #mount result partition
- BLOCK_DEVICE_NAME=$(blkid | grep "BOOT" | awk -F: '{print $1}')
+ BLOCK_DEVICE_NAME=$(blkid | grep "BOOT_ACS" | awk -F: '{print $1}')
 
  if [ ! -z "$BLOCK_DEVICE_NAME" ]; then
   mount $BLOCK_DEVICE_NAME /mnt

--- a/IR/Yocto/meta-woden/wic/woden.wks.in
+++ b/IR/Yocto/meta-woden/wic/woden.wks.in
@@ -1,5 +1,5 @@
 bootloader --ptable gpt --timeout=10 --append="rootfstype=ext4"
 
-part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER}" --part-type="C12A7328-F81F-11D2-BA4B-00A0C93EC93B" --label BOOT --active --align 1024 --use-uuid --size 150M
+part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER}" --part-type="C12A7328-F81F-11D2-BA4B-00A0C93EC93B" --label BOOT_ACS --active --align 1024 --use-uuid --size 150M
 
 part / --source rootfs --fstype=ext4 --label root --align 1024 --use-uuid

--- a/SR/README.md
+++ b/SR/README.md
@@ -63,7 +63,7 @@ Note: The image is generated in a compressed (.xz) format. The image must be unc
 
 ## Build output
 This image comprise of single FAT file system partition recognized by UEFI: <br />
-- 'boot' <br />
+- 'BOOT_ACS' <br />
   Approximate size: 640 MB <br />
   contains bootable applications and test suites. <br />
   contains a 'acs_results' directory which stores logs of the automated execution of ACS.

--- a/common/ramdisk/init.sh
+++ b/common/ramdisk/init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2021-2023, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2024, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -72,7 +72,7 @@ ADDITIONAL_CMD_OPTION=`cat /proc/cmdline | awk '{ print $NF}'`
 
 if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
  #mount result partition
- BLOCK_DEVICE_NAME=$(blkid | grep "BOOT" | awk -F: '{print $1}')
+ BLOCK_DEVICE_NAME=$(blkid | grep "BOOT_ACS" | awk -F: '{print $1}')
 
  if [ ! -z "$BLOCK_DEVICE_NAME" ]; then
   mount $BLOCK_DEVICE_NAME /mnt

--- a/common/scripts/make_image.sh
+++ b/common/scripts/make_image.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2021-2023, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2024, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -181,10 +181,10 @@ prepare_disk_image ()
     cat part_table > $IMG_BB
 
     #Create fat partition
-    create_fatpart "BOOT" $FAT_SIZE
-    create_cfgfiles "BOOT"
-    cat BOOT >> $IMG_BB
-    
+    create_fatpart "BOOT_ACS" $FAT_SIZE
+    create_cfgfiles "BOOT_ACS"
+    cat BOOT_ACS >> $IMG_BB
+
     #Space for backup partition table at the bottom (1M)
     cat part_table >> $IMG_BB
 
@@ -194,8 +194,7 @@ prepare_disk_image ()
 
     #remove intermediate files
     rm -f part_table
-    rm -f BOOT
-    rm -f RESULT
+    rm -f BOOT_ACS
     #remove compressed image if present from previous build
     if [ -f $PLATDIR/$IMG_BB.xz ]; then
         rm $PLATDIR/$IMG_BB.xz


### PR DESCRIPTION
Fixes https://github.com/ARM-software/sbsa-acs/issues/429

BOOT partition renamed to BOOT_ACS 