### PR TITLE
Remove duplicate fwts tests esrt and uefibootpath

### DIFF
--- a/common/config/acs_run_config.ini
+++ b/common/config/acs_run_config.ini
@@ -42,7 +42,7 @@ sbsa_verbose = 3
 # This variable Enable/Disable FWTS run(Valid values true or false).
 automation_fwts_run = true
 # Add modules to run in FWTS command, the modules needs to be seperated by space
-fwts_modules = --uefi-set-var-multiple=1 --uefi-get-mn-count-multiple=1 --sbbr esrt uefibootpath aest cedt slit srat hmat pcct pdtt bgrt bert einj erst hest sdei nfit iort mpam ibft ras2
+fwts_modules = --uefi-set-var-multiple=1 --uefi-get-mn-count-multiple=1 --sbbr aest cedt slit srat hmat pcct pdtt bgrt bert einj erst hest sdei nfit iort mpam ibft ras2
 
 [BBSR_SCT]
 # This variable Enable/Disable BBSR_SCT run(Valid values true or false).

--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -169,7 +169,7 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
     mkdir -p /mnt/acs_results/fwts
     echo "SystemReady band ACS v3.0.1" > /mnt/acs_results/fwts/FWTSResults.log
     if [ "$automation_enabled" == "False" ]; then
-      fwts  -r stdout -q --uefi-set-var-multiple=1 --uefi-get-mn-count-multiple=1 --sbbr esrt uefibootpath aest cedt slit srat hmat pcct pdtt bgrt bert einj erst hest sdei nfit iort mpam ibft ras2 >> /mnt/acs_results/fwts/FWTSResults.log
+      fwts  -r stdout -q --uefi-set-var-multiple=1 --uefi-get-mn-count-multiple=1 --sbbr aest cedt slit srat hmat pcct pdtt bgrt bert einj erst hest sdei nfit iort mpam ibft ras2 >> /mnt/acs_results/fwts/FWTSResults.log
     else
       $fwts_command -r stdout -q >> /mnt/acs_results/fwts/FWTSResults.log
     fi


### PR DESCRIPTION
 - esrt and uefibootpath tests are already part of --sbbr test category of fwts
 - currently they are called twice, once from command line and once from --sbbr tests category