### PR TITLE
 Sync init.sh up with linux-distro-cmds.sh in systemready-es-sr-template and fix IR automation test issue with debug_dump.nsh

### DIFF
--- a/common/config/debug_dump.nsh
+++ b/common/config/debug_dump.nsh
@@ -1,4 +1,4 @@
-# Copyright (c) 2021,2023, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2024, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -30,47 +30,60 @@ for %m in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%m:\acs_results then
         FS%m:
         cd FS%m:\acs_results
-        if exist uefi_dump then
-            echo "UEFI debug logs already run"
-            echo "press any key to rerun UEFI debug logs"
-            FS%m:\EFI\BOOT\bbr\SCT\stallforkey.efi 10
-            if %lasterror% == 0 then
-                goto DEBUG_DUMP
-            else
-                goto Done
-            endif
+    endif      
+    if exist uefi_dump then
+        echo "UEFI debug logs already run"
+        echo "press any key to rerun UEFI debug logs"
+        FS%m:\EFI\BOOT\bbr\SCT\stallforkey.efi 10
+        if %lasterror% == 0 then
+            goto DEBUG_DUMP
         else
-            mkdir uefi_dump
-:DEBUG_DUMP
-            cd uefi_dump
-            echo "Starting UEFI Debug dump"
-            connect -r
-            pci > pci.log
-            drivers > drivers.log
-            devices > devices.log
-            dmpstore -all > dmpstore.log
-            dh -d > dh.log
-            memmap > memmap.log
-            bcfg boot dump > bcfg.log
-            devtree > devtree.log
-            ver > uefi_version.log
-            ifconfig -l > ifconfig.log
-            dmem > dmem.log
-            for %n in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
-                    if exist FS%n:\EFI\BOOT\bsa\ir_bsa.flag then
-                        #IR Specific ->DT
-                    else
-                        echo "" > map.log
-                        map -r >> map.log
-                        smbiosview > smbiosview.log
-                        acpiview -l  > acpiview_l.log
-                        acpiview -r 2 > acpiview_r.log
-                        acpiview > acpiview.log
-                        goto Done
-                    endif
-                    goto Done
-            endfor
+            goto Done
         endif
+    else
+        mkdir uefi_dump
+:DEBUG_DUMP
+        cd uefi_dump
+        echo "Starting UEFI Debug dump"
+        connect -r
+        pci > pci.log
+        drivers > drivers.log
+        devices > devices.log
+        dh -d -v > dh.log
+        dmpstore -all -s dmpstore.bin
+        dmpstore -all > dmpstore.log
+        memmap > memmap.log
+        bcfg boot dump -v > bcfg.log
+        devtree > devtree.log
+        ver > uefi_version.log
+        dmem > dmem.log
+        sermode > sermode.log
+        mode > mode.log
+        timezone > timezone.log
+        date > date.log
+        time > time.log
+        getmtc > getmtc.log
+        ifconfig -l > ifconfig.log
+        ifconfig -s eth0 dhcp 
+        ifconfig -s eth1 dhcp
+        connect -r    
+        ifconfig -l > ifconfig_after_dhcp.log                
+        for %n in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+                if exist FS%n:\EFI\BOOT\bsa\ir_bsa.flag then
+                    #IR Specific ->DT
+                else
+                    echo "" > map.log
+                    map -r >> map.log
+                    smbiosview > smbiosview.log
+                    acpiview -l  > acpiview_l.log
+                    acpiview -r 2 > acpiview_r.log
+                    acpiview > acpiview.log
+		    acpiview -s DSDT -d
+		    acpiview -s SSDT -d
+                    goto Done
+                endif
+                goto Done
+        endfor
     endif
 endfor
 :Done

--- a/common/config/debug_dump.nsh
+++ b/common/config/debug_dump.nsh
@@ -30,60 +30,60 @@ for %m in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%m:\acs_results then
         FS%m:
         cd FS%m:\acs_results
-    endif      
-    if exist uefi_dump then
-        echo "UEFI debug logs already run"
-        echo "press any key to rerun UEFI debug logs"
-        FS%m:\EFI\BOOT\bbr\SCT\stallforkey.efi 10
-        if %lasterror% == 0 then
-            goto DEBUG_DUMP
+    endif 
+endfor         
+if exist uefi_dump then
+    echo "UEFI debug logs already run"
+    echo "press any key to rerun UEFI debug logs"
+    FS%m:\EFI\BOOT\bbr\SCT\stallforkey.efi 10
+    if %lasterror% == 0 then
+        goto DEBUG_DUMP
+    else
+        goto Done
+    endif
+else
+    mkdir uefi_dump
+:DEBUG_DUMP
+    cd uefi_dump
+    echo "Starting UEFI Debug dump"
+    connect -r
+    pci > pci.log
+    drivers > drivers.log
+    devices > devices.log
+    dh -d -v > dh.log
+    dmpstore -all -s dmpstore.bin
+    dmpstore -all > dmpstore.log
+    memmap > memmap.log
+    bcfg boot dump -v > bcfg.log
+    devtree > devtree.log
+    ver > uefi_version.log
+    dmem > dmem.log
+    sermode > sermode.log
+    mode > mode.log
+    timezone > timezone.log
+    date > date.log
+    time > time.log
+    getmtc > getmtc.log
+    ifconfig -l > ifconfig.log
+    ifconfig -s eth0 dhcp 
+    ifconfig -s eth1 dhcp
+    connect -r    
+    ifconfig -l > ifconfig_after_dhcp.log                
+    for %n in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+        if exist FS%n:\EFI\BOOT\bsa\ir_bsa.flag then
+            #IR Specific ->DT
         else
+            echo "" > map.log
+            map -r >> map.log
+            smbiosview > smbiosview.log
+            acpiview -l  > acpiview_l.log
+            acpiview -r 2 > acpiview_r.log
+            acpiview > acpiview.log
+            acpiview -s DSDT -d
+            acpiview -s SSDT -d
             goto Done
         endif
-    else
-        mkdir uefi_dump
-:DEBUG_DUMP
-        cd uefi_dump
-        echo "Starting UEFI Debug dump"
-        connect -r
-        pci > pci.log
-        drivers > drivers.log
-        devices > devices.log
-        dh -d -v > dh.log
-        dmpstore -all -s dmpstore.bin
-        dmpstore -all > dmpstore.log
-        memmap > memmap.log
-        bcfg boot dump -v > bcfg.log
-        devtree > devtree.log
-        ver > uefi_version.log
-        dmem > dmem.log
-        sermode > sermode.log
-        mode > mode.log
-        timezone > timezone.log
-        date > date.log
-        time > time.log
-        getmtc > getmtc.log
-        ifconfig -l > ifconfig.log
-        ifconfig -s eth0 dhcp 
-        ifconfig -s eth1 dhcp
-        connect -r    
-        ifconfig -l > ifconfig_after_dhcp.log                
-        for %n in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
-                if exist FS%n:\EFI\BOOT\bsa\ir_bsa.flag then
-                    #IR Specific ->DT
-                else
-                    echo "" > map.log
-                    map -r >> map.log
-                    smbiosview > smbiosview.log
-                    acpiview -l  > acpiview_l.log
-                    acpiview -r 2 > acpiview_r.log
-                    acpiview > acpiview.log
-		    acpiview -s DSDT -d
-		    acpiview -s SSDT -d
-                    goto Done
-                endif
-                goto Done
-        endfor
-    endif
-endfor
+        goto Done
+    endfor
+endif
 :Done

--- a/common/ramdisk/init.sh
+++ b/common/ramdisk/init.sh
@@ -104,17 +104,39 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
 
  #linux debug dump
  mkdir -p /mnt/acs_results/linux_dump
- lspci -vvv &> /mnt/acs_results/linux_dump/lspci.log
- lsusb > /mnt/acs_results/linux_dump/lsusb.log
- uname -a > /mnt/acs_results/linux_dump/uname.log
+ dmesg > /mnt/acs_results/linux_dump/dmesg.log
+ lspci > /mnt/acs_results/linux_dump/lspci.log
+ lspci -vvv &> /mnt/acs_results/linux_dump/lspci-vvv.log
  cat /proc/interrupts > /mnt/acs_results/linux_dump/interrupts.log
  cat /proc/cpuinfo > /mnt/acs_results/linux_dump/cpuinfo.log
  cat /proc/meminfo > /mnt/acs_results/linux_dump/meminfo.log
  cat /proc/iomem > /mnt/acs_results/linux_dump/iomem.log
+ lscpu > /mnt/acs_results/linux_dump/lscpu.log
+ lsblk > /mnt/acs_results/linux_dump/lsblk.log
+ lsusb > /mnt/acs_results/linux_dump/lsusb.log
+ dmidecode > /mnt/acs_results/linux_dump/dmidecode.log
+ dmidecode --dump-bin /mnt/acs_results/linux_dump/dmidecode.bin
+ uname -a > /mnt/acs_results/linux_dump/uname.log
+ cat /etc/os-release > /mnt/acs_results/linux_dump/cat-etc-os-release.log
+ date > /mnt/acs_results/linux_dump/date.log
+ # timedatectl > /mnt/acs_results/linux_dump/timedatectl.txt
+ hwclock > /mnt/acs_results/linux_dump/hwclock.log
+ efibootmgr > /mnt/acs_results/linux_dump/efibootmgr.log
+ efibootmgr -t 20 > /mnt/acs_results/linux_dump/efibootmgr-t-20.log
+ efibootmgr -t 5 > /mnt/acs_results/linux_dump/efibootmgr-t-5.log
+ efibootmgr -c > /mnt/acs_results/linux_dump/efibootmgr-c.txt
+ ifconfig > /mnt/acs_results/linux_dump/ifconfig.log
+ ip addr show > /mnt/acs_results/linux_dump/ip-addr-show.log
+ ping -c 5 www.arm.com > /mnt/acs_results/linux_dump/ping-c-5-www-arm-com.log
+ # acpidump > /mnt/acs_results/linux_dump/acpi.log
+ # acpixtract -a > /mnt/acs_results/linux_dump/acpi.log
+ # iasl -d /mnt/acs_results/linux_dump/*.dat
+ # date --set="20221215 05:30" > /mnt/acs_results/linux_dump/date-set-202212150530.log
+ # date > /mnt/acs_results/linux_dump/date-after-set.log
+ # hwclock --set --date "2023-01-01 09:10:15" > /mnt/acs_results/linux_dump/hw-colock-set-20230101091015.log
+ # hwclock > /mnt/acs_results/linux_dump/hwclock-after-set.log
  ls -lR /sys/firmware > /mnt/acs_results/linux_dump/firmware.log
  cp -r /sys/firmware /mnt/acs_results/linux_dump/
- dmidecode > /mnt/acs_results/linux_dump/dmidecode.log
- efibootmgr > /mnt/acs_results/linux_dump/efibootmgr.log
 
  mkdir -p /mnt/acs_results/fwts
 


### PR DESCRIPTION
Two changes:  
1. Sync init.sh up with linux-distro-cmds.sh in systemready-es-sr-template
https://gitlab.arm.com/systemready/systemready-es-sr-template/-/blob/main/os-logs/linux-distro-cmds.sh
So that we don't need to ask partner to run linux-distro-cmds.sh again to collect the commands' output that haven't been covered by init.sh
The commented-out commands means the ACS Linux still haven't supported them or has issue with them. 

2. Fixed the issue that the uefi_dump folder gets created in an unexpected file system
The issue was reported by IR ACS users on https://github.com/ARM-software/arm-systemready/pull/187#discussion_r1639306891
Basically, the change is just moving the "endfor" from line 88 to line 34 so that it won't change the FS number for the case where there is no acs_result folder.

Signed-off-by: Sunny Wang <sunny.wang@arm.com>



