### PR TITLE
Copy signed EFI binaries to deploy image for runtime availability

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
@@ -68,6 +68,8 @@ do_sign_images() {
     wic cp DO_SIGN/EFI ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/
     wic cp DO_SIGN/Image ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/
 
+    # Copy signed EFI binaries back to deploy directory
+    wic cp DO_SIGN/acs_tests ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/
     echo "Copy back complete"
 }
 


### PR DESCRIPTION
This PR ensures that all signed EFI binaries under `acs_tests` are included in the final `.wic` image.