### PR TITLE
Switch BSA, SBSA, and BBR tags to legacy versions for compatibility

### DIFF
--- a/common/config/systemready-band-source.cfg
+++ b/common/config/systemready-band-source.cfg
@@ -46,14 +46,14 @@ EFITOOLS_SRC_TAG=v1.9.2
 
 #Arm BSA source tag.
 #NOTE: If the value is NULL then the latest BSA source will be downloaded
-ARM_BSA_TAG=""
+ARM_BSA_TAG="v25.04_SR_3.0.1"
 
 #NOTE: If the value is NULL then the latest SBSA source will be downloaded
-ARM_SBSA_TAG=""
+ARM_SBSA_TAG="v25.04_SR_3.0.1"
 
 #Arm BBR source tag
 #NOTE: If the value is NULL then the latest BBR source will be downloaded
-ARM_BBR_TAG=""
+ARM_BBR_TAG="v25.04_SR_3.0.1"
 
 #Arm LINUX ACS source tag
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded

--- a/common/config/systemready-dt-band-source.cfg
+++ b/common/config/systemready-dt-band-source.cfg
@@ -41,11 +41,11 @@ GRUB_SRC_TAG=grub-2.06
 
 #Arm BSA source tag.
 #NOTE: If the value is NULL then the latest BSA source will be downloaded
-ARM_BSA_TAG=""
+ARM_BSA_TAG="v25.04_DT_3.0.1"
 
 #Arm BBR source tag
 #NOTE: If the value is NULL then the latest BBR source will be downloaded
-ARM_BBR_TAG=""
+ARM_BBR_TAG="v25.04_DT_3.0.1"
 
 #Arm LINUX ACS source tag
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded


### PR DESCRIPTION
This PR updates the tags for the following repositories in the SystemReady repo:

- BSA

- SBSA

- BBR