### PR TITLE
Updated test category and bsa's gicv2m is now included in gic tests

### DIFF
--- a/common/log_parser/bsa/logs_to_json.py
+++ b/common/log_parser/bsa/logs_to_json.py
@@ -67,6 +67,8 @@ def main(input_files, output_file):
                         suite_name = suite_name_match.group(1).strip()
                     else:
                         suite_name = line.strip().split("*** Starting")[1].split("tests")[0].strip()
+                    if suite_name == "GICv2m":
+                         suite_name = "GIC"    
                     processing = True
                     in_test = False
                     i += 1

--- a/common/log_parser/test_categoryDT.json
+++ b/common/log_parser/test_categoryDT.json
@@ -269,7 +269,7 @@
       "Test Suite": "RuntimeServicesTest",
       "specName": "UEFI",
       "rel Import. to main readiness": "Critical",
-      "Waivable": "yes",
+      "Waivable": "no",
       "SRS scope": "Required",
       "FunctionID": 4,
       "Main Readiness Grouping": "runtime readiness"
@@ -437,7 +437,7 @@
       "Test Suite": "Capsule update",
       "specName": "SRS",
       "rel Import. to main readiness": "Minor",
-      "Waivable": "yes",
+      "Waivable": "no",
       "SRS scope": "Required",
       "FunctionID": 2,
       "Main Readiness Grouping": "maintenance readiness"


### PR DESCRIPTION
Updated test category and bsa's gicv2m is now included in gic tests