### PR TITLE
Update linux-acs tag to track latest mainline code

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-drv/bsa-acs-drv.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-drv/bsa-acs-drv.bb
@@ -8,7 +8,7 @@ COMPATIBLE_MACHINE:genericarm64 = "genericarm64"
 inherit module-base
 
 SRC_URI += "git://github.com/ARM-software/sysarch-acs;destsuffix=sysarch-acs;protocol=https;branch=main;name=sysarch-acs \
-            git://git.gitlab.arm.com/linux-arm/linux-acs.git;destsuffix=linux-acs;protocol=https;branch=sysarch-acs;name=linux-acs \
+            git://git.gitlab.arm.com/linux-arm/linux-acs.git;destsuffix=linux-acs;protocol=https;branch=master;name=linux-acs \
             "
 SRCREV_FORMAT = "sysarch-acs_linux-acs"
 SRCREV_sysarch-acs = "${AUTOREV}"

--- a/common/config/systemready-band-source.cfg
+++ b/common/config/systemready-band-source.cfg
@@ -53,7 +53,7 @@ ARM_BBR_TAG=""
 
 #Arm LINUX ACS source tag
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded
-ARM_LINUX_ACS_TAG=systemready_3.0.1
+ARM_LINUX_ACS_TAG=""
 
 #Buildroot version used for sbsa7.1
 BUILDROOT_SRC_VERSION=2022.08.1

--- a/common/config/systemready-dt-band-source.cfg
+++ b/common/config/systemready-dt-band-source.cfg
@@ -48,7 +48,7 @@ ARM_BBR_TAG=""
 
 #Arm LINUX ACS source tag
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded
-ARM_LINUX_ACS_TAG=systemready_3.0.1
+ARM_LINUX_ACS_TAG=""
 
 # EDK2-LIBC source tag from https://github.com/tianocore/edk2-libc
 EDK2_LIBC_SRC_TAG=""


### PR DESCRIPTION
This PR updates the linux-acs tag to point to the latest commit on the main branch. With active development moving to the sysarch-acs repository, this change ensures that the linux-acs tag continues to serve as an access point for the most recent codebase.