### PR TITLE
Yocto DT build changes for glibc issue and reduce time taken by DT build

### DIFF
--- a/SystemReady-devicetree-band/Yocto/build-scripts/build-systemready-dt-band-live-image.sh
+++ b/SystemReady-devicetree-band/Yocto/build-scripts/build-systemready-dt-band-live-image.sh
@@ -19,33 +19,7 @@
 set -x
 TOP_DIR=`pwd`
 pushd $TOP_DIR/meta-woden
-kas shell kas/woden.yml
-bitbake llvm-native
-if [ $? -eq 1 ]; then
-    echo "llvm-native recipe failed"
-    exit
-fi
-bitbake rust-native
-if [ $? -eq 1 ]; then
-    echo "rust-native recipe failed"
-    exit
-fi
-bitbake glibc
-if [ $? -eq 1 ]; then
-    echo "glibc recipe failed"
-    exit
-fi
-bitbake glibc-locale
-if [ $? -eq 1 ]; then
-    echo "glibc-locale recipe failed"
-    exit
-fi
-bitbake qemu-system-native
-if [ $? -eq 1 ]; then
-    echo "qemu-system-native recipe failed"
-    exit
-fi
-bitbake woden-image
+kas shell kas/woden.yml --command "bitbake llvm-native && bitbake rust-native && bitbake glibc && bitbake glibc-locale && bitbake qemu-system-native && bitbake woden-image"
 if [ $? -eq 0 ]; then
     if [ -f $TOP_DIR/meta-woden/build/tmp/deploy/images/genericarm64/woden-image-genericarm64.rootfs.wic ]; then
       cd $TOP_DIR/meta-woden/build/tmp/deploy/images/genericarm64

--- a/SystemReady-devicetree-band/Yocto/build-scripts/build-systemready-dt-band-live-image.sh
+++ b/SystemReady-devicetree-band/Yocto/build-scripts/build-systemready-dt-band-live-image.sh
@@ -19,7 +19,7 @@
 set -x
 TOP_DIR=`pwd`
 pushd $TOP_DIR/meta-woden
-kas shell kas/woden.yml --command "bitbake llvm-native && bitbake rust-native && bitbake glibc && bitbake glibc-locale && bitbake qemu-system-native && && bitbake cargo-native && bitbake linux-yocto && bitbake woden-image"
+kas shell kas/woden.yml --command "bitbake llvm-native && bitbake rust-native && bitbake glibc && bitbake glibc-locale && bitbake qemu-system-native && bitbake cargo-native && bitbake linux-yocto && bitbake woden-image"
 if [ $? -eq 0 ]; then
     if [ -f $TOP_DIR/meta-woden/build/tmp/deploy/images/genericarm64/woden-image-genericarm64.rootfs.wic ]; then
       cd $TOP_DIR/meta-woden/build/tmp/deploy/images/genericarm64

--- a/SystemReady-devicetree-band/Yocto/build-scripts/build-systemready-dt-band-live-image.sh
+++ b/SystemReady-devicetree-band/Yocto/build-scripts/build-systemready-dt-band-live-image.sh
@@ -19,7 +19,33 @@
 set -x
 TOP_DIR=`pwd`
 pushd $TOP_DIR/meta-woden
-kas build kas/woden.yml
+kas shell kas/woden.yml
+bitbake llvm-native
+if [ $? -eq 1 ]; then
+    echo "llvm-native recipe failed"
+    exit
+fi
+bitbake rust-native
+if [ $? -eq 1 ]; then
+    echo "rust-native recipe failed"
+    exit
+fi
+bitbake glibc
+if [ $? -eq 1 ]; then
+    echo "glibc recipe failed"
+    exit
+fi
+bitbake glibc-locale
+if [ $? -eq 1 ]; then
+    echo "glibc-locale recipe failed"
+    exit
+fi
+bitbake qemu-system-native
+if [ $? -eq 1 ]; then
+    echo "qemu-system-native recipe failed"
+    exit
+fi
+bitbake woden-image
 if [ $? -eq 0 ]; then
     if [ -f $TOP_DIR/meta-woden/build/tmp/deploy/images/genericarm64/woden-image-genericarm64.rootfs.wic ]; then
       cd $TOP_DIR/meta-woden/build/tmp/deploy/images/genericarm64

--- a/SystemReady-devicetree-band/Yocto/build-scripts/build-systemready-dt-band-live-image.sh
+++ b/SystemReady-devicetree-band/Yocto/build-scripts/build-systemready-dt-band-live-image.sh
@@ -19,7 +19,7 @@
 set -x
 TOP_DIR=`pwd`
 pushd $TOP_DIR/meta-woden
-kas shell kas/woden.yml --command "bitbake llvm-native && bitbake rust-native && bitbake glibc && bitbake glibc-locale && bitbake qemu-system-native && bitbake woden-image"
+kas shell kas/woden.yml --command "bitbake llvm-native && bitbake rust-native && bitbake glibc && bitbake glibc-locale && bitbake qemu-system-native && && bitbake cargo-native && bitbake linux-yocto && bitbake woden-image"
 if [ $? -eq 0 ]; then
     if [ -f $TOP_DIR/meta-woden/build/tmp/deploy/images/genericarm64/woden-image-genericarm64.rootfs.wic ]; then
       cd $TOP_DIR/meta-woden/build/tmp/deploy/images/genericarm64

--- a/SystemReady-devicetree-band/Yocto/meta-woden/kas/woden.yml
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/kas/woden.yml
@@ -38,7 +38,8 @@ repos:
 
 local_conf_header:
   threads: |
-    GLIBC_GENERATE_LOCALES = "en_US.UTF-8 fr_FR.UTF-8"
+    GLIBC_GENERATE_LOCALES = "en_US.UTF-8 en_GB.UTF-8 C.UTF-8"
+    IMAGE_LINGUAS = "en-us en-gb"
     BB_NUMBER_THREADS = "16"
     PARALLEL_MAKE = "-j16"
 

--- a/SystemReady-devicetree-band/Yocto/meta-woden/kas/woden.yml
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/kas/woden.yml
@@ -38,6 +38,7 @@ repos:
 
 local_conf_header:
   threads: |
+    GLIBC_GENERATE_LOCALES = "en_US.UTF-8 fr_FR.UTF-8"
     BB_NUMBER_THREADS = "16"
     PARALLEL_MAKE = "-j16"
 


### PR DESCRIPTION
* Limit the glibc locale packages to what is needed, ensuring it passes
* Divide the yocto build steps to build the dependency which creates bottleneck.