### PR TITLE
Fix PFDI commit id for v3.1.0 DT release

### DIFF
--- a/common/config/systemready-dt-band-source.cfg
+++ b/common/config/systemready-dt-band-source.cfg
@@ -64,4 +64,5 @@ FWTS_VERSION=25.01.00
 
 #This tag is to download pdfi source from sysarch-acs
 #NOTE: If the value is NULL then the latest sysarch-acs with pfdi branch source will be downloaded
-PFDI_SRC_TAG=""
+# TAG Version - v25.09_PFDI_0.8.0
+PFDI_SRC_TAG="b2bfdbd58c0e3cd67df3a0be3e2e8457c788167c"


### PR DESCRIPTION
PFDI tag v25.09_PFDI_0.8.0 will be used for v3.1.0 release