### PR TITLE
Remove the use of old GCC49 variables

### DIFF
--- a/SystemReady-band/build-scripts/build-bsaefi.sh
+++ b/SystemReady-band/build-scripts/build-bsaefi.sh
@@ -26,7 +26,7 @@
 # UEFI_BUILD_ENABLED - Flag to enable building UEFI
 # UEFI_PATH - sub-directory containing UEFI code
 # UEFI_BUILD_MODE - DEBUG or RELEASE
-# UEFI_TOOLCHAIN - Toolchain supported by Linaro uefi-tools: GCC49, GCC48 or GCC47
+# UEFI_TOOLCHAIN - Toolchain supported by Linaro uefi-tools
 # UEFI_PLATFORMS - List of platforms to build
 # UEFI_PLAT_{platform name} - array of platform parameters:
 #     - platname - the name of the platform used by the build
@@ -39,11 +39,11 @@
 TOP_DIR=`pwd`
 . $TOP_DIR/../common/config/systemready-band-source.cfg
 UEFI_PATH=edk2
-UEFI_TOOLCHAIN=GCC49
+UEFI_TOOLCHAIN=GCC
 CROSS_COMPILE=$TOP_DIR/$GCC
 UEFI_LIBC_PATH=edk2-libc
 OUTDIR=${TOP_DIR}/output
-BSA_EFI_PATH=edk2/Build/Shell/DEBUG_GCC49/AARCH64/
+BSA_EFI_PATH=edk2/Build/Shell/DEBUG_GCC/AARCH64/
 KEYS_DIR=$TOP_DIR/bbsr-keys
 
 do_build()
@@ -75,7 +75,7 @@ do_clean()
     PATH="$PATH:$CROSS_COMPILE_DIR"
     source ./edksetup.sh
     make -C BaseTools/Source/C clean
-    rm -rf Build/Shell/DEBUG_GCC49
+    rm -rf Build/Shell/DEBUG_GCC
     popd
 }
 

--- a/SystemReady-band/build-scripts/build-parser-app.sh
+++ b/SystemReady-band/build-scripts/build-parser-app.sh
@@ -53,7 +53,7 @@ rm -rf "$APP_PATH"
 cp -r "$TOP_DIR/../common/parser" "$APP_PATH"
 
 echo "Setting environment variables..."
-export GCC49_AARCH64_PREFIX="$GCC_BIN"
+export GCC_AARCH64_PREFIX="$GCC_BIN"
 export PACKAGES_PATH="$EDK2_DIR:$LIBC_DIR"
 
 echo "packages path : $PACKAGES_PATH"
@@ -63,9 +63,9 @@ source ./edksetup.sh --reconfig
 make -C BaseTools/Source/C
 
 echo "Building Parser.efi..."
-build -a AARCH64 -t GCC49 -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/$APP_NAME/Parser.inf
+build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/$APP_NAME/Parser.inf
 
-cp "$EDK2_DIR/Build/Shell/DEBUG_GCC49/AARCH64/Parser.efi" "$TOP_DIR/$APP_NAME/Parser.efi"
+cp "$EDK2_DIR/Build/Shell/DEBUG_GCC/AARCH64/Parser.efi" "$TOP_DIR/$APP_NAME/Parser.efi"
 git reset --hard
 
 popd
@@ -93,7 +93,7 @@ do_clean()
     PATH="$PATH:$CROSS_COMPILE_DIR"
     source ./edksetup.sh
     make -C BaseTools/Source/C clean
-    rm -rf Build/Shell/DEBUG_GCC49
+    rm -rf Build/Shell/DEBUG_GCC
     popd
 }
 

--- a/SystemReady-band/build-scripts/build-sbsaefi.sh
+++ b/SystemReady-band/build-scripts/build-sbsaefi.sh
@@ -26,7 +26,7 @@
 # UEFI_BUILD_ENABLED - Flag to enable building UEFI
 # UEFI_PATH - sub-directory containing UEFI code
 # UEFI_BUILD_MODE - DEBUG or RELEASE
-# UEFI_TOOLCHAIN - Toolchain supported by Linaro uefi-tools: GCC49, GCC48 or GCC47
+# UEFI_TOOLCHAIN - Toolchain supported by Linaro uefi-tools
 # UEFI_PLATFORMS - List of platforms to build
 # UEFI_PLAT_{platform name} - array of platform parameters:
 #     - platname - the name of the platform used by the build
@@ -38,12 +38,12 @@
 TOP_DIR=`pwd`
 . $TOP_DIR/../common/config/systemready-band-source.cfg
 UEFI_PATH=edk2
-UEFI_TOOLCHAIN=GCC49
+UEFI_TOOLCHAIN=GCC
 UEFI_BUILD_MODE=RELEASE
 CROSS_COMPILE=$TOP_DIR/$GCC
 UEFI_LIBC_PATH=edk2-libc
 OUTDIR=${TOP_DIR}/output
-SBSA_EFI_PATH=edk2/Build/Shell/DEBUG_GCC49/AARCH64/
+SBSA_EFI_PATH=edk2/Build/Shell/DEBUG_GCC/AARCH64/
 KEYS_DIR=$TOP_DIR/bbsr-keys
 
 do_build()
@@ -74,7 +74,7 @@ do_clean()
     PATH="$PATH:$CROSS_COMPILE_DIR"
     source ./edksetup.sh
     make -C BaseTools/Source/C clean
-    rm -rf Build/Shell/DEBUG_GCC49
+    rm -rf Build/Shell/DEBUG_GCC
     popd
 }
 

--- a/SystemReady-band/build-scripts/build-uefi.sh
+++ b/SystemReady-band/build-scripts/build-uefi.sh
@@ -26,7 +26,7 @@
 # UEFI_BUILD_ENABLED - Flag to enable building UEFI
 # UEFI_PATH - sub-directory containing UEFI code
 # UEFI_BUILD_MODE - DEBUG or RELEASE
-# UEFI_TOOLCHAIN - Toolchain supported by Linaro uefi-tools: GCC49, GCC48 or GCC47
+# UEFI_TOOLCHAIN - Toolchain supported by Linaro uefi-tools
 # UEFI_PLATFORMS - List of platforms to build
 # UEFI_PLAT_{platform name} - array of platform parameters:
 #     - platname - the name of the platform used by the build


### PR DESCRIPTION
 - more recent edk2 toolchain configuration are not longer using GCC49 variables. use GCC variables

 - Aligns to sysarch-acs changes sysarch-acs#74