### PR TITLE
Fix backdoor host tools leakage

### DIFF
--- a/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
@@ -3,7 +3,13 @@ DESCRIPTION = "UEFI SCT tests to check for compliance against the EBBR recipe"
 HOMEPAGE = "https://github.com/ARM-software/bbr-acs"
 
 inherit deploy
-DEPENDS = "efitools-native sbsigntool-native sie-keys"
+DEPENDS = "efitools-native sbsigntool-native"
+
+# When the sie-keys package is built it deploys the signing keys. This
+# recipe uses the deployed keys so we need to ensure do_deploy has
+# completed before we attempt to sign anything.
+do_compile[depends] = "sie-keys:do_deploy"
+export KEYS_DIR="${DEPLOY_DIR_IMAGE}/security-interface-extension-keys"
 
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://bbr-acs/LICENSE.md;md5=2a944942e1496af1886903d274dedb13"
@@ -53,10 +59,6 @@ do_configure() {
     git apply --ignore-whitespace --ignore-space-change ${S}/bbr-acs/bbsr/patches/0001-SIE-Patch-for-UEFI-SCT-Build.patch
 
 }
-
-export KEYS_DIR="${S}/../../../generic_arm64-oe-linux/sie-keys/1.0-r0/security-interface-extension-keys"
-
-
 
 # *********************************************
 # sign .efi executables for Secure Boot

--- a/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "UEFI SCT tests to check for compliance against the EBBR recipe"
 HOMEPAGE = "https://github.com/ARM-software/bbr-acs"
 
 inherit deploy
-DEPENDS = "sie-keys"
+DEPENDS = "sbsigntool-native sie-keys"
 
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://bbr-acs/LICENSE.md;md5=2a944942e1496af1886903d274dedb13"
@@ -124,9 +124,9 @@ do_signimage() {
 }
 
 do_compile() {
-    #For openssl
+    #For efitools
     echo "S is ${S}"
-    export PATH="${S}/../../../generic_arm64-oe-linux/sie-keys/1.0-r0/efitools:/usr/bin:${PATH}"
+    export PATH="${S}/../../../generic_arm64-oe-linux/sie-keys/1.0-r0/efitools:${PATH}"
     echo "New Path: $PATH";
 
     cd ${S}/edk2-test
@@ -140,8 +140,6 @@ do_compile() {
 
     echo "UEFI-SCT Build done..."
 
-    #For sbsign
-    export PATH="${PATH}:/usr/bin"
     do_signimage
 
 }

--- a/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "UEFI SCT tests to check for compliance against the EBBR recipe"
 HOMEPAGE = "https://github.com/ARM-software/bbr-acs"
 
 inherit deploy
-DEPENDS = "sbsigntool-native sie-keys"
+DEPENDS = "efitools-native sbsigntool-native sie-keys"
 
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://bbr-acs/LICENSE.md;md5=2a944942e1496af1886903d274dedb13"
@@ -124,11 +124,6 @@ do_signimage() {
 }
 
 do_compile() {
-    #For efitools
-    echo "S is ${S}"
-    export PATH="${S}/../../../generic_arm64-oe-linux/sie-keys/1.0-r0/efitools:${PATH}"
-    echo "New Path: $PATH";
-
     cd ${S}/edk2-test
     # create softlink to SctPkg
     ln -sf ${S}/edk2-test/uefi-sct/SctPkg SctPkg

--- a/IR/Yocto/meta-woden/recipes-acs/sie-keys/sie-keys.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/sie-keys/sie-keys.bb
@@ -5,7 +5,7 @@ S = "${WORKDIR}"
 
 SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git;destsuffix=efitools;protocol=https;nobranch=1;name=efitools"
 
-DEPENDS += "help2man-native libfile-slurp-perl-native"
+DEPENDS += "help2man-native libfile-slurp-perl-native openssl-native sbsigntool-native"
 
 inherit perlnative
 
@@ -15,7 +15,6 @@ SRCREV_efitools = "392836a46ce3c92b55dc88a1aebbcfdfc5dcddce"
 #do_configure[noexec] = "1"
 do_configure() {
     echo "Building efitools..."
-    export PATH="${PATH}:/usr/bin"
     echo "TARGET_PREFIX = ${TARGET_PREFIX} , OLD_TARGET_PREFIX=${OLD_TARGET_PREFIX}, CROSS_COMPILE = ${CROSS_COMPILE} BUILD_CC=${BUILD_CC} $BUILD_LD"
     cd ${S}/efitools
     sed -i -e "1s:#!.*:#!/usr/bin/env nativeperl:" xxdi.pl
@@ -35,9 +34,9 @@ do_compile() {
     mkdir -p $KEYS_DIR
     cd $KEYS_DIR
 
-    #For openssl
+    #Add efitools to the PATH
     echo "S is ${S}"
-    export PATH="${S}/efitools:/usr/bin:${PATH}"
+    export PATH="${S}/efitools:${PATH}"
     echo "New Path: $PATH";
 
     # generate TestPK1: DER and signed siglist

--- a/IR/Yocto/meta-woden/recipes-acs/sie-keys/sie-keys.bb
+++ b/IR/Yocto/meta-woden/recipes-acs/sie-keys/sie-keys.bb
@@ -3,29 +3,15 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 inherit deploy
 S = "${WORKDIR}"
 
-SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git;destsuffix=efitools;protocol=https;nobranch=1;name=efitools"
-
-DEPENDS += "help2man-native libfile-slurp-perl-native openssl-native sbsigntool-native"
+DEPENDS += "\
+    efitools-native \
+    help2man-native \
+    libfile-slurp-perl-native \
+    openssl-native \
+    sbsigntool-native \
+"
 
 inherit perlnative
-
-SRCREV_efitools = "392836a46ce3c92b55dc88a1aebbcfdfc5dcddce"
-
-# no configure step
-#do_configure[noexec] = "1"
-do_configure() {
-    echo "Building efitools..."
-    echo "TARGET_PREFIX = ${TARGET_PREFIX} , OLD_TARGET_PREFIX=${OLD_TARGET_PREFIX}, CROSS_COMPILE = ${CROSS_COMPILE} BUILD_CC=${BUILD_CC} $BUILD_LD"
-    cd ${S}/efitools
-    sed -i -e "1s:#!.*:#!/usr/bin/env nativeperl:" xxdi.pl
-    sed -i  '1 i\CC = ${BUILD_CC}' ${S}/efitools/Make.rules
-    sed -i  '1 i\LD = ${BUILD_LD}' ${S}/efitools/Make.rules
-
-    make clean
-    echo " =================Clean done===================="
-    make
-    echo "efitools is built successfully"
-}
 
 do_compile() {
 
@@ -33,11 +19,6 @@ do_compile() {
     echo "do_compile: security-interface-extension-keys"
     mkdir -p $KEYS_DIR
     cd $KEYS_DIR
-
-    #Add efitools to the PATH
-    echo "S is ${S}"
-    export PATH="${S}/efitools:${PATH}"
-    echo "New Path: $PATH";
 
     # generate TestPK1: DER and signed siglist
     NAME=TestPK1

--- a/IR/Yocto/meta-woden/recipes-images/images/woden-image.bb
+++ b/IR/Yocto/meta-woden/recipes-images/images/woden-image.bb
@@ -40,6 +40,8 @@ IMAGE_EFI_BOOT_FILES += "Bsa.efi;EFI/BOOT/bsa/Bsa.efi \
                          Shell.efi;EFI/BOOT/Shell.efi \
 "
 
+DEPENDS += "sbsigntool-native"
+
 do_sign_images() {
     rm -rf DO_SIGN
     mkdir DO_SIGN
@@ -51,9 +53,6 @@ do_sign_images() {
     #Sign the executables
     TEST_DB1_KEY=$KEYS_DIR/TestDB1.key
     TEST_DB1_CRT=$KEYS_DIR/TestDB1.crt
-
-    #For sbsign
-    export PATH="${PATH}:/usr/bin"
 
     sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT DO_SIGN/EFI/BOOT/bsa/Bsa.efi --output DO_SIGN/EFI/BOOT/bsa/Bsa.efi
     sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT DO_SIGN/EFI/BOOT/Shell.efi --output DO_SIGN/EFI/BOOT/Shell.efi


### PR DESCRIPTION
This PR fixes a couple of oddities in the sie-keys recipe.

In particular the recipe really shouldn't be adding /usr/bin to the PATH since that undermines all of OpenEmbedded's careful work to isolate from the host configuration. Also I couldn't figure out why sie-keys needs it own private copy of efitools to I replaced that with the corresponding native package too.

I originally found these issues because the IR ACS would not build without installing additional undocumented host packages. However rather than update the build documentation, in this case it is better to fix things by making the existing documentation true instead!