### PR TITLE
build: fix gnulib fetch by updating GNULIB_URL to GitHub

### DIFF
--- a/SystemReady-band/build-scripts/build-grub.sh
+++ b/SystemReady-band/build-scripts/build-grub.sh
@@ -59,6 +59,7 @@ do_build ()
         # required the bootstrap tool to be executed before the configure step.
         if [ -e bootstrap ]; then
             if [ ! -e grub-core/lib/gnulib/stdlib.in.h ]; then
+                GNULIB_URL="https://github.com/coreutils/gnulib.git" \
                 ./bootstrap
             fi
         fi


### PR DESCRIPTION
- Fetching gnulib over the git protocol (git://) is failing. 
- Update the GNULIB_URL to use https://github.com/coreutils/gnulib.git for more reliable downloads