### PR TITLE
Automatically SecureBoot to Linux, post completion of BBSR SCT

### DIFF
--- a/SystemReady-band/README.md
+++ b/SystemReady-band/README.md
@@ -8,7 +8,7 @@
 - [Steps to Manually Build Image](#steps-to-manually-build-image)
 - [Image Directory Structure](#image-directory-structure)
 - [Details and Functionalities of the Image](#details-and-functionalities-of-the-image)
-  - [Grub Menu & Complaince Run](#grub-menu--complaince-run)
+  - [Grub Menu & Compliance Run](#grub-menu--compliance-run)
   - [ACS configs file](#acs-configs-file)
   - [Log Parser scripts](#log-parser-scripts)
     - [Standard Formatted Result](#standard-formatted-result)
@@ -143,8 +143,8 @@ This image comprise of single FAT file system partition recognized by UEFI: <br 
   - app directory contains CapsuleApp.efi
   - bbr directory contains SCT related bianries and sequence files
   - bbsr-keys contains cryptographic keys for secure boot and testing secure firmware updates
-  - bsa directory contains bsa uefi executable for bsa complaince
-  - bsa/sbsa directory contains sbsa uefi executable for bsa complaince
+  - bsa directory contains bsa uefi executable for bsa compliance
+  - bsa/sbsa directory contains sbsa uefi executable for bsa compliance
   - config directory contains system, acs related config files
   - debug directory contains script to gather debug information
   - parser directory contains uefi parser executable to parse acs_config file
@@ -164,22 +164,20 @@ This image comprise of single FAT file system partition recognized by UEFI: <br 
 
 ## Details and Functionalities of the Image
 
-### Grub Menu & Complaince Run
+### Grub Menu & Compliance Run
 ```
  │ Linux Boot                                    │
  │*SystemReady band ACS (Automation)             │
- │ SCT for BBSR (optional)                       │
- │ Linux Boot for BBSR (optional)                │
+ │ BBSR Compliance (Automation)                  │
  │ Linux Boot with SetVirtualAddressMap enabled  |
 ```
  - **Linux Boot** : This option will boot the ACS Linux kernel and run the default Linux tool (linux debug dump, fwts, linux bsa, linux sbsa (if selected))
    - noacs command line parameter: Edit the Linux Boot grub menu option and add **noacs** at the end of Linux Boot grub menu option, to boot into ACS Linux kernel without running the default Linux test suites.
    - initcall_blacklist=psci_checker command line parameter: Edit the Linux Boot grub menu option and add **initcall_blacklist=psci_checker** to skip default linux psci_checker tool.
- - **SystemReady band ACS (Automation)** : This is **default** option and will run the automated complaince
-   - UEFI complaince run - SCT, BSA UEFI, SBSA UEFI (if selected)
-   - Boots to Linux and run Linux complaince run - FWTS, BSA Linux, SBSA Linux (if selected)
- - **SCT for BBSR (optional)** : This option will run the SCT tests required for BBSR complaince. For the verification steps of BBSR ACS, refer to the [BBSR ACS Verification](../common/docs/BBSR_ACS_Verification.md).
- - **Linux Boot for BBSR (optional)** : This option will run the SCT tests required for BBSR complaince. For the verification steps of BBSR ACS, refer to the [BBSR ACS Verification](../common/docs/BBSR_ACS_Verification.md).
+ - **SystemReady band ACS (Automation)** : This is **default** option and will run the automated compliance
+   - UEFI compliance run - SCT, BSA UEFI, SBSA UEFI (if selected)
+   - Boots to Linux and run Linux compliance run - FWTS, BSA Linux, SBSA Linux (if selected)
+ - **BBSR Compliance (Automation)** : This option will run the SCT and FWTS tests required for BBSR compliance, perform a Linux secure boot, and, if a TPM is present, evaluate the measured boot log. For the verification steps of BBSR ACS, refer to the [BBSR ACS Verification](../common/docs/BBSR_ACS_Verification.md).
  - **Linux Boot with SetVirtualAddressMap enabled** : This option is for debug purpose, to boot ACS Linux with SetVAMap on.
 
 ### ACS configs file
@@ -188,8 +186,8 @@ This image comprise of single FAT file system partition recognized by UEFI: <br 
 - **acs_run_config.ini**: This file is used to manage the execution of various ACS test suites and supports passing parameters to them. <br />
    The current options supported are: <br />
    -  SbsaRunEnabled - The value supported is 0 and 1.
-      - 0: Don't run SBSA complaince in automation run
-      - 1: Run SBSA complaince in automation run
+      - 0: Don't run SBSA compliance in automation run
+      - 1: Run SBSA compliance in automation run
  
 - **system_config.txt**: The file is used to collect below system information which is required for **ACS_Summary.html** report, this needs to be manually filled by user.
    - FW source code: Unknown

--- a/SystemReady-devicetree-band/README.md
+++ b/SystemReady-devicetree-band/README.md
@@ -8,7 +8,7 @@
 - [Steps to Manually Build Image](#steps-to-manually-build-image)
 - [Image Directory Structure](#image-directory-structure)
 - [Details and Functionalities of the Image](#details-and-functionalities-of-the-image)
-  - [Grub Menu & Complaince Run](#grub-menu--complaince-run)
+  - [Grub Menu & Compliance Run](#grub-menu--compliance-run)
   - [Log Parser scripts](#log-parser-scripts)
     - [Standard Formatted Result](#standard-formatted-result)
     - [Waiver application process](#waiver-application-process)
@@ -141,9 +141,9 @@ This image comprises of 2 FAT file system partition recognized by UEFI: <br />
   - startup.nsh - uefi automation run startup file
 - acs_tests contains executable files and configs related for test suites
   - app directory contains CapsuleApp.efi
-  - bbr directory contains SCT related bianries and sequence files
+  - bbr directory contains SCT related binaries and sequence files
   - bbsr-keys contains cryptographic keys for secure boot and testing secure firmware updates
-  - bsa directory contains bsa uefi executable for bsa complaince
+  - bsa directory contains bsa uefi executable for bsa compliance
   - config directory contains system, acs related config files
   - debug directory contains script to gather debug information
   - debug/pingtest.nsh is uefi script for ping test
@@ -166,22 +166,20 @@ This image comprises of 2 FAT file system partition recognized by UEFI: <br />
 
 ## Details and Functionalities of the Image
 
-### Grub Menu & Complaince Run
+### Grub Menu & Compliance Run
 ```
  │ Linux Boot                                    │
  │*bbr/bsa                                       │
- │ SCT for BBSR (optional)                       │
- │ Linux Boot for BBSR (optional)                │
+ │ BBSR Compliance (Automation)                  │
 
 ```
  - **Linux Boot** : This option will boot the ACS Linux kernel and run the default Linux tool (linux debug dump, fwts, linux bsa, linux sbsa (if selected))
    - noacs command line parameter: Edit the Linux Boot grub menu option and add **noacs** at the end of Linux Boot grub menu option, to boot into ACS Linux kernel without running the default Linux test suites.
    - initcall_blacklist=psci_checker command line parameter: Edit the Linux Boot grub menu option and add **initcall_blacklist=psci_checker** to skip default linux psci_checker tool.
- - **bbr/bsa** : This is **default** option and will run the automated complaince
-   - UEFI complaince run - SCT, BSA UEFI, [Capsule Update](https://github.com/chetan-rathore/arm-systemready/blob/main/common/docs/Automatic_Capsule_Update_guide.md)
-   - Boots to Linux and run Linux complaince run - FWTS, BSA Linux
- - **SCT for BBSR (optional)** : This option will run the SCT tests required for BBSR complaince. For the verification steps of BBSR ACS, refer to the [BBSR ACS Verification](../common/docs/BBSR_ACS_Verification.md).
- - **Linux Boot for BBSR (optional)** : This option will run the SCT tests required for BBSR complaince. For the verification steps of BBSR ACS, refer to the [BBSR ACS Verification](../common/docs/BBSR_ACS_Verification.md).
+ - **bbr/bsa** : This is **default** option and will run the automated compliance
+   - UEFI compliance run - SCT, BSA UEFI, [Capsule Update](https://github.com/chetan-rathore/arm-systemready/blob/main/common/docs/Automatic_Capsule_Update_guide.md)
+   - Boots to Linux and run Linux compliance run - FWTS, BSA Linux
+ - **BBSR Compliance (Automation)** : This option will run the SCT and FWTS tests required for BBSR compliance, perform a Linux secure boot, and, if a TPM is present, evaluate the measured boot log. For the verification steps of BBSR ACS, refer to the [BBSR ACS Verification](../common/docs/BBSR_ACS_Verification.md).
 
 ### ACS configs file
 - **acs_config_dt.txt**: The file specifies the ARM specification version that the ACS tool suite complies with, and this information is included in the **System_Information** table of the **ACS_Summary.html** report.

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
@@ -114,26 +114,14 @@ do_dir_deploy() {
     sed -i 's\default=boot\default=bbr/bsa\g' grub.cfg
     sed -i 's\boot\Linux Boot\g' grub.cfg
 
-    if grep  -Eq "SCT for BBSR"  grub.cfg
+    if grep  -Eq "BBSR Compliance (Automation)"  grub.cfg
     then
-        echo "grub entry for SCT for BBSR already present"
+        echo "grub entry for BBSR Compliance (Automation) already present"
     else
-        echo "menuentry 'SCT for BBSR (optional)' {chainloader /EFI/BOOT/Shell.efi -nostartup bbsr_startup.nsh}" >> grub.cfg
-    fi
-
-    if grep  -Eq "Linux Boot for BBSR"  grub.cfg
-    then
-        echo "grub entry for Linux Boot for BBSR already present"
-    else
-        awk '/menuentry '\''Linux Boot'\''/, /ext4/' grub.cfg | sed 's/Linux Boot/Linux Boot for BBSR (optional)/' | sed 's/ext4/ext4  psci_checker=disable video=efifb:off secureboot/' >> grub.cfg
-        echo "}" >> grub.cfg
+        echo "menuentry 'BBSR Compliance (Automation)' {chainloader /EFI/BOOT/Shell.efi -nostartup bbsr_startup.nsh}" >> grub.cfg
     fi
 
     sed -i "/menuentry 'Linux Boot'/,/}/{ /linux /a \
-    initrd /core-image-initramfs-boot-genericarm64.cpio.gz
-    }" grub.cfg
-
-    sed -i "/menuentry 'Linux Boot for BBSR (optional)'/,/}/{ /linux /a \
     initrd /core-image-initramfs-boot-genericarm64.cpio.gz
     }" grub.cfg
 

--- a/common/config/grub-buildroot.cfg
+++ b/common/config/grub-buildroot.cfg
@@ -13,12 +13,8 @@ menuentry 'Linux Boot' {
 menuentry 'SystemReady band ACS (Automation)' {
     chainloader /EFI/BOOT/Shell.efi
 }
-menuentry 'SCT for BBSR (optional)' {
+menuentry 'BBSR Compliance (Automation)' {
     chainloader /EFI/BOOT/Shell.efi -nostartup bbsr_startup.nsh
-}
-menuentry 'Linux Boot for BBSR (optional)' {
-    linux /Image rootwait verbose debug psci_checker=disable console=tty0 console=ttyS0  console=ttyAMA0 secureboot
-    initrd /ramdisk-buildroot.img
 }
 menuentry 'Linux Boot with SetVirtualAddressMap enabled' {
     linux /Image rootwait verbose debug crashkernel=256M psci_checker=disable acsforcevamap console=tty0 console=ttyS0  console=ttyAMA0

--- a/common/docs/BBSR_ACS_Verification.md
+++ b/common/docs/BBSR_ACS_Verification.md
@@ -129,9 +129,7 @@ Note: The SecureBoot keys are present in \<bootfs>\acs_tests/bbsr-keys
 
 3. To run the BBSR ACS suites, choose following in grub options.
 ```
-"SCT for BBSR (optional)" for BBSR SCT tests
-and
-"Linux Boot for BBSR (optional)" for Secure Linux boot, BBSR FWTS and TPM2 logs.
+"BBSR Compliance (Automation)" for BBSR SCT tests, Secure Linux boot, BBSR FWTS and TPM2 logs.
 ```
 
 Note: SystemReady-devicetree-band ACS image can also be run using the above steps, if the underlying firmware is UEFI.
@@ -192,9 +190,7 @@ $QEMU \
 
 3. Execute the "run_qemu.sh", To run the BBSR ACS suites, choose following in grub options.
 ```
-"SCT for BBSR (optional)" for BBSR SCT tests
-and
-"Linux Boot for BBSR (optional)" for Secure Linux boot, BBSR FWTS and TPM2 logs.
+"BBSR Compliance (Automation)" for BBSR SCT tests, Secure Linux boot, BBSR FWTS and TPM2 logs.
 ```
 
 Note: SystemReady-devicetree-band Yocto ACS supports automatic enrollment of secure boot keys, still if the system fails to enter SecureBoot mode, Please refer to "Enrolling keys in U-boot" section of [BBSR ACS Users Guide](https://developer.arm.com/documentation/102872/latest) for instructions to enroll manually. <br>

--- a/common/uefi_scripts/bbsr_startup.nsh
+++ b/common/uefi_scripts/bbsr_startup.nsh
@@ -67,29 +67,33 @@ for %q in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
 endfor
 
 :StartTest
-
 for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%i:\acs_tests\bbr\bbsr_SctStartup.nsh then
-        # create a file to mark BBSR SCT in progress
-        echo "" > FS%i:\acs_tests\bbr\bbsr_sct_inprogress.flag
+        # flag BBSR compliance testing is in progress
+        echo "" > FS%i:\acs_tests\bbr\bbsr_inprogress.flag
         FS%i:\acs_tests\bbr\bbsr_SctStartup.nsh
-        # remove bbsr_sct_inprogress.flag file to mark BBSR SCT complete
-        rm FS%i:\acs_tests\bbr\bbsr_sct_inprogress.flag
-        for %k in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
-            if  exist FS%k:\acs_results\BBSR\sct_results\ then
-                if  exist FS%i:\acs_tests\bbr\SCT\Overall then
-                    cp -r FS%i:\acs_tests\bbr\SCT\Overall FS%k:\acs_results\BBSR\sct_results\
-                endif
-                if  exist FS%i:\acs_tests\bbr\SCT\Dependency\EfiCompliantBBTest then
-                    cp -r FS%i:\acs_tests\bbr\SCT\Dependency\EfiCompliantBBTest FS%k:\acs_results\BBSR\sct_results\
-                endif
-                if  exist FS%i:\acs_tests\bbr\SCT\Sequence then
-                    cp -r FS%i:\acs_tests\bbr\SCT\Sequence FS%k:\acs_results\BBSR\sct_results\
-                endif
-            endif
-        endfor
-     echo "BBSR SCT test suite execution is complete. Resetting the system"
-     reset
-     endif
+        # remove bbsr_inprogress.flag file to mark BBSR compliance testing,
+        # as we secureboot to Linux in next step
+        rm FS%i:\acs_tests\bbr\bbsr_inprogress.flag
+    endif
 endfor
+
+# Boot Linux with SecureBoot enabled
+echo "Booting Linux (SecureBoot)"
+for %l in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+    # Buildroot based build (SystemReady band)
+    if exist FS%l:\Image and exist FS%l:\ramdisk-buildroot.img then
+        FS%l:
+        cd FS%l:\
+        Image initrd=\ramdisk-buildroot.img rootwait verbose debug psci_checker=disable console=tty0 console=ttyS0  console=ttyAMA0 secureboot
+    endif
+    # Yocto based build (SystemReady-DT band)
+    if exist FS%l:\Image and exist FS%l:\yocto_image.flag then
+        FS%l:
+        cd FS%l:\
+        # Below command is placeholder that is populated with working parameters during SystemReady DT ACS build
+        Image LABEL=BOOT secureboot
+    endif
+endfor
+echo "Image not found"
 

--- a/common/uefi_scripts/startup.nsh
+++ b/common/uefi_scripts/startup.nsh
@@ -21,8 +21,8 @@ connect -r
 
 # check if BBSR SCT in progress, if yes resume the run.
 for %b in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
-    if exist FS%b:\acs_tests\bbr\bbsr_sct_inprogress.flag then
-        echo "BBSR SCT in progress, Resuming ..."
+    if exist FS%b:\acs_tests\bbr\bbsr_inprogress.flag then
+        echo "BBSR compliance testing in progress, Resuming ..."
         FS%b:\EFI\BOOT\bbsr_startup.nsh
     endif
 endfor


### PR DESCRIPTION
- added changes to enable automatic secureboot to linux, after completion BBSR SCT. Post boot FWTS and TPM checks were run.
- Removed BBSR Linux Boot grub option.