### PR TITLE
IR: build-scripts: add some missing dependencies

### DIFF
--- a/IR/Yocto/build-scripts/get_source.sh
+++ b/IR/Yocto/build-scripts/get_source.sh
@@ -45,7 +45,8 @@ sudo apt install git curl mtools gdisk gcc liblz4-tool zstd \
  openssl automake autotools-dev libtool bison flex \
  bc uuid-dev python3 libglib2.0-dev libssl-dev autopoint \
  make gcc g++ gnu-efi libfile-slurp-perl help2man \
- python3-pip chrpath diffstat lz4 -y
+ python3-pip chrpath diffstat lz4 cpio gawk locales wget -y
+sudo locale-gen en_US.utf8
 
 sudo pip3 install kas
 

--- a/IR/Yocto/build-scripts/get_source.sh
+++ b/IR/Yocto/build-scripts/get_source.sh
@@ -45,8 +45,7 @@ sudo apt install git curl mtools gdisk gcc liblz4-tool zstd \
  openssl automake autotools-dev libtool bison flex \
  bc uuid-dev python3 libglib2.0-dev libssl-dev autopoint \
  make gcc g++ gnu-efi libfile-slurp-perl help2man \
- python3-pip chrpath diffstat lz4 cpio gawk locales wget -y
-sudo locale-gen en_US.utf8
+ python3-pip chrpath diffstat lz4 cpio gawk wget -y
 
 sudo pip3 install kas
 
@@ -108,7 +107,7 @@ copy_recipes()
     if [ ! -z "$ARM_LINUX_ACS_TAG" ]; then
         sed -i -E 's/SRCREV_linux-acs\s+=\s+"\$\{AUTOREV\}"/SRCREV_linux-acs = \"'${ARM_LINUX_ACS_TAG}'"/g' $TOP_DIR/meta-woden/recipes-acs/bsa-acs-drv/bsa-acs-drv.bb
     fi
-    
+
     if [ ! -z "$EDK2_TEST_PARSER_TAG" ]; then
         sed -i -E 's/SRCREV_edk2-test-parser\s+=\s+"\$\{AUTOREV\}"/SRCREV_edk2-test-parser = \"'${EDK2_TEST_PARSER_TAG}'"/g' $TOP_DIR/meta-woden/recipes-acs/edk2-test-parser/edk2-test-parser.bb
     fi
@@ -140,4 +139,3 @@ copy_recipes()
 
 copy_recipes
 customise_image
-


### PR DESCRIPTION
When attempting to build ACS in a relatively spartan environment (such as a container image) then get_source.sh does not install all the required prerequisites.

cpio, gawk and wget are all listed in HOSTTOOLS so the fix for these is obvious.

locales in a little more subtle. bitbake forcefully adopts the en_US.utf8 locale to ensure that locale-skew cannot cause different build results on different machine. That requires the US locale to exist. We can make that happen by installing locales (if needed) and then running locale-gen. Note that locale-gen will not change the user or system-wide locale preferences, it will just generates the required locale. See: https://www.unix.com/man-page/linux/8/locale-gen/