### PR TITLE
changes to resume BBSR SCT if test in progress

### DIFF
--- a/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
@@ -43,12 +43,9 @@ do_configure() {
     cp ${SBBR_TEST_DIR}/build_bbr.sh uefi-sct/SctPkg/
     cp ${S}/bbr-acs/ebbr/config/EfiCompliant_EBBR.ini uefi-sct/SctPkg/UEFI/
 
-
     echo "Applying security interface extension ACS patch..."
     cp -r ${S}/bbr-acs/bbsr/sct-tests/BBSRVariableSizeTest uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices
     cp -r ${S}/bbr-acs/bbsr/sct-tests/SecureBoot uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices
-    cp -r ${S}/bbr-acs/bbsr/sct-tests/TCG2Protocol uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol
-    cp -r ${S}/bbr-acs/bbsr/sct-tests/TCG2.h uefi-sct/SctPkg/UEFI/Protocol
 
     git apply --ignore-whitespace --ignore-space-change ${S}/bbr-acs/bbsr/patches/0001-SIE-Patch-for-UEFI-SCT-Build.patch
 

--- a/common/config/common_config.cfg
+++ b/common/config/common_config.cfg
@@ -33,7 +33,7 @@ EDK2_SRC_VERSION=edk2-stable202302
 EDK2_SRC_TAG=f80f052277c88a67c55e107b550f504eeea947d3
 
 # EDK2-TEST source tag from  https://github.com/tianocore/edk2-test
-SCT_SRC_TAG=032822757792c5d4d0bfed1fd8524e69ef4f2d17
+SCT_SRC_TAG=abb54c667fe6ae2a41144c010871569ef519c459
 # GRUB2 source from https://github.com/rhboot/grub2.git
 GRUB_SRC_TAG=grub-2.06
 

--- a/common/config/sie_startup.nsh
+++ b/common/config/sie_startup.nsh
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2022-2024, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -80,7 +80,11 @@ endfor
 
 for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%i:\EFI\BOOT\bbr\sie_SctStartup.nsh then
+        # create a file to mark BBSR SCT in progress
+        echo "" > FS%i:\EFI\BOOT\bbr\bbsr_sct_inprogress.flag
         FS%i:\EFI\BOOT\bbr\sie_SctStartup.nsh
+        # remove bbsr_sct_inprogress.flag file to mark BBSR SCT complete
+        rm FS%i:\EFI\BOOT\bbr\bbsr_sct_inprogress.flag
         for %k in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             if  exist FS%k:\acs_results\SIE\sct_results\ then
                 if  exist FS%i:\EFI\BOOT\bbr\SCT\Overall then

--- a/common/config/sr_es_common_config.cfg
+++ b/common/config/sr_es_common_config.cfg
@@ -34,7 +34,7 @@ LINUX_KERNEL_VERSION=6.8
 EDK2_SRC_VERSION=edk2-stable202402
 
 # EDK2-TEST source tag from  https://github.com/tianocore/edk2-test
-SCT_SRC_TAG=032822757792c5d4d0bfed1fd8524e69ef4f2d17
+SCT_SRC_TAG=abb54c667fe6ae2a41144c010871569ef519c459
 
 # GRUB2 source from https://github.com/rhboot/grub2.git
 GRUB_SRC_TAG=grub-2.06

--- a/common/config/startup.nsh
+++ b/common/config/startup.nsh
@@ -29,6 +29,14 @@
 echo -off
 connect -r
 
+# check if BBSR SCT in progress, if yes resume the run.
+for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+    if exist FS%i:\EFI\BOOT\bbr\bbsr_sct_inprogress.flag then
+        echo BBSR SCT in progress, Resuming ...
+        FS%i:\EFI\BOOT\sie_startup.nsh
+    endif
+endfor
+
 for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%i:\EFI\BOOT\bbr\SctStartup.nsh then
         FS%i:\EFI\BOOT\bbr\SctStartup.nsh %1


### PR DESCRIPTION
- running BBSR SCT if the test is already in progress
- upgraded edk2-sct tag compatible with bbr patches.
- ebbr-sct changes.