### PR TITLE
Add more commands to debug_dump.nsh and make it independently runnable

### DIFF
--- a/common/config/debug_dump.nsh
+++ b/common/config/debug_dump.nsh
@@ -1,4 +1,4 @@
-# Copyright (c) 2021,2023, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2024, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -30,47 +30,60 @@ for %m in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%m:\acs_results then
         FS%m:
         cd FS%m:\acs_results
-        if exist uefi_dump then
-            echo "UEFI debug logs already run"
-            echo "press any key to rerun UEFI debug logs"
-            FS%m:\EFI\BOOT\bbr\SCT\stallforkey.efi 10
-            if %lasterror% == 0 then
-                goto DEBUG_DUMP
-            else
-                goto Done
-            endif
+    endif      
+    if exist uefi_dump then
+        echo "UEFI debug logs already run"
+        echo "press any key to rerun UEFI debug logs"
+        FS%m:\EFI\BOOT\bbr\SCT\stallforkey.efi 10
+        if %lasterror% == 0 then
+            goto DEBUG_DUMP
         else
-            mkdir uefi_dump
-:DEBUG_DUMP
-            cd uefi_dump
-            echo "Starting UEFI Debug dump"
-            connect -r
-            pci > pci.log
-            drivers > drivers.log
-            devices > devices.log
-            dmpstore -all > dmpstore.log
-            dh -d > dh.log
-            memmap > memmap.log
-            bcfg boot dump > bcfg.log
-            devtree > devtree.log
-            ver > uefi_version.log
-            ifconfig -l > ifconfig.log
-            dmem > dmem.log
-            for %n in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
-                    if exist FS%n:\EFI\BOOT\bsa\ir_bsa.flag then
-                        #IR Specific ->DT
-                    else
-                        echo "" > map.log
-                        map -r >> map.log
-                        smbiosview > smbiosview.log
-                        acpiview -l  > acpiview_l.log
-                        acpiview -r 2 > acpiview_r.log
-                        acpiview > acpiview.log
-                        goto Done
-                    endif
-                    goto Done
-            endfor
+            goto Done
         endif
+    else
+        mkdir uefi_dump
+:DEBUG_DUMP
+        cd uefi_dump
+        echo "Starting UEFI Debug dump"
+        connect -r
+        pci > pci.log
+        drivers > drivers.log
+        devices > devices.log
+        dh -d -v > dh.log
+        dmpstore -all -s dmpstore.bin
+        dmpstore -all > dmpstore.log
+        memmap > memmap.log
+        bcfg boot dump -v > bcfg.log
+        devtree > devtree.log
+        ver > uefi_version.log
+        dmem > dmem.log
+        sermode > sermode.log
+        mode > mode.log
+        timezone > timezone.log
+        date > date.log
+        time > time.log
+        getmtc > getmtc.log
+        ifconfig -l > ifconfig.log
+        ifconfig -s eth0 dhcp 
+        ifconfig -s eth1 dhcp
+        connect -r    
+        ifconfig -l > ifconfig_after_dhcp.log                
+        for %n in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+                if exist FS%n:\EFI\BOOT\bsa\ir_bsa.flag then
+                    #IR Specific ->DT
+                else
+                    echo "" > map.log
+                    map -r >> map.log
+                    smbiosview > smbiosview.log
+                    acpiview -l  > acpiview_l.log
+                    acpiview -r 2 > acpiview_r.log
+                    acpiview > acpiview.log
+		    acpiview -s DSDT -d
+		    acpiview -s SSDT -d
+                    goto Done
+                endif
+                goto Done
+        endfor
     endif
 endfor
 :Done


### PR DESCRIPTION
With this change, we will no longer sync up debug_dump.nsh with https://gitlab.arm.com/systemready/systemready-es-sr-template#fwuefi-shell-cmds-logs

Making it independently runnable is for the case where users want to run only debug_dump.nsh without using ACS image and knowledge of how to manually run the debug_dump.nsh. In other words, non-expert user can individually download the debug_dump.nsh to EFI\BOOT or a media device and then reboot the system to UEFI shell and run it.

Signed-off-by: Sunny Wang <sunny.wang@arm.com>