### PR TITLE
noacs grub option "ACS completed" print issue

### DIFF
--- a/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/IR/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -141,12 +141,13 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
  # run read_blk_devices.py, parse block devices, and perform read if partition doesn't belond
  # in precious partitions
  python3 /bin/read_blk_devices.py | tee /mnt/acs_results/linux_tools/read_blk_devices.log
+ echo "ACS run is completed"
 else
  echo ""
  echo "Additional option set to not run ACS Tests. Skipping ACS tests on Linux"
  echo ""
 fi
-echo "ACS run is completed"
+
 echo "Please press <Enter> to continue ..."
 echo -e -n "\n"
 exit 0

--- a/common/ramdisk/init.sh
+++ b/common/ramdisk/init.sh
@@ -171,6 +171,7 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
  else
      echo "SCT result does not exist, cannot run edk2-test-parser tool cannot run"
  fi
+ echo "The ACS test suites are completed."
 else
  echo ""
  echo "Additional option set to not run ACS Tests. Skipping ACS tests on Linux"
@@ -179,6 +180,5 @@ fi
 
 sync /mnt
 sleep 3
-echo "The ACS test suites are completed."
 
 exec sh +m


### PR DESCRIPTION
Fixes #154 

- noacs option disables all the linux tools run. 
- But the print "ACS test suit completed" was always there that is fixed now. 
