### PR TITLE
Update the edk2-test-parser commit to fix for ignore the old HII

### DIFF
--- a/common/config/systemready-dt-band-source.cfg
+++ b/common/config/systemready-dt-band-source.cfg
@@ -54,7 +54,7 @@ ARM_LINUX_ACS_TAG=""
 EDK2_LIBC_SRC_TAG=""
 
 #edk2-test-parser version
-EDK2_TEST_PARSER_TAG=801eab9993b81d2989bed58abd1e8555f82a8226
+EDK2_TEST_PARSER_TAG=36eb96df657aefeccd1b76e09c8a72fdfefc6e5a
 
 #systemready-scripts version
 SYSTEMREADY_SCRIPTS_TAG=195d98b79445e53e097dca5f702df29df8aa0ffc


### PR DESCRIPTION
More details on fix https://gitlab.arm.com/systemready/edk2-test-parser/-/commit/36eb96df657aefeccd1b76e09c8a72fdfefc6e5a