### PR TITLE
refine capsule-on-disk result logic for stricter verdict consistency

### DIFF
--- a/common/log_parser/standalone_tests/logs_to_json.py
+++ b/common/log_parser/standalone_tests/logs_to_json.py
@@ -930,13 +930,12 @@ def parse_capsule_update_logs(capsule_update_log_path, capsule_on_disk_log_path,
                     test_info = "\n".join(info_lines)
                     if "signed_capsule.bin not present" in test_info.lower():
                         result = "FAILED"
+                    elif "uefi capsule update has failed" in test_info.lower():
+                        result = "FAILED"
                     elif "succeed to write signed_capsule.bin" in test_info.lower():
-                        if "uefi capsule update has failed" in test_info.lower():
-                            result = "FAILED"
-                        else:
-                            result = "PASSED"
+                        result = "PASSED"
                     else:
-                        result = "WARNING"
+                        result = "FAILED"
                     break
                 else:
                     i += 1


### PR DESCRIPTION
	-check "UEFI capsule update has failed" explicitly before success; preserve FAIL when both success and failure markers appear
	-Change default outcome from WARNING → FAILED for unrecognized OD results to make reporting stricter and consistent.
	-Keep "signed_capsule.bin not present" as FAILED and only PASS when "succeed to write signed_capsule.bin" is seen without failure indicators.

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com