### PR TITLE
dt-validate parser: support new format and warnings

### DIFF
--- a/common/log_parser/main_log_parser.sh
+++ b/common/log_parser/main_log_parser.sh
@@ -356,7 +356,7 @@ if [ $YOCTO_FLAG_PRESENT -eq 1 ]; then
     fi
 
     # 2) DT_VALIDATE
-    DT_VALIDATE_LOG="$LINUX_TOOLS_LOGS_PATH/dt-validate.log"
+    DT_VALIDATE_LOG="$LINUX_TOOLS_LOGS_PATH/dt-validate-parser.log"
     DT_VALIDATE_JSON="$JSONS_DIR/dt_validate.json"
     if check_file "$DT_VALIDATE_LOG" "M"; then
         python3 "$SCRIPTS_PATH/standalone_tests/logs_to_json.py" \


### PR DESCRIPTION
- Handle both error and warning lines (new “node  dt-validate …  message”), keeping old “/path: node: message” parsing but skipping it when 'dt-validate' is present.
- Set description to the first token (e.g., “/”, “signature”, “l2-cache0”) and reason to only the trailing message.
- Map errors to FAILED→fail_reasons and warnings to WARNINGS→warning_reasons; fix “/ … True is not of type 'object'” cases.

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com