### PR TITLE
Skip PCIe displayport, mass storage, nic card

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -147,7 +147,7 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
         echo "Running Linux BSA tests"
         insmod /lib/modules/*/kernel/bsa_acs/bsa_acs.ko
         echo "SystemReady devicetree band ACS v3.1.0" > /mnt/acs_results_template/acs_results/linux_acs/bsa_acs_app/BSALinuxResults.log
-        bsa >> /mnt/acs_results_template/acs_results/linux_acs/bsa_acs_app/BSALinuxResults.log
+        bsa --skip-dp-nic-ms >> /mnt/acs_results_template/acs_results/linux_acs/bsa_acs_app/BSALinuxResults.log
         dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results_template/acs_results/linux_acs/bsa_acs_app/BsaResultsKernel.log
         sync /mnt
         sleep 5

--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -189,9 +189,9 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
       insmod /lib/modules/bsa_acs.ko
       echo "SystemReady band ACS v3.0.1" > /mnt/acs_results/linux/BsaResultsApp.log
       if [ "$automation_enabled" == "False" ]; then
-        /bin/bsa >> /mnt/acs_results/linux/BsaResultsApp.log
+        /bin/bsa --skip-dp-nic-ms >> /mnt/acs_results/linux/BsaResultsApp.log
       else
-        $bsa_command >> /mnt/acs_results/linux/BsaResultsApp.log
+        $bsa_command --skip-dp-nic-ms >> /mnt/acs_results/linux/BsaResultsApp.log
       fi
       dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/BsaResultsKernel.log
       sync /mnt
@@ -213,7 +213,7 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
       if [ -f  /lib/modules/sbsa_acs.ko ]; then
         insmod /lib/modules/sbsa_acs.ko
         echo "SystemReady band ACS v3.0.1" > /mnt/acs_results/linux/SbsaResultsApp.log
-        $sbsa_command >> /mnt/acs_results/linux/SbsaResultsApp.log
+        $sbsa_command --skip-dp-nic-ms >> /mnt/acs_results/linux/SbsaResultsApp.log
         dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/SbsaResultsKernel.log
         sync /mnt
         sleep 5


### PR DESCRIPTION
Based on previous certification/complaince inputs, side effects are seen when bsa/sbsa test changes config of PCIe devices whose class code are display port, mass storage, network controller...these devices were skipped at build time for old binaries, with change in in sysarch-acs design to build all at runtime, the test were run on skipped device and caused exception with daily build. Explicitly skipping the devices to retain same run as old binaries.