### PR TITLE
Log parser changes for making merged json fields consistent

### DIFF
--- a/common/log_parser/bbr/fwts/logs_to_json.py
+++ b/common/log_parser/bbr/fwts/logs_to_json.py
@@ -26,7 +26,7 @@ def parse_fwts_log(log_path):
     main_tests = []
     current_test = None
     current_subtest = None
-    Test_suite_Description = None
+    Test_suite_description = None
 
     # Summary variables
     suite_summary = {
@@ -64,10 +64,10 @@ def parse_fwts_log(log_path):
                     results.append(current_test)
 
                 # Start a new main test
-                Test_suite_Description = line.split(':', 1)[1].strip() if ':' in line else "No description"
+                Test_suite_description = line.split(':', 1)[1].strip() if ':' in line else "No description"
                 current_test = {
                     "Test_suite": main_test,
-                    "Test_suite_Description": Test_suite_Description,
+                    "Test_suite_description": Test_suite_description,
                     "subtests": [],
                     "test_suite_summary": {
                         "total_passed": 0,
@@ -198,7 +198,7 @@ def parse_fwts_log(log_path):
             skip_acpi_match = re.search(r"ACPI\s+(\S+)\s+table does not exist, skipping test", line)
             if skip_acpi_match and current_test:
                 # Create a new subtest to record the skip
-                sub_desc = current_test.get("Test_suite_Description")
+                sub_desc = current_test.get("Test_suite_description")
 
                 skip_subtest = {
                     "sub_Test_Number": "Test 1 of 1",

--- a/common/log_parser/bsa/logs_to_json.py
+++ b/common/log_parser/bsa/logs_to_json.py
@@ -44,7 +44,8 @@ def main(input_files, output_file):
         "total_aborted": 0,
         "total_skipped": 0,
         "total_warnings": 0,
-        "total_failed_with_waiver": 0
+        "total_failed_with_waiver": 0,
+        "total_ignored": 0
     }
 
     # Dictionary to keep track of test numbers per suite to avoid duplicates
@@ -100,7 +101,9 @@ def main(input_files, output_file):
                         result_data[suite_name].append(subtest_entry)
                         test_numbers_per_suite[suite_name].add(test_number)
                         # Update suite_summary
-                        if result == "PASSED":
+                        if "FAILED" in result and "WAIVER" in result:
+                            suite_summary["total_failed_with_waiver"] += 1
+                        elif result == "PASSED":
                             suite_summary["total_passed"] += 1
                         elif result == "FAILED":
                             suite_summary["total_failed"] += 1
@@ -157,7 +160,9 @@ def main(input_files, output_file):
                             result_data[suite_name].append(subtest_entry)
                             test_numbers_per_suite[suite_name].add(test_number)
                             # Update suite_summary
-                            if result == "PASSED":
+                            if "FAILED" in result and "WAIVER" in result:
+                                suite_summary["total_failed_with_waiver"] += 1
+                            elif result == "PASSED":
                                 suite_summary["total_passed"] += 1
                             elif result == "FAILED":
                                 suite_summary["total_failed"] += 1
@@ -212,12 +217,16 @@ def main(input_files, output_file):
             "total_aborted": 0,
             "total_skipped": 0,
             "total_warnings": 0,
+            "total_failed_with_waiver": 0,
+            "total_ignored": 0
         }
 
         # Count test results for the suite
         for subtest in subtests:
             result = subtest['sub_test_result']
-            if result == "PASSED":
+            if "FAILED" in result and "WAIVER" in result:
+                test_suite_summary["total_failed_with_waiver"] += 1
+            elif result == "PASSED":
                 test_suite_summary["total_passed"] += 1
             elif result == "FAILED":
                 test_suite_summary["total_failed"] += 1

--- a/common/log_parser/os_tests/logs_to_json.py
+++ b/common/log_parser/os_tests/logs_to_json.py
@@ -70,7 +70,8 @@ def parse_ethtool_test_log(log_data, os_name):
         "total_failed_with_waiver": 0,
         "total_skipped": 0,
         "total_aborted": 0,
-        "total_warnings": 0
+        "total_warnings": 0,
+        "total_ignored": 0
     }
 
     current_test = {

--- a/common/log_parser/os_tests/logs_to_json.py
+++ b/common/log_parser/os_tests/logs_to_json.py
@@ -39,16 +39,27 @@ def create_subtest(subtest_number, description, status, reason=""):
     return result
 
 def update_suite_summary(suite_summary, status):
-    if status in ["PASSED", "FAILED", "SKIPPED", "ABORTED", "WARNINGS"]:
-        key = f"total_{status.lower()}"
-        suite_summary[key] += 1
+    s = status.strip().upper()
+    if s in ("FAILED (WITH WAIVER)", "FAILED_WITH_WAIVER"):
+        suite_summary["total_failed_with_waiver"] += 1
+        return
+    mapping = {
+        "PASSED": "total_passed",
+        "FAILED": "total_failed",
+        "SKIPPED": "total_skipped",
+        "ABORTED": "total_aborted",
+        "WARNING": "total_warnings",
+        "WARNINGS": "total_warnings",
+    }
+    if s in mapping:
+        suite_summary[mapping[s]] += 1
 
 def parse_ethtool_test_log(log_data, os_name):
     results = []
     test_suite_key = f"ethtool_test_{os_name}"  # e.g., ethtool_test_linux-opensuse-leap-15.5-version
 
     mapping = {
-        "Test_suite_name": "Network",
+        "Test_suite": "Network",
         "Test_suite_description": "Network validation",
         "Test_case_description": "Ethernet Tool Tests"
     }
@@ -56,13 +67,14 @@ def parse_ethtool_test_log(log_data, os_name):
     suite_summary = {
         "total_passed": 0,
         "total_failed": 0,
+        "total_failed_with_waiver": 0,
         "total_skipped": 0,
         "total_aborted": 0,
         "total_warnings": 0
     }
 
     current_test = {
-        "Test_suite_name": mapping["Test_suite_name"],
+        "Test_suite": mapping["Test_suite"],
         "Test_suite_description": mapping["Test_suite_description"],
         "Test_case": test_suite_key,
         "Test_case_description": mapping["Test_case_description"],

--- a/common/log_parser/standalone_tests/logs_to_json.py
+++ b/common/log_parser/standalone_tests/logs_to_json.py
@@ -959,7 +959,8 @@ def parse_psci_logs(psci_log_path):
         "total_skipped": 0,
         "total_aborted": 0,
         "total_warnings": 0,
-        "total_failed_with_waivers": 0
+        "total_failed_with_waiver": 0,
+        "total_ignored": 0
     }
 
     current_test = {

--- a/common/log_parser/standalone_tests/logs_to_json.py
+++ b/common/log_parser/standalone_tests/logs_to_json.py
@@ -22,32 +22,32 @@ import os
 # Test Suite Mapping
 test_suite_mapping = {
     "dt_kselftest": {
-        "Test_suite_name": "Peripherals",
+        "Test_suite": "Peripherals",
         "Test_suite_description": "Validation for device tree",
         "Test_case_description": "Device Tree kselftests"
     },
     "dt_validate": {
-        "Test_suite_name": "DTValidation",
+        "Test_suite": "DTValidation",
         "Test_suite_description": "Validation for device tree",
         "Test_case_description": "Device Tree Validation"
     },
     "ethtool_test": {
-        "Test_suite_name": "Network",
+        "Test_suite": "Network",
         "Test_suite_description": "Network validation",
         "Test_case_description": "Ethernet Tool Tests"
     },
     "read_write_check_blk_devices": {
-        "Test_suite_name": "Boot sources",
+        "Test_suite": "Boot sources",
         "Test_suite_description": "Checks for boot sources",
         "Test_case_description": "Read/Write Check on Block Devices"
     },
     "capsule_update": {
-        "Test_suite_name": "Capsule Update",
+        "Test_suite": "Capsule Update",
         "Test_suite_description": "Testing firmware capsule update mechanism",
         "Test_case_description": "Capsule Update Tests"
     },
     "psci_check": {
-        "Test_suite_name": "PSCI",
+        "Test_suite": "PSCI",
         "Test_suite_description": "PSCI version check",
         "Test_case_description": "PSCI compliance"
     },
@@ -94,7 +94,7 @@ def parse_dt_kselftest_log(log_data):
     }
 
     current_test = {
-        "Test_suite_name": mapping["Test_suite_name"],
+        "Test_suite": mapping["Test_suite"],
         "Test_suite_description": mapping["Test_suite_description"],
         "Test_case": test_suite_key,
         "Test_case_description": mapping["Test_case_description"],
@@ -157,7 +157,7 @@ def parse_dt_validate_log(log_data):
     }
 
     current_test = {
-        "Test_suite_name": mapping["Test_suite_name"],
+        "Test_suite": mapping["Test_suite"],
         "Test_suite_description": mapping["Test_suite_description"],
         "Test_case": test_suite_key,
         "Test_case_description": mapping["Test_case_description"],
@@ -211,7 +211,7 @@ def parse_ethtool_test_log(log_data):
     }
 
     current_test = {
-        "Test_suite_name": mapping["Test_suite_name"],
+        "Test_suite": mapping["Test_suite"],
         "Test_suite_description": mapping["Test_suite_description"],
         "Test_case": test_suite_key,
         "Test_case_description": mapping["Test_case_description"],
@@ -477,7 +477,7 @@ def parse_read_write_check_blk_devices_log(log_data):
     }
 
     current_test = {
-        "Test_suite_name": mapping["Test_suite_name"],
+        "Test_suite": mapping["Test_suite"],
         "Test_suite_description": mapping["Test_suite_description"],
         "Test_case": test_suite_key,
         "Test_case_description": mapping["Test_case_description"],
@@ -776,7 +776,7 @@ def parse_read_write_check_blk_devices_log(log_data):
 def parse_capsule_update_logs(capsule_update_log_path, capsule_test_results_log_path):
     test_suite_key = "capsule_update"
     mapping = {
-        "Test_suite_name": "Capsule Update",
+        "Test_suite": "Capsule Update",
         "Test_suite_description": "Tests for automatic capsule update",
         "Test_case_description": "Capsule Update"
     }
@@ -791,7 +791,7 @@ def parse_capsule_update_logs(capsule_update_log_path, capsule_test_results_log_
     }
 
     current_test = {
-        "Test_suite_name": mapping["Test_suite_name"],
+        "Test_suite": mapping["Test_suite"],
         "Test_suite_description": mapping["Test_suite_description"],
         "Test_case": test_suite_key,
         "Test_case_description": mapping["Test_case_description"],
@@ -963,7 +963,7 @@ def parse_psci_logs(psci_log_path):
     }
 
     current_test = {
-        "Test_suite_name": mapping["Test_suite_name"],       # "PSCI"
+        "Test_suite": mapping["Test_suite"],       # "PSCI"
         "Test_suite_description": mapping["Test_suite_description"],  # "PSCI version check"
         "Test_case": test_suite_key,                         # "psci_check"
         "Test_case_description": mapping["Test_case_description"],  # "PSCI compliance"


### PR DESCRIPTION
Renamed Test_suite_Description → Test_suite_description (fwts)
- Added normalize_result for consistent PASSED/FAILED/SKIPPED outputs (sct)
- Updated BSA parser to include total_ignored and detect failed_with_waiver
- Updated OS tests parser to handle failed_with_waiver/ignored in summary
- Standardized Test_suite naming in standalone parsers
- Fixed PSCI summary keys: singular total_failed_with_waiver + total_ignored