### PR TITLE
Enable tag-based SBMR-ACS download

### DIFF
--- a/SystemReady-band/build-scripts/get_source.sh
+++ b/SystemReady-band/build-scripts/get_source.sh
@@ -159,9 +159,22 @@ get_bbr_acs_src()
 get_sbmr_acs_src()
 {
     echo "Downloading sbmr-acs source code."
-    git clone --depth 1 https://github.com/ARM-software/sbmr-acs sbmr-acs
+    if [ -z "$SBMR_ACS_TAG" ]; then
+        git clone --depth 1 https://github.com/ARM-software/sbmr-acs sbmr-acs
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to download sbmr-acs source code"
+            exit 1
+        fi
+    else
+        echo "Using SBMR-ACS TAG: $SBMR_ACS_TAG"
+        git clone --depth 1 --branch "$SBMR_ACS_TAG" https://github.com/ARM-software/sbmr-acs sbmr-acs
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to download sbmr-acs source code with tag $SBMR_ACS_TAG"
+            exit 1
+        fi
+    fi
     pushd $TOP_DIR/sbmr-acs
-        git archive --format=tar.gz -o sbmr-acs.tar.gz main
+        git archive --format=tar.gz -o sbmr-acs.tar.gz HEAD
     popd
 }
 

--- a/common/config/systemready-band-source.cfg
+++ b/common/config/systemready-band-source.cfg
@@ -55,6 +55,10 @@ ARM_BBR_TAG="00be42e82452cdad0b862728082568f3d7d2a1c3"
 #NOTE: If the value is NULL then the latest Linux ACS source will be downloaded
 ARM_LINUX_ACS_TAG=""
 
+#Arm SBMR-ACS source tag
+#NOTE: If the value is NULL then the latest SBMR-ACS source will be downloaded
+SBMR_ACS_TAG=""
+
 #Buildroot version used for sbsa7.1
 BUILDROOT_SRC_VERSION=2022.08.1
 


### PR DESCRIPTION
- SystemReady-band/build-scripts/get_source.sh: support SBMR_ACS_TAG
- common/config/systemready-band-source.cfg: add SBMR_ACS_TAG