### PR TITLE
SR ES ACS firmware upgrade

### DIFF
--- a/common/config/sr_es_common_config.cfg
+++ b/common/config/sr_es_common_config.cfg
@@ -31,10 +31,10 @@
 LINUX_KERNEL_VERSION=6.4
 
 #EDK2 source tag from https://github.com/tianocore/edk2.git
-EDK2_SRC_VERSION=edk2-stable202305
+EDK2_SRC_VERSION=edk2-stable202402
 
 # EDK2-TEST source tag from  https://github.com/tianocore/edk2-test
-SCT_SRC_TAG=315e3a56a6d9261d4fad4c1950f2d01a052eeba4
+SCT_SRC_TAG=952292aae171fe4e2aacdd556f236c602523c2d5
 
 # GRUB2 source from https://github.com/rhboot/grub2.git
 GRUB_SRC_TAG=grub-2.06


### PR DESCRIPTION
- edk2 updated to edk2-stable202402
- SCT (edk2-test) updated to 952292aae171fe4e2aacdd556f236c602523c2d5