### PR TITLE
Run SBMR ACS before the hardware tests of xBSA

### DIFF
--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -222,6 +222,7 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
         # display port, mass storage, network controller...SKIP them
         /bin/bsa --skip-dp-nic-ms >> /mnt/acs_results/linux/BsaResultsApp.log
       else
+        echo "Running command $bsa_command --skip-dp-nic-ms"
         $bsa_command --skip-dp-nic-ms  >> /mnt/acs_results/linux/BsaResultsApp.log
       fi
       dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/BsaResultsKernel.log
@@ -244,6 +245,7 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
       if [ -f  /lib/modules/sbsa_acs.ko ]; then
         insmod /lib/modules/sbsa_acs.ko
         echo "SystemReady band ACS v3.1.0" > /mnt/acs_results/linux/SbsaResultsApp.log
+        echo "Running command $sbsa_command --skip-dp-nic-ms"
         $sbsa_command --skip-dp-nic-ms >> /mnt/acs_results/linux/SbsaResultsApp.log
         dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/SbsaResultsKernel.log
         sync /mnt


### PR DESCRIPTION
- Some of xBSA tests are functional tests which leads to interference with SBMR ACS run
- SBMR ACS run previously was a seperate grub menu option
- As SBMR is now integrated with systemready automation grub menu, run it before xbsa acs

Fixes #517 