### PR TITLE
Increase 8250 serial ports for SR/ES

### DIFF
--- a/common/scripts/build-linux.sh
+++ b/common/scripts/build-linux.sh
@@ -99,6 +99,9 @@ do_build ()
     sed -i 's/# CONFIG_OPTEE is not set/CONFIG_OPTEE=y/g' $LINUX_OUT_DIR/.config
     #Configurations to enable rshim support in ES/SR ACS images
     echo "CONFIG_MLXBF_TMFIFO=y" >> $LINUX_OUT_DIR/.config
+    #Configurations to increase serial ports
+    echo "CONFIG_SERIAL_8250_NR_UARTS=32" >> $LINUX_OUT_DIR/.config
+    echo "CONFIG_SERIAL_8250_RUNTIME_UARTS=32" >> $LINUX_OUT_DIR/.config
 
     if [[ $arch = "aarch64" ]]
     then


### PR DESCRIPTION
To adapt to more devices, increase the number of 8250 serial ports instead of explicitly specifying console.

Refer to #148 