### PR TITLE
copy acs_waiver.json into result directory

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -355,6 +355,11 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
         fi
       /usr/bin/log_parser/main_log_parser.sh /mnt/acs_results_template/acs_results /mnt/acs_tests/config/acs_config.txt /mnt/acs_tests/config/system_config.txt /mnt/acs_tests/config/acs_waiver.json
       fi
+      # Copying acs_waiver.json into result directory.
+      if [ -f /mnt/acs_tests/config/acs_waiver.json ]; then
+        mkdir -p /mnt/acs_results_template/acs_results/acs_summary/config
+        cp /mnt/acs_tests/config/acs_waiver.json /mnt/acs_results_template/acs_results/acs_summary/config
+      fi
       echo "Please wait acs results are syncing on storage medium."
       sync /mnt
       sleep 60

--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -257,6 +257,10 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
   #copying acs_run_config.ini into results directory.
   mkdir -p /mnt/acs_results/acs_summary/config
   cp /mnt/acs_tests/config/acs_run_config.ini /mnt/acs_results/acs_summary/config
+  # Copying acs_waiver.json into result directory.
+  if [ -f /mnt/acs_tests/config/acs_waiver.json ]; then
+    cp /mnt/acs_tests/config/acs_waiver.json /mnt/acs_results/acs_summary/config
+  fi
   sync /mnt
 
   echo "ACS automated test suites run is completed."


### PR DESCRIPTION
- Added conditional check in script to copy /mnt/acs_tests/config/acs_waiver.json into /mnt/acs_results/acs_summary/config
- Ensures waiver file is only copied if it exists
- Creates destination directory if missing