### PR TITLE
(fix) Make consistent SRS compliance results summary tittle in console dump and acs summary html

### DIFF
--- a/common/log_parser/merge_jsons.py
+++ b/common/log_parser/merge_jsons.py
@@ -564,11 +564,11 @@ def merge_json_files(json_files, output_file):
 
     acs_results_summary["Overall Compliance Result"] = overall_comp
     if overall_comp.startswith("Not Compliant"):
-        print(f"\n{RED}SRS 3.0 Compliance result: {overall_comp}{RESET}\n")
+        print(f"\n{RED}SRS requirements compliance result: {overall_comp}{RESET}\n")
     elif overall_comp.startswith("Compliant with waivers"):
-        print(f"\n{YELLOW}SRS 3.0 Compliance result: {overall_comp}{RESET}\n")
+        print(f"\n{YELLOW}SRS requirements compliance result: {overall_comp}{RESET}\n")
     else:
-        print(f"\n{GREEN}SRS 3.0 Compliance result: {overall_comp}{RESET}\n")
+        print(f"\n{GREEN}SRS requirements compliance result: {overall_comp}{RESET}\n")
 
     if "Overall Compliance Results" in acs_results_summary:
         del acs_results_summary["Overall Compliance Results"]


### PR DESCRIPTION
Currently the SRS compliance results tittle in console logs is different from the ACS summary html page.

Fixes #524 