### PR TITLE
Skip SBSA test 105 from automation run temporary

### DIFF
--- a/common/uefi_scripts/sbsa.nsh
+++ b/common/uefi_scripts/sbsa.nsh
@@ -69,8 +69,8 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                     goto SbsaNormalMode
                 endif
 :SbsaVerboseRun
-                echo "SBSA Command: Sbsa.efi -v 1 -skip 1500 -skip-dp-nic-ms -f SbsaVerboseTempResults.log"
-                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -v 1 -skip 1500 -skip-dp-nic-ms -f SbsaVerboseTempResults.log
+                echo "SBSA Command: Sbsa.efi -v 1 -skip 1500,105 -skip-dp-nic-ms -f SbsaVerboseTempResults.log"
+                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -v 1 -skip 1500,105 -skip-dp-nic-ms -f SbsaVerboseTempResults.log
                 stall 200000
                 if exist FS%i:\acs_results\uefi\SbsaVerboseTempResults.log then
                     echo " SystemReady band ACS v3.1.0" > SbsaVerboseResults.log
@@ -101,16 +101,16 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             endif
 :SbsaNormalRun
             if "%1" == "false" then
-                echo "SBSA Command: Sbsa.efi -skip 1500 -skip-dp-nic-ms -f SbsaTempResults.log"
-                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip 1500 -skip-dp-nic-ms -f SbsaTempResults.log
+                echo "SBSA Command: Sbsa.efi -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log"
+                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log
             else
                 if "%SbsaCommand%" == "" then
                     echo "SbsaCommand variable does not exist, running default command Sbsa.efi -skip 1500"
-                    echo "SBSA Command: Sbsa.efi -skip 1500 -skip-dp-nic-ms -f SbsaTempResults.log"
-                    FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip 1500 -skip-dp-nic-ms -f SbsaTempResults.log
+                    echo "SBSA Command: Sbsa.efi -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log"
+                    FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log
                 else
-                    echo "SBSA Command: %SbsaCommand% -skip-dp-nic-ms -f SbsaTempResults.log"
-                    FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip-dp-nic-ms -f SbsaTempResults.log
+                    echo "SBSA Command: %SbsaCommand% -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log"
+                    FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log
                 endif
             endif
             stall 200000


### PR DESCRIPTION
 - SBSA test 105 is a new test added from latest v3.0.1 release
 - This test is failing on some particular systems and needs to be checked
 - Temp skipping for automation running