### PR TITLE
SCT tag updated for SR/ES ACS

### DIFF
--- a/common/config/sr_es_common_config.cfg
+++ b/common/config/sr_es_common_config.cfg
@@ -34,7 +34,7 @@ LINUX_KERNEL_VERSION=6.4
 EDK2_SRC_VERSION=edk2-stable202402
 
 # EDK2-TEST source tag from  https://github.com/tianocore/edk2-test
-SCT_SRC_TAG=952292aae171fe4e2aacdd556f236c602523c2d5
+SCT_SRC_TAG=032822757792c5d4d0bfed1fd8524e69ef4f2d17
 
 # GRUB2 source from https://github.com/rhboot/grub2.git
 GRUB_SRC_TAG=grub-2.06


### PR DESCRIPTION
SCT tag updated to 032822757792c5d4d0bfed1fd8524e69ef4f2d17 for SR/ES ACS