### PR TITLE
Install gnu-efi dependencies in github runners

### DIFF
--- a/.github/workflows/SystemReady_band_BUILD.yml
+++ b/.github/workflows/SystemReady_band_BUILD.yml
@@ -29,6 +29,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+    - name: Install gnu-efi dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y gnu-efi
     - name: Start building
       run:
         sudo -s;

--- a/.github/workflows/SystemReady_band_Daily_Build.yml
+++ b/.github/workflows/SystemReady_band_Daily_Build.yml
@@ -25,6 +25,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+    - name: Install gnu-efi dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y gnu-efi
     - name: Start building
       run:
         sudo -s;

--- a/.github/workflows/SystemReady_band_SBMR_inband.yaml
+++ b/.github/workflows/SystemReady_band_SBMR_inband.yaml
@@ -32,6 +32,10 @@ jobs:
       with:
         fetch-depth: 1
         ref: server-base-manageability-requirements-acs
+    - name: Install gnu-efi dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y gnu-efi
     - name: Start building
       run:
         sudo -s;


### PR DESCRIPTION
CI jobs in the github runner are failing during efitools build, it is due to some changes on github runner machine as on local machines issue is not seen.

Add a step to install the gnu-efi dependency.