### PR TITLE
log parser changes for ethtool and os tests and minor fixes:

### DIFF
--- a/common/log_parser/merge_jsons.py
+++ b/common/log_parser/merge_jsons.py
@@ -604,6 +604,8 @@ def merge_json_files(json_files, output_file):
     else:
         print(f"{RED}BBSR compliance results: {bbsr_comp_str}{RESET}\n")
 
+    merged_results["Suite_Name: acs_info"]["BBSR compliance results"] = acs_results_summary.pop("BBSR compliance results", None)    
+
     RENAME_SUITES_TO_STANDALONE = {
         "Suite_Name: DT Kselftest": "Suite_Name: Standalone",
         "Suite_Name: CAPSULE_UPDATE": "Suite_Name: Standalone",

--- a/common/log_parser/os_tests/json_to_html.py
+++ b/common/log_parser/os_tests/json_to_html.py
@@ -450,6 +450,7 @@ def main():
                     total_tests += 1
                     test_status = 'PASSED'
                     has_skipped = False
+                    saw_pass = False
 
                     if test.get('subtests'):
                         for subtest in test['subtests']:
@@ -463,9 +464,11 @@ def main():
                                 # treat any other status as failure
                                 test_status = 'FAILED'
                                 break
+                            else:
+                                saw_pass = True
                         else:
-                            if has_skipped and test_status != 'FAILED':
-                                test_status = 'SKIPPED'
+                            if test_status != 'FAILED':
+                                test_status = 'PASSED' if saw_pass else 'SKIPPED'
                     else:
                         test_status = 'SKIPPED'
 

--- a/common/log_parser/os_tests/json_to_html.py
+++ b/common/log_parser/os_tests/json_to_html.py
@@ -450,7 +450,7 @@ def main():
                     total_tests += 1
                     test_status = 'PASSED'
                     has_skipped = False
-                    saw_pass = False
+                    has_pass = False
 
                     if test.get('subtests'):
                         for subtest in test['subtests']:
@@ -464,11 +464,11 @@ def main():
                                 # treat any other status as failure
                                 test_status = 'FAILED'
                                 break
-                            else:
-                                saw_pass = True
+                            elif subtest_status == 'PASSED':
+                                has_pass = True
                         else:
                             if test_status != 'FAILED':
-                                test_status = 'PASSED' if saw_pass else 'SKIPPED'
+                                test_status = 'PASSED' if has_pass else 'SKIPPED'
                     else:
                         test_status = 'SKIPPED'
 

--- a/common/log_parser/os_tests/logs_to_json.py
+++ b/common/log_parser/os_tests/logs_to_json.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,370 +15,70 @@
 # limitations under the License.
 
 import sys
-import re
+from pathlib import Path
 import json
-import os
 
-def create_subtest(subtest_number, description, status, reason=""):
-    result = {
-        "sub_Test_Number": str(subtest_number),
-        "sub_Test_Description": description,
-        "sub_test_result": {
-            "PASSED": 1 if status == "PASSED" else 0,
-            "FAILED": 1 if status == "FAILED" else 0,
-            "ABORTED": 0,
-            "SKIPPED": 1 if status == "SKIPPED" else 0,
-            "WARNINGS": 0,
-            "pass_reasons": [reason] if status == "PASSED" and reason else [],
-            "fail_reasons": [reason] if status == "FAILED" and reason else [],
-            "abort_reasons": [],
-            "skip_reasons": [reason] if status == "SKIPPED" and reason else [],
-            "warning_reasons": []
-        }
-    }
-    return result
+# Put repo root (parent of "common") on sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
-def update_suite_summary(suite_summary, status):
-    s = status.strip().upper()
-    if s in ("FAILED (WITH WAIVER)", "FAILED_WITH_WAIVER"):
-        suite_summary["total_failed_with_waiver"] += 1
+try:
+    from common.log_parser.standalone_tests.logs_to_json import parse_ethtool_test_log
+except ImportError as e:
+    raise ImportError(
+        "Could not import parse_ethtool_test_log from common.log_parser.standalone_tests.logs_to_json "
+        "even after adding the repo root to sys.path. Verify the path exists."
+    ) from e
+
+def _normalize_suite_summary(obj):
+    if not isinstance(obj, dict):
         return
-    mapping = {
-        "PASSED": "total_passed",
-        "FAILED": "total_failed",
-        "SKIPPED": "total_skipped",
-        "ABORTED": "total_aborted",
-        "WARNING": "total_warnings",
-        "WARNINGS": "total_warnings",
-    }
-    if s in mapping:
-        suite_summary[mapping[s]] += 1
+    _OS_SCHEMA_KEYS = [
+        "total_passed",
+        "total_failed",
+        "total_failed_with_waiver",
+        "total_aborted",
+        "total_skipped",
+        "total_warnings",
+        "total_ignored",
+    ]
+    if "total_failed_with_waivers" in obj and "total_failed_with_waiver" not in obj:
+        obj["total_failed_with_waiver"] = obj.pop("total_failed_with_waivers")
+    for k in list(obj.keys()):
+        if k not in _OS_SCHEMA_KEYS:
+            obj.pop(k, None)
+    for k in _OS_SCHEMA_KEYS:
+        obj.setdefault(k, 0)
 
-def parse_ethtool_test_log(log_data, os_name):
-    results = []
-    test_suite_key = f"ethtool_test_{os_name}"  # e.g., ethtool_test_linux-opensuse-leap-15.5-version
-
-    mapping = {
-        "Test_suite": "Network",
-        "Test_suite_description": "Network validation",
-        "Test_case_description": "Ethernet Tool Tests"
-    }
-
-    suite_summary = {
-        "total_passed": 0,
-        "total_failed": 0,
-        "total_failed_with_waiver": 0,
-        "total_skipped": 0,
-        "total_aborted": 0,
-        "total_warnings": 0,
-        "total_ignored": 0
-    }
-
-    current_test = {
-        "Test_suite": mapping["Test_suite"],
-        "Test_suite_description": mapping["Test_suite_description"],
-        "Test_case": test_suite_key,
-        "Test_case_description": mapping["Test_case_description"],
-        "subtests": [],
-        "test_suite_summary": suite_summary.copy()
-    }
-
-    subtest_number = 1
-    interface = None
-    detected_interfaces = []
-    i = 0
-    while i < len(log_data):
-        line = log_data[i].strip()
-
-        # Detection of Ethernet Interfaces
-        if line.startswith("INFO: Detected following ethernet interfaces via ip command :"):
-            interfaces = []
-            i += 1
-            while i < len(log_data) and log_data[i].strip() and not log_data[i].startswith("INFO"):
-                match = re.match(r'\d+:\s+(\S+)', log_data[i].strip())
-                if match:
-                    interfaces.append(match.group(1))
-                i += 1
-            if interfaces:
-                detected_interfaces = interfaces
-                status = "PASSED"
-                description = f"Detection of Ethernet Interfaces: {', '.join(interfaces)}"
-            else:
-                status = "FAILED"
-                description = "No Ethernet Interfaces Detected"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-            continue
-
-        # Bringing Down Ethernet Interfaces
-        if "INFO: Bringing down all ethernet interfaces using ifconfig" in line:
-            status = "PASSED"
-            description = "Bringing down all Ethernet interfaces"
-            for j in range(i + 1, len(log_data)):
-                if "Unable to bring down ethernet interface" in log_data[j]:
-                    status = "FAILED"
-                    description = "Failed to bring down some Ethernet interfaces"
-                    break
-                if "****************************************************************" in log_data[j]:
-                    break
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # Bringing up interface
-        if "INFO: Bringing up ethernet interface:" in line:
-            interface = line.split(":")[-1].strip()
-            # Check if the interface was brought up successfully
-            if i + 1 < len(log_data) and "Unable to bring up ethernet interface" in log_data[i + 1]:
-                status = "FAILED"
-                description = f"Bring up interface {interface}"
-            else:
-                status = "PASSED"
-                description = f"Bring up interface {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # Running ethtool Command
-        if f"INFO: Running \"ethtool {interface}\" :" in line:
-            status = "PASSED"
-            description = f"Running ethtool on {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # Self-test detection
-        if "INFO: Ethernet interface" in line and "ethtool self test" in line:
-            if "doesn't supports ethtool self test" in line:
-                status = "SKIPPED"
-                desc   = f"Self-test on {interface} (Not supported)"
-            else:
-                # Look ahead up to 20 lines to find "The test result is ..."
-                result_status = None
-                for k in range(i + 1, min(i + 21, len(log_data))):
-                    if "The test result is" in log_data[k]:
-                        result_status = "PASSED" if "PASS" in log_data[k] else "FAILED"
-                        break
-
-                if result_status:
-                    status = result_status
-                    desc   = f"Self-test on {interface}"
-                else:
-                    status = "FAILED"
-                    desc   = f"Self-test on {interface} (Result not found)"
-
-            sub = create_subtest(subtest_number, desc, status)
-            current_test["subtests"].append(sub)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # Link detection
-        if "Link detected:" in line:
-            if "yes" in line:
-                status = "PASSED"
-                description = f"Link detected on {interface}"
-            else:
-                status = "FAILED"
-                description = f"Link not detected on {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # DHCP support
-        if "doesn't support DHCP" in line or "support DHCP" in line:
-            if "doesn't support DHCP" in line:
-                status = "FAILED"
-                description = f"DHCP support on {interface}"
-            else:
-                status = "PASSED"
-                description = f"DHCP support on {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # Ping to router/gateway
-        if "INFO: Ping to router/gateway" in line:
-            if "is successful" in line:
-                status = "PASSED"
-                description = f"Ping to router/gateway on {interface}"
-            else:
-                status = "FAILED"
-                description = f"Ping to router/gateway on {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # --- router/gateway failure variant (from updated ethtool function) ---
-        if "Failed to ping router/gateway" in line:
-            intf = line.split("for")[-1].strip()
-            status = "FAILED"
-            description = f"Ping to router/gateway on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # Ping to www.arm.com
-        if "INFO: Ping to www.arm.com" in line:
-            if "is successful" in line:
-                status = "PASSED"
-                description = f"Ping to www.arm.com on {interface}"
-            else:
-                status = "FAILED"
-                description = f"Ping to www.arm.com on {interface}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # --- www.arm.com failure/success variants (from updated ethtool function) ---
-        if "Failed to ping www.arm.com via" in line:
-            intf = line.split("via")[-1].strip()
-            status = "FAILED"
-            description = f"Ping to www.arm.com on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # >>> Wget checks <<<
-        if "INFO: wget failed to reach https://www.arm.com via" in line:
-            intf = line.split("via")[-1].strip()
-            status = "FAILED"
-            description = f"Wget connectivity to https://www.arm.com on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        if "INFO: wget successfully accessed https://www.arm.com via" in line:
-            intf = line.split("via")[-1].strip()
-            status = "PASSED"
-            description = f"Wget connectivity to https://www.arm.com on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        # >>> Curl checks <<<
-        if "INFO: curl failed to fetch https://www.arm.com via" in line:
-            intf = line.split("via")[-1].strip()
-            status = "FAILED"
-            description = f"Curl connectivity to https://www.arm.com on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        if "INFO: curl successfully fetched https://www.arm.com via" in line:
-            intf = line.split("via")[-1].strip()
-            status = "PASSED"
-            description = f"Curl connectivity to https://www.arm.com on {intf}"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-        i += 1
-
-    # If ping tests were not found, add them as SKIPPED
-    for intf in detected_interfaces:
-        # Check if ping tests for this interface are present
-        ping_to_router_present = any(
-            subtest["sub_Test_Description"] == f"Ping to router/gateway on {intf}"
-            for subtest in current_test["subtests"]
-        )
-        ping_to_arm_present = any(
-            subtest["sub_Test_Description"] == f"Ping to www.arm.com on {intf}"
-            for subtest in current_test["subtests"]
-        )
-        if not ping_to_router_present:
-            # Ping to router/gateway
-            description = f"Ping to router/gateway on {intf}"
-            status = "SKIPPED"
-            subtest = create_subtest(subtest_number, description, status)
-            current_test["subtests"].append(subtest)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-        if not ping_to_arm_present:
-            # Ping to www.arm.com
-            description = f"Ping to www.arm.com on {intf}"
-            status = "SKIPPED"
-            subtest = create_subtest(subtest_number, description, status)
-            update_suite_summary(current_test["test_suite_summary"], status)
-            current_test["subtests"].append(subtest)
-            suite_summary[f"total_{status.lower()}"] += 1
-            subtest_number += 1
-
-    # Finalize results
-    results.append(current_test)
-
-    # --------------------------------------------------------------------------
-    # REMOVE EMPTY REASON ARRAYS IN EACH SUBTEST'S sub_test_result
-    # --------------------------------------------------------------------------
-    for test in results:
-        for subtest in test["subtests"]:
-            subres = subtest["sub_test_result"]
-            if not subres["pass_reasons"]:
-                del subres["pass_reasons"]
-            if not subres["fail_reasons"]:
-                del subres["fail_reasons"]
-            if not subres["abort_reasons"]:
-                del subres["abort_reasons"]
-            if not subres["skip_reasons"]:
-                del subres["skip_reasons"]
-            if not subres["warning_reasons"]:
-                del subres["warning_reasons"]
-
-    return {
-        "test_results": results,
-        "suite_summary": suite_summary
-    }
-
-def parse_log(log_file_path, os_name):
-    with open(log_file_path, 'r') as f:
-        log_data = f.readlines()
-    return parse_ethtool_test_log(log_data, os_name)
-
-if __name__ == "__main__":
+def main():
     if len(sys.argv) != 4:
         print("Usage: python3 logs_to_json.py <path to ethtool_test.log> <output JSON file path> <os_name>")
         sys.exit(1)
 
-    log_file_path = sys.argv[1]
-    output_file_path = sys.argv[2]
+    log_file_path = Path(sys.argv[1]).expanduser().resolve()
+    output_file_path = Path(sys.argv[2]).expanduser().resolve()
     os_name = sys.argv[3]
 
-    try:
-        output_json = parse_log(log_file_path, os_name)
-    except ValueError as ve:
-        print(f"Error: {ve}")
+    if not log_file_path.is_file():
+        print(f"Error: log file not found: {log_file_path}")
         sys.exit(1)
 
-    with open(output_file_path, 'w') as outfile:
-        json.dump(output_json, outfile, indent=4)
+    with open(log_file_path, "r", encoding="utf-8", errors="ignore") as f:
+        log_lines = f.readlines()
 
+    parsed = parse_ethtool_test_log(log_lines)
+
+    # Override test case name for OS schema
+    for test in parsed.get("test_results", []):
+        if isinstance(test, dict) and "Test_case" in test:
+            test["Test_case"] = f"ethtool_test_{os_name}"
+
+    # Normalize suite_summary to OS schema
+    for test in parsed.get("test_results", []):
+        _normalize_suite_summary(test.get("test_suite_summary", {}))
+    _normalize_suite_summary(parsed.get("suite_summary", {}))
+
+    with open(output_file_path, "w", encoding="utf-8") as outfile:
+        json.dump(parsed, outfile, indent=4, ensure_ascii=False)
+
+if __name__ == "__main__":
+    main()

--- a/common/log_parser/os_tests/logs_to_json.py
+++ b/common/log_parser/os_tests/logs_to_json.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,70 +15,385 @@
 # limitations under the License.
 
 import sys
-from pathlib import Path
+import re
 import json
+import os
 
-# Put repo root (parent of "common") on sys.path
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+ansi_escape = re.compile(r'\x1B\[[0-9;]*[A-Za-z]')
 
-try:
-    from common.log_parser.standalone_tests.logs_to_json import parse_ethtool_test_log
-except ImportError as e:
-    raise ImportError(
-        "Could not import parse_ethtool_test_log from common.log_parser.standalone_tests.logs_to_json "
-        "even after adding the repo root to sys.path. Verify the path exists."
-    ) from e
+def create_subtest(subtest_number, description, status, reason=""):
+    result = {
+        "sub_Test_Number": str(subtest_number),
+        "sub_Test_Description": description,
+        "sub_test_result": {
+            "PASSED": 1 if status == "PASSED" else 0,
+            "FAILED": 1 if status == "FAILED" else 0,
+            "ABORTED": 0,
+            "SKIPPED": 1 if status == "SKIPPED" else 0,
+            "WARNINGS": 0,
+            "pass_reasons": [reason] if status == "PASSED" and reason else [],
+            "fail_reasons": [reason] if status == "FAILED" and reason else [],
+            "abort_reasons": [],
+            "skip_reasons": [reason] if status == "SKIPPED" and reason else [],
+            "warning_reasons": []
+        }
+    }
+    return result
 
-def _normalize_suite_summary(obj):
-    if not isinstance(obj, dict):
+def update_suite_summary(suite_summary, status):
+    s = status.strip().upper()
+    if s in ("FAILED (WITH WAIVER)", "FAILED_WITH_WAIVER"):
+        suite_summary["total_failed_with_waiver"] += 1
         return
-    _OS_SCHEMA_KEYS = [
-        "total_passed",
-        "total_failed",
-        "total_failed_with_waiver",
-        "total_aborted",
-        "total_skipped",
-        "total_warnings",
-        "total_ignored",
-    ]
-    if "total_failed_with_waivers" in obj and "total_failed_with_waiver" not in obj:
-        obj["total_failed_with_waiver"] = obj.pop("total_failed_with_waivers")
-    for k in list(obj.keys()):
-        if k not in _OS_SCHEMA_KEYS:
-            obj.pop(k, None)
-    for k in _OS_SCHEMA_KEYS:
-        obj.setdefault(k, 0)
+    mapping = {
+        "PASSED": "total_passed",
+        "FAILED": "total_failed",
+        "SKIPPED": "total_skipped",
+        "ABORTED": "total_aborted",
+        "WARNING": "total_warnings",
+        "WARNINGS": "total_warnings",
+    }
+    if s in mapping:
+        suite_summary[mapping[s]] += 1
 
-def main():
+def parse_ethtool_test_log(log_data, os_name):
+    results = []
+    test_suite_key = f"ethtool_test_{os_name}"  # e.g., ethtool_test_linux-opensuse-leap-15.5-version
+
+    mapping = {
+        "Test_suite": "Network",
+        "Test_suite_description": "Network validation",
+        "Test_case_description": "Ethernet Tool Tests"
+    }
+
+    suite_summary = {
+        "total_passed": 0,
+        "total_failed": 0,
+        "total_failed_with_waiver": 0,
+        "total_skipped": 0,
+        "total_aborted": 0,
+        "total_warnings": 0,
+        "total_ignored": 0
+    }
+
+    current_test = {
+        "Test_suite": mapping["Test_suite"],
+        "Test_suite_description": mapping["Test_suite_description"],
+        "Test_case": test_suite_key,
+        "Test_case_description": mapping["Test_case_description"],
+        "subtests": [],
+        "test_suite_summary": suite_summary.copy()
+    }
+
+    subtest_number = 1
+    interface = None
+    detected_interfaces = []
+    i = 0
+    # strip ANSI codes from the entire log once
+    log_data = [re.sub(ansi_escape, '', s) for s in log_data]
+    while i < len(log_data):
+        line = re.sub(ansi_escape, '', log_data[i]).strip()
+
+        # Detecting interfaces
+        if line.startswith("INFO: No ethernet interfaces detected via ip linux command"):
+            status = "FAILED"
+            desc = "No Ethernet Interfaces Detected"
+            sub = create_subtest(subtest_number, desc, status)
+            current_test["subtests"].append(sub)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+            i += 1
+            continue
+
+        # Detection of Ethernet Interfaces
+        if line.startswith("INFO: Detected following ethernet interfaces via ip command :"):
+            interfaces = []
+            i += 1
+            while i < len(log_data) and log_data[i].strip() and not log_data[i].startswith("INFO"):
+                match = re.match(r'\d+:\s+(\S+)', log_data[i].strip())
+                if match:
+                    interfaces.append(match.group(1))
+                i += 1
+            if interfaces:
+                detected_interfaces = interfaces
+                status = "PASSED"
+                description = f"Detection of Ethernet Interfaces: {', '.join(interfaces)}"
+            else:
+                status = "FAILED"
+                description = "No Ethernet Interfaces Detected"
+            subtest = create_subtest(subtest_number, description, status)
+            current_test["subtests"].append(subtest)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+            continue
+
+        # Bringing Down Ethernet Interfaces
+        if "INFO: Bringing down all ethernet interfaces using ifconfig" in line:
+            status = "PASSED"
+            description = "Bringing down all Ethernet interfaces"
+            for j in range(i + 1, len(log_data)):
+                if "Unable to bring down ethernet interface" in log_data[j]:
+                    status = "FAILED"
+                    description = "Failed to bring down some Ethernet interfaces"
+                    break
+                if "****************************************************************" in log_data[j]:
+                    break
+            subtest = create_subtest(subtest_number, description, status)
+            current_test["subtests"].append(subtest)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        # Bringing up interface
+        if "INFO: Bringing up ethernet interface:" in line:
+            interface = line.split(":")[-1].strip()
+            # Check if the interface was brought up successfully
+            if i + 1 < len(log_data) and "Unable to bring up ethernet interface" in log_data[i + 1]:
+                status = "FAILED"
+                description = f"Bring up interface {interface}"
+            else:
+                status = "PASSED"
+                description = f"Bring up interface {interface}"
+            subtest = create_subtest(subtest_number, description, status)
+            current_test["subtests"].append(subtest)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        # Running ethtool Command
+        if f'INFO: Running "ethtool {interface}' in line:
+            status = "PASSED"
+            description = f"Running ethtool on {interface}"
+            subtest = create_subtest(subtest_number, description, status)
+            current_test["subtests"].append(subtest)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        # Self-test detection
+        if "INFO: Ethernet interface" in line and "ethtool self test" in line:
+            if "doesn't supports ethtool self test" in line:
+                status = "SKIPPED"
+                desc   = f"Self-test on {interface} (Not supported)"
+            else:
+                # Look ahead up to 20 lines to find "The test result is ..."
+                result_status = None
+                for k in range(i + 1, min(i + 21, len(log_data))):
+                    if "The test result is" in log_data[k]:
+                        result_status = "PASSED" if "PASS" in log_data[k] else "FAILED"
+                        break
+
+                if result_status:
+                    status = result_status
+                    desc   = f"Self-test on {interface}"
+                else:
+                    status = "FAILED"
+                    desc   = f"Self-test on {interface} (Result not found)"
+
+            sub = create_subtest(subtest_number, desc, status)
+            current_test["subtests"].append(sub)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        # Link detection
+        if "Link detected:" in line:
+            if "yes" in line:
+                status = "PASSED"
+                description = f"Link detected on {interface}"
+            else:
+                status = "FAILED"
+                description = f"Link not detected on {interface}"
+            subtest = create_subtest(subtest_number, description, status)
+            current_test["subtests"].append(subtest)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        # DHCP support
+        if "doesn't support DHCP" in line or "support DHCP" in line:
+            if "doesn't support DHCP" in line:
+                status = "FAILED"
+                description = f"DHCP support on {interface}"
+            else:
+                status = "PASSED"
+                description = f"DHCP support on {interface}"
+            subtest = create_subtest(subtest_number, description, status)
+            current_test["subtests"].append(subtest)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        # Ping to router/gateway
+        if "INFO: Ping to router/gateway" in line:
+            if "is successful" in line:
+                status = "PASSED"
+                description = f"Ping to router/gateway on {interface}"
+            else:
+                status = "FAILED"
+                description = f"Ping to router/gateway on {interface}"
+            subtest = create_subtest(subtest_number, description, status)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            current_test["subtests"].append(subtest)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        # --- router/gateway failure variant (from updated ethtool function) ---
+        if "Failed to ping router/gateway" in line:
+            intf = line.split("for")[-1].strip()
+            status = "FAILED"
+            description = f"Ping to router/gateway on {intf}"
+            subtest = create_subtest(subtest_number, description, status)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            current_test["subtests"].append(subtest)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        # Ping to www.arm.com
+        if "INFO: Ping to www.arm.com" in line:
+            if "is successful" in line:
+                status = "PASSED"
+                description = f"Ping to www.arm.com on {interface}"
+            else:
+                status = "FAILED"
+                description = f"Ping to www.arm.com on {interface}"
+            subtest = create_subtest(subtest_number, description, status)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            current_test["subtests"].append(subtest)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        # --- www.arm.com failure/success variants (from updated ethtool function) ---
+        if "Failed to ping www.arm.com via" in line:
+            intf = line.split("via")[-1].strip()
+            status = "FAILED"
+            description = f"Ping to www.arm.com on {intf}"
+            subtest = create_subtest(subtest_number, description, status)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            current_test["subtests"].append(subtest)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        # >>> Wget checks <<<
+        if "INFO: wget failed to reach https://www.arm.com via" in line:
+            intf = line.split("via")[-1].strip()
+            status = "FAILED"
+            description = f"Wget connectivity to https://www.arm.com on {intf}"
+            subtest = create_subtest(subtest_number, description, status)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            current_test["subtests"].append(subtest)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        if "INFO: wget successfully accessed https://www.arm.com via" in line:
+            intf = line.split("via")[-1].strip()
+            status = "PASSED"
+            description = f"Wget connectivity to https://www.arm.com on {intf}"
+            subtest = create_subtest(subtest_number, description, status)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            current_test["subtests"].append(subtest)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        # >>> Curl checks <<<
+        if "INFO: curl failed to fetch https://www.arm.com via" in line:
+            intf = line.split("via")[-1].strip()
+            status = "FAILED"
+            description = f"Curl connectivity to https://www.arm.com on {intf}"
+            subtest = create_subtest(subtest_number, description, status)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            current_test["subtests"].append(subtest)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        if "INFO: curl successfully fetched https://www.arm.com via" in line:
+            intf = line.split("via")[-1].strip()
+            status = "PASSED"
+            description = f"Curl connectivity to https://www.arm.com on {intf}"
+            subtest = create_subtest(subtest_number, description, status)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            current_test["subtests"].append(subtest)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+        i += 1
+
+    # If ping tests were not found, add them as SKIPPED
+    for intf in detected_interfaces:
+        # Check if ping tests for this interface are present
+        ping_to_router_present = any(
+            subtest["sub_Test_Description"] == f"Ping to router/gateway on {intf}"
+            for subtest in current_test["subtests"]
+        )
+        ping_to_arm_present = any(
+            subtest["sub_Test_Description"] == f"Ping to www.arm.com on {intf}"
+            for subtest in current_test["subtests"]
+        )
+        if not ping_to_router_present:
+            # Ping to router/gateway
+            description = f"Ping to router/gateway on {intf}"
+            status = "SKIPPED"
+            subtest = create_subtest(subtest_number, description, status)
+            current_test["subtests"].append(subtest)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+        if not ping_to_arm_present:
+            # Ping to www.arm.com
+            description = f"Ping to www.arm.com on {intf}"
+            status = "SKIPPED"
+            subtest = create_subtest(subtest_number, description, status)
+            update_suite_summary(current_test["test_suite_summary"], status)
+            current_test["subtests"].append(subtest)
+            suite_summary[f"total_{status.lower()}"] += 1
+            subtest_number += 1
+
+    # Finalize results
+    results.append(current_test)
+
+    # --------------------------------------------------------------------------
+    # REMOVE EMPTY REASON ARRAYS IN EACH SUBTEST'S sub_test_result
+    # --------------------------------------------------------------------------
+    for test in results:
+        for subtest in test["subtests"]:
+            subres = subtest["sub_test_result"]
+            if not subres["pass_reasons"]:
+                del subres["pass_reasons"]
+            if not subres["fail_reasons"]:
+                del subres["fail_reasons"]
+            if not subres["abort_reasons"]:
+                del subres["abort_reasons"]
+            if not subres["skip_reasons"]:
+                del subres["skip_reasons"]
+            if not subres["warning_reasons"]:
+                del subres["warning_reasons"]
+
+    return {
+        "test_results": results,
+        "suite_summary": suite_summary
+    }
+
+def parse_log(log_file_path, os_name):
+    with open(log_file_path, 'r') as f:
+        log_data = f.readlines()
+    return parse_ethtool_test_log(log_data, os_name)
+
+if __name__ == "__main__":
     if len(sys.argv) != 4:
         print("Usage: python3 logs_to_json.py <path to ethtool_test.log> <output JSON file path> <os_name>")
         sys.exit(1)
 
-    log_file_path = Path(sys.argv[1]).expanduser().resolve()
-    output_file_path = Path(sys.argv[2]).expanduser().resolve()
+    log_file_path = sys.argv[1]
+    output_file_path = sys.argv[2]
     os_name = sys.argv[3]
 
-    if not log_file_path.is_file():
-        print(f"Error: log file not found: {log_file_path}")
+    try:
+        output_json = parse_log(log_file_path, os_name)
+    except ValueError as ve:
+        print(f"Error: {ve}")
         sys.exit(1)
 
-    with open(log_file_path, "r", encoding="utf-8", errors="ignore") as f:
-        log_lines = f.readlines()
-
-    parsed = parse_ethtool_test_log(log_lines)
-
-    # Override test case name for OS schema
-    for test in parsed.get("test_results", []):
-        if isinstance(test, dict) and "Test_case" in test:
-            test["Test_case"] = f"ethtool_test_{os_name}"
-
-    # Normalize suite_summary to OS schema
-    for test in parsed.get("test_results", []):
-        _normalize_suite_summary(test.get("test_suite_summary", {}))
-    _normalize_suite_summary(parsed.get("suite_summary", {}))
-
-    with open(output_file_path, "w", encoding="utf-8") as outfile:
-        json.dump(parsed, outfile, indent=4, ensure_ascii=False)
-
-if __name__ == "__main__":
-    main()
+    with open(output_file_path, 'w') as outfile:
+        json.dump(output_json, outfile, indent=4)


### PR DESCRIPTION
1.log parser correctly remove ansi characters from logs and parse it    
2.OS log parsing now just imports ethtool script from standalone logs_to_json.py    
3.fixed a bug where cause of space and colon "running ethtool " test was not getting parsed    
4.fixed pass+skip= skipped to pass+skip=pass   
5.bbsr extension results shows only once

fix for : #496 (for ansi characters)
 