### PR TITLE
fix(psci): treat psci not run or supported as non-compliance

### DIFF
--- a/common/log_parser/merge_jsons.py
+++ b/common/log_parser/merge_jsons.py
@@ -457,7 +457,7 @@ def merge_json_files(json_files, output_file):
             else:
                 if DT_OR_SR_MODE == "DT":
                     acs_results_summary[label] = "Not Compliant: not run"
-                    print(f"Suite: Recommended: {suite_name}: {acs_results_summary[label]}")
+                    print(f"{RED}Suite: Recommended: {suite_name}: {acs_results_summary[label]}{RESET}")
                     overall_comp = "Not Compliant"
                     missing_list.append(suite_name)
                 else:
@@ -526,7 +526,7 @@ def merge_json_files(json_files, output_file):
         if missing_list:
             reason_parts.append(f"missing suite(s): {', '.join(missing_list)}")
         if non_waived_list:
-            reason_parts.append(f"non-waived fails in suite(s): {', '.join(non_waived_list)}")
+            reason_parts.append(f"failures in suite(s): {', '.join(non_waived_list)}")
         if reason_parts:
             overall_comp += f" ({'; '.join(reason_parts)})"
     elif overall_comp == "Compliant with waivers":


### PR DESCRIPTION
 - Treat below conditions as failure of compliance
   - if psci_kernel.log is not created OR
   - there is no PSCI version due to psci not supported
 - if recommended version is not met, psci test suite will be fail but not impact overall compliance