### PR TITLE
linux-yocto: Add USB config for KV260

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-kernel/linux/files/systemready.cfg
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-kernel/linux/files/systemready.cfg
@@ -20,6 +20,9 @@ CONFIG_ARM_PSCI_FW=y
 CONFIG_ARM_PSCI_CPUIDLE_DOMAIN=y
 CONFIG_ARM_PSCI_CHECKER=y
 
+# Enable KV260 USB support - Status: Upstreamed to official genericarm64 kernel meta data
+CONFIG_USB_ONBOARD_DEV_USB5744=y
+
 
 
 


### PR DESCRIPTION
Enable the on-board USB for the KV260. This  config is already upstreamed to the yocto kernel cache repo and this change will be made redundant, once ACS will upgrade to the new upcoming Yocto Release.