### PR TITLE
Add support for capturing results of multi-payload capsule updates

### DIFF
--- a/common/linux_scripts/extract_capsule_fw_version.py
+++ b/common/linux_scripts/extract_capsule_fw_version.py
@@ -18,10 +18,7 @@ import chardet
 import re
 import sys
 
-def extract_hex_value(file_path):
-    # Regular expression to match 'FwVersion - 0x<hex_value>'
-    pattern = sys.argv[1]
-
+def extract_hex_values(file_path, pattern):
     # Detect file encoding using chardet
     with open(file_path, 'rb') as file:
         raw_data = file.read()
@@ -33,22 +30,27 @@ def extract_hex_value(file_path):
         with open(file_path, 'r', encoding=encoding) as file:
             lines = file.readlines()
 
+        matches = []
         for line in lines:
             match = re.search(pattern, line)
             if match:
-                return match.group(1)
+                try:
+                    matches.append(match.group(1))
+                except IndexError:
+                    continue
+        return matches
 
     except UnicodeDecodeError:
         print(f"Error: Unable to decode the file {file_path} with detected encoding: {encoding}")
-        return None
+        return []
 
-    return None
+if len(sys.argv) != 3:
+    print("Usage: python3 extract_capsule_fw_version.py <pattern> <file_path>")
+    sys.exit(1)
 
+pattern = sys.argv[1]
 file_path = sys.argv[2]
-hex_value = extract_hex_value(file_path)
 
-# Print the result
-if hex_value:
-    print(hex_value)
-else:
-    print("No 'FwVersion' found in the file.")
+hex_values = extract_hex_values(file_path, pattern)
+for val in hex_values:
+    print(val)


### PR DESCRIPTION
- Updated init.sh and extract_capsule_fw_version.py to log results for multi-payload capsules.
- Enables parsing and validation of individual payload update status and versions.

Change-Id: Ib12f942c41278e0fb1affd8979db3e75fcc6d2eb