### PR TITLE
OS tests script now imports parse_ethtool_test_log() from standalone_…

### DIFF
--- a/common/log_parser/os_tests/logs_to_json.py
+++ b/common/log_parser/os_tests/logs_to_json.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,367 +18,117 @@ import sys
 import re
 import json
 import os
+from pathlib import Path
+import importlib.util
 
-def create_subtest(subtest_number, description, status, reason=""):
-    result = {
-        "sub_Test_Number": str(subtest_number),
-        "sub_Test_Description": description,
-        "sub_test_result": {
-            "PASSED": 1 if status == "PASSED" else 0,
-            "FAILED": 1 if status == "FAILED" else 0,
-            "ABORTED": 0,
-            "SKIPPED": 1 if status == "SKIPPED" else 0,
-            "WARNINGS": 0,
-            "pass_reasons": [reason] if status == "PASSED" and reason else [],
-            "fail_reasons": [reason] if status == "FAILED" and reason else [],
-            "abort_reasons": [],
-            "skip_reasons": [reason] if status == "SKIPPED" and reason else [],
-            "warning_reasons": []
-        }
-    }
-    return result
+def _load_standalone_parser(standalone_path: Path):
+    """
+    Dynamically import the existing standalone logs_to_json.py so we can call
+    its parse_ethtool_test_log() without duplicating code.
+    """
+    if not standalone_path.is_file():
+        raise FileNotFoundError(f"Standalone parser not found at: {standalone_path}")
 
-def update_suite_summary(suite_summary, status):
-    s = status.strip().upper()
-    if s in ("FAILED (WITH WAIVER)", "FAILED_WITH_WAIVER"):
-        suite_summary["total_failed_with_waiver"] += 1
-        return
-    mapping = {
-        "PASSED": "total_passed",
-        "FAILED": "total_failed",
-        "SKIPPED": "total_skipped",
-        "ABORTED": "total_aborted",
-        "WARNING": "total_warnings",
-        "WARNINGS": "total_warnings",
-    }
-    if s in mapping:
-        suite_summary[mapping[s]] += 1
+    spec = importlib.util.spec_from_file_location("standalone_parser", str(standalone_path))
+    mod = importlib.util.module_from_spec(spec)
+    if spec.loader is None:
+        raise ImportError(f"Unable to load module from {standalone_path}")
+    spec.loader.exec_module(mod)
 
-def parse_ethtool_test_log(log_data, os_name):
-    results = []
-    test_suite_key = f"ethtool_test_{os_name}"  # e.g., ethtool_test_linux-opensuse-leap-15.5-version
+    if not hasattr(mod, "parse_ethtool_test_log"):
+        raise AttributeError("Standalone parser missing function: parse_ethtool_test_log(log_data)")
+    return mod
 
-    mapping = {
-        "Test_suite": "Network",
-        "Test_suite_description": "Network validation",
-        "Test_case_description": "Ethernet Tool Tests"
-    }
 
-    suite_summary = {
-        "total_passed": 0,
-        "total_failed": 0,
-        "total_failed_with_waiver": 0,
-        "total_skipped": 0,
-        "total_aborted": 0,
-        "total_warnings": 0,
-        "total_ignored": 0
-    }
+def _ethtool_path() -> Path:
+    env = os.getenv("STANDALONE_PARSER_PATH")
+    if env:
+        return Path(env).expanduser().resolve()
 
-    current_test = {
-        "Test_suite": mapping["Test_suite"],
-        "Test_suite_description": mapping["Test_suite_description"],
-        "Test_case": test_suite_key,
-        "Test_case_description": mapping["Test_case_description"],
-        "subtests": [],
-        "test_suite_summary": suite_summary.copy()
-    }
-
-    subtest_number = 1
-    interface = None
-    detected_interfaces = []
-    i = 0
-    while i < len(log_data):
-        line = log_data[i].strip()
-
-        # Detection of Ethernet Interfaces
-        if line.startswith("INFO: Detected following ethernet interfaces via ip command :"):
-            interfaces = []
-            i += 1
-            while i < len(log_data) and log_data[i].strip() and not log_data[i].startswith("INFO"):
-                match = re.match(r'\d+:\s+(\S+)', log_data[i].strip())
-                if match:
-                    interfaces.append(match.group(1))
-                i += 1
-            if interfaces:
-                detected_interfaces = interfaces
-                status = "PASSED"
-                description = f"Detection of Ethernet Interfaces: {', '.join(interfaces)}"
-            else:
-                status = "FAILED"
-                description = "No Ethernet Interfaces Detected"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
+    here = Path(__file__).resolve().parent
+    candidates = [
+        here.parent / "standalone_tests" / "logs_to_json.py",
+    ]
+    self_path = Path(__file__).resolve()
+    for c in candidates:
+        try:
+            c = c.resolve()
+        except Exception:
             continue
+        if c.is_file() and c != self_path:
+            return c
 
-        # Bringing Down Ethernet Interfaces
-        if "INFO: Bringing down all ethernet interfaces using ifconfig" in line:
-            status = "PASSED"
-            description = "Bringing down all Ethernet interfaces"
-            for j in range(i + 1, len(log_data)):
-                if "Unable to bring down ethernet interface" in log_data[j]:
-                    status = "FAILED"
-                    description = "Failed to bring down some Ethernet interfaces"
-                    break
-                if "****************************************************************" in log_data[j]:
-                    break
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
+    raise FileNotFoundError(
+        "Could not find standalone logs_to_json.py. "
+        "Set STANDALONE_PARSER_PATH to its absolute path."
+    )
 
-        # Bringing up interface
-        if "INFO: Bringing up ethernet interface:" in line:
-            interface = line.split(":")[-1].strip()
-            # Check if the interface was brought up successfully
-            if i + 1 < len(log_data) and "Unable to bring up ethernet interface" in log_data[i + 1]:
-                status = "FAILED"
-                description = f"Bring up interface {interface}"
-            else:
-                status = "PASSED"
-                description = f"Bring up interface {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
 
-        # Running ethtool Command
-        if f"INFO: Running \"ethtool {interface}\" :" in line:
-            status = "PASSED"
-            description = f"Running ethtool on {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # Self-test detection
-        if "INFO: Ethernet interface" in line and "ethtool self test" in line:
-            if "doesn't supports ethtool self test" in line:
-                status = "SKIPPED"
-                desc   = f"Self-test on {interface} (Not supported)"
-            else:
-                # Look ahead up to 20 lines to find "The test result is ..."
-                result_status = None
-                for k in range(i + 1, min(i + 21, len(log_data))):
-                    if "The test result is" in log_data[k]:
-                        result_status = "PASSED" if "PASS" in log_data[k] else "FAILED"
-                        break
-
-                if result_status:
-                    status = result_status
-                    desc   = f"Self-test on {interface}"
-                else:
-                    status = "FAILED"
-                    desc   = f"Self-test on {interface} (Result not found)"
-
-            sub = create_subtest(subtest_number, desc, status)
-            current_test["subtests"].append(sub)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # Link detection
-        if "Link detected:" in line:
-            if "yes" in line:
-                status = "PASSED"
-                description = f"Link detected on {interface}"
-            else:
-                status = "FAILED"
-                description = f"Link not detected on {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # DHCP support
-        if "doesn't support DHCP" in line or "support DHCP" in line:
-            if "doesn't support DHCP" in line:
-                status = "FAILED"
-                description = f"DHCP support on {interface}"
-            else:
-                status = "PASSED"
-                description = f"DHCP support on {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # Ping to router/gateway
-        if "INFO: Ping to router/gateway" in line:
-            if "is successful" in line:
-                status = "PASSED"
-                description = f"Ping to router/gateway on {interface}"
-            else:
-                status = "FAILED"
-                description = f"Ping to router/gateway on {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # --- router/gateway failure variant (from updated ethtool function) ---
-        if "Failed to ping router/gateway" in line:
-            intf = line.split("for")[-1].strip()
-            status = "FAILED"
-            description = f"Ping to router/gateway on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # Ping to www.arm.com
-        if "INFO: Ping to www.arm.com" in line:
-            if "is successful" in line:
-                status = "PASSED"
-                description = f"Ping to www.arm.com on {interface}"
-            else:
-                status = "FAILED"
-                description = f"Ping to www.arm.com on {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # --- www.arm.com failure/success variants (from updated ethtool function) ---
-        if "Failed to ping www.arm.com via" in line:
-            intf = line.split("via")[-1].strip()
-            status = "FAILED"
-            description = f"Ping to www.arm.com on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # >>> Wget checks <<<
-        if "INFO: wget failed to reach https://www.arm.com via" in line:
-            intf = line.split("via")[-1].strip()
-            status = "FAILED"
-            description = f"Wget connectivity to https://www.arm.com on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        if "INFO: wget successfully accessed https://www.arm.com via" in line:
-            intf = line.split("via")[-1].strip()
-            status = "PASSED"
-            description = f"Wget connectivity to https://www.arm.com on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # >>> Curl checks <<<
-        if "INFO: curl failed to fetch https://www.arm.com via" in line:
-            intf = line.split("via")[-1].strip()
-            status = "FAILED"
-            description = f"Curl connectivity to https://www.arm.com on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        if "INFO: curl successfully fetched https://www.arm.com via" in line:
-            intf = line.split("via")[-1].strip()
-            status = "PASSED"
-            description = f"Curl connectivity to https://www.arm.com on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        i += 1
-
-    # If ping tests were not found, add them as SKIPPED
-    for intf in detected_interfaces:
-        # Check if ping tests for this interface are present
-        ping_to_router_present = any(
-            subtest["sub_Test_Description"] == f"Ping to router/gateway on {intf}"
-            for subtest in current_test["subtests"]
-        )
-        ping_to_arm_present = any(
-            subtest["sub_Test_Description"] == f"Ping to www.arm.com on {intf}"
-            for subtest in current_test["subtests"]
-        )
-        if not ping_to_router_present:
-            # Ping to router/gateway
-            description = f"Ping to router/gateway on {intf}"
-            status = "SKIPPED"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-        if not ping_to_arm_present:
-            # Ping to www.arm.com
-            description = f"Ping to www.arm.com on {intf}"
-            status = "SKIPPED"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-    # Finalize results
-    results.append(current_test)
-
-    # --------------------------------------------------------------------------
-    # REMOVE EMPTY REASON ARRAYS IN EACH SUBTEST'S sub_test_result
-    # --------------------------------------------------------------------------
-    for test in results:
-        for subtest in test["subtests"]:
-            subres = subtest["sub_test_result"]
-            if not subres["pass_reasons"]:
-                del subres["pass_reasons"]
-            if not subres["fail_reasons"]:
-                del subres["fail_reasons"]
-            if not subres["abort_reasons"]:
-                del subres["abort_reasons"]
-            if not subres["skip_reasons"]:
-                del subres["skip_reasons"]
-            if not subres["warning_reasons"]:
-                del subres["warning_reasons"]
-
-    return {
-        "test_results": results,
-        "suite_summary": suite_summary
-    }
-
-def parse_log(log_file_path, os_name):
-    with open(log_file_path, 'r') as f:
-        log_data = f.readlines()
-    return parse_ethtool_test_log(log_data, os_name)
-
-if __name__ == "__main__":
+def main():
     if len(sys.argv) != 4:
         print("Usage: python3 logs_to_json.py <path to ethtool_test.log> <output JSON file path> <os_name>")
         sys.exit(1)
 
-    log_file_path = sys.argv[1]
-    output_file_path = sys.argv[2]
+    log_file_path = Path(sys.argv[1]).expanduser().resolve()
+    output_file_path = Path(sys.argv[2]).expanduser().resolve()
     os_name = sys.argv[3]
 
-    try:
-        output_json = parse_log(log_file_path, os_name)
-    except ValueError as ve:
-        print(f"Error: {ve}")
+    if not log_file_path.is_file():
+        print(f"Error: log file not found: {log_file_path}")
         sys.exit(1)
 
-    with open(output_file_path, 'w') as outfile:
-        json.dump(output_json, outfile, indent=4)
+    # Locate and load the existing standalone parser module
+    standalone_path = _ethtool_path()
+    standalone = _load_standalone_parser(standalone_path)
 
+    # Read the log and parse using the single source of truth
+    with open(log_file_path, "r") as f:
+        log_lines = f.readlines()
+
+    # --- Single source of truth for the parser ---
+    parsed = standalone.parse_ethtool_test_log(log_lines)
+
+    # Keep OS-test naming exactly as before:
+    # "Test_case": f"ethtool_test_{os_name}"
+    try:
+        for test in parsed.get("test_results", []):
+            if isinstance(test, dict) and "Test_case" in test:
+                test["Test_case"] = f"ethtool_test_{os_name}"
+    except Exception:
+        # Non-fatal: if structure ever changes, we still output the parsed JSON.
+        pass
+
+    # Normalize suite_summary keys to match OS-test schema
+    _OS_SCHEMA_KEYS = [
+        "total_passed",
+        "total_failed",
+        "total_failed_with_waiver",
+        "total_aborted",
+        "total_skipped",
+        "total_warnings",
+        "total_ignored",
+    ]
+
+    def _normalize_suite_summary(obj):
+        if not isinstance(obj, dict):
+            return
+        # plural -> singular
+        if "total_failed_with_waivers" in obj and "total_failed_with_waiver" not in obj:
+            obj["total_failed_with_waiver"] = obj.pop("total_failed_with_waivers")
+        # drop anything not in schema
+        for k in list(obj.keys()):
+            if k not in _OS_SCHEMA_KEYS:
+                obj.pop(k, None)
+        # ensure all keys exist
+        for k in _OS_SCHEMA_KEYS:
+            obj.setdefault(k, 0)
+
+    for test in parsed.get("test_results", []):
+        _normalize_suite_summary(test.get("test_suite_summary", {}))
+    _normalize_suite_summary(parsed.get("suite_summary", {}))
+
+    with open(output_file_path, "w") as outfile:
+        json.dump(parsed, outfile, indent=4)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
1.	It expects 3 arguments – input log file, output JSON file, and os_name.
2.	It finds the standalone logs_to_json.py (by env var STANDALONE_PARSER_PATH or relative path ../standalone_tests/).
3.	It dynamically imports that file and verifies parse_ethtool_test_log exists.
4.	It reads the given log and passes all lines to parse_ethtool_test_log, ensuring the parsing logic comes only from the standalone script.
5.	It then rewrites the "Test_case" field to include the OS name (e.g., ethtool_test_linux-Ubuntu) to preserve OS-specific tagging.
6.	Finally, it writes the parsed JSON results to the specified output file.

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com