### PR TITLE
Toolchain 13.2.x needed for latest BSA/SBSA compilation

### DIFF
--- a/common/config/sr_es_common_config.cfg
+++ b/common/config/sr_es_common_config.cfg
@@ -63,11 +63,11 @@ ARM_LINUX_ACS_TAG=""
 BUILDROOT_SRC_VERSION=2022.08.1
 
 #Cross compiler tools from https://releases.linaro.org/components/toolchain/binaries
-GCC_TOOLS_VERSION=10.3-2021.07
-CROSS_COMPILER_URL=https://developer.arm.com/-/media/Files/downloads/gnu-a/${GCC_TOOLS_VERSION}/binrel/gcc-arm-${GCC_TOOLS_VERSION}-x86_64-aarch64-none-linux-gnu.tar.xz
+GCC_TOOLS_VERSION=13.2.rel1
+CROSS_COMPILER_URL=https://developer.arm.com/-/media/Files/downloads/gnu/${GCC_TOOLS_VERSION}/binrel/arm-gnu-toolchain-${GCC_TOOLS_VERSION}-x86_64-aarch64-none-linux-gnu.tar.xz
 
-#Export Tool chain path
-GCC=tools/gcc-arm-${GCC_TOOLS_VERSION}-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
+#Export Toolchain path
+GCC=tools/arm-gnu-toolchain-${GCC_TOOLS_VERSION}-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
 
 #edk2-test-parser version
 EDK2_TEST_PARSER_TAG=v2023.04

--- a/common/scripts/get_source.sh
+++ b/common/scripts/get_source.sh
@@ -148,8 +148,9 @@ get_cross_compiler2()
         mkdir -p tools
         pushd $TOP_DIR/tools
         wget $CROSS_COMPILER_URL --no-check-certificate
-        tar -xf gcc-arm-${GCC_TOOLS_VERSION}-x86_64-${TAG}.tar.xz
-        rm gcc-arm-${GCC_TOOLS_VERSION}-x86_64-${TAG}.tar.xz
+        tar -xf arm-gnu-toolchain-${GCC_TOOLS_VERSION}-x86_64-${TAG}.tar.xz
+        mv arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-linux-gnu arm-gnu-toolchain-13.2.rel1-x86_64-aarch64-none-linux-gnu
+        rm arm-gnu-toolchain-${GCC_TOOLS_VERSION}-x86_64-${TAG}.tar.xz
         popd
     fi
 }


### PR DESCRIPTION
Recent test changes on BSA/SBSA (https://github.com/ARM-software/bsa-acs/commit/80dd214f37d329da95a302ca371568cfb9436bc3) added register reads of system register, which requires tollchain > 10.3