### PR TITLE
Keep kernel version to 6.10

### DIFF
--- a/SystemReady-band/build-scripts/build-linux.sh
+++ b/SystemReady-band/build-scripts/build-linux.sh
@@ -124,8 +124,7 @@ do_package ()
     cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/nvme/host/nvme.ko $TOP_DIR/ramdisk/drivers
     cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/nvme/host/nvme-core.ko $TOP_DIR/ramdisk/drivers
     cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/usb/host/xhci-pci-renesas.ko $TOP_DIR/ramdisk/drivers
-    #xhci-pci is inbuilt in linux v6.12 with shci-pci-renesas config enabled
-    #cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/usb/host/xhci-pci.ko $TOP_DIR/ramdisk/drivers
+    cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/usb/host/xhci-pci.ko $TOP_DIR/ramdisk/drivers
     cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/char/tpm/tpm_tis.ko $TOP_DIR/ramdisk/drivers
     cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/char/tpm/tpm_tis_spi.ko $TOP_DIR/ramdisk/drivers
     cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/char/tpm/tpm_tis_i2c_cr50.ko $TOP_DIR/ramdisk/drivers

--- a/common/config/systemready-band-source.cfg
+++ b/common/config/systemready-band-source.cfg
@@ -28,7 +28,7 @@
 
 
 #Linux kernel version. Source downloaded from https://github.com/torvalds/linux.git
-LINUX_KERNEL_VERSION=6.12
+LINUX_KERNEL_VERSION=6.10
 
 #EDK2 source tag from https://github.com/tianocore/edk2.git
 EDK2_SRC_VERSION=edk2-stable202411

--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -47,7 +47,7 @@ mdev -s
 
 echo "Starting disk drivers"
 insmod /lib/modules/xhci-pci-renesas.ko
-#insmod /lib/modules/xhci-pci.ko
+insmod /lib/modules/xhci-pci.ko
 insmod /lib/modules/nvme-core.ko
 insmod /lib/modules/nvme.ko
 


### PR DESCRIPTION
With Linux 6.12, failure are observed in the ACS MSI test, the root cause seems to be related to changes in MSI initialization in linux. Reverting to a stable 6.10 version which worked fine.