### PR TITLE
Added DT ethtool test fixes binary

### DIFF
--- a/SystemReady-devicetree-band/prebuilt_images/ethtool-fixes/.gitattributes
+++ b/SystemReady-devicetree-band/prebuilt_images/ethtool-fixes/.gitattributes
@@ -1,0 +1,1 @@
+*.xz filter=lfs diff=lfs merge=lfs -text

--- a/SystemReady-devicetree-band/prebuilt_images/ethtool-fixes/README.md
+++ b/SystemReady-devicetree-band/prebuilt_images/ethtool-fixes/README.md
@@ -1,0 +1,5 @@
+After downloading the image, run below steps to decompress the file
+
+> xz -d systemready-dt_acs_live_image.wic.xz
+
+Once decompressed to the .wic format, flash the image to your system and reboot.

--- a/SystemReady-devicetree-band/prebuilt_images/ethtool-fixes/systemready-dt_acs_live_image.wic.xz
+++ b/SystemReady-devicetree-band/prebuilt_images/ethtool-fixes/systemready-dt_acs_live_image.wic.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5abf238ce0be17a7043928b6f8e267a8303e1c238d2ae777af118ecbc1a97e4b
+size 164929824


### PR DESCRIPTION
Add pre-built DT image with ethtool test bug fixes.

- Kselftest check failure due to mismatch of string between test and log parser
- wget check failure due to invalid wget arguments
