### PR TITLE
Dt_validate changes: mark header-only and empty logs as compliant

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -185,11 +185,11 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
           mv /mnt/acs_results_template/acs_results/linux_tools/dt-validate.log /mnt/acs_results_template/acs_results/linux_tools/dt-validate.log.old
         fi
         echo "Running dt-validate tool "
-        echo -e "SystemReady devicetree band ACS v3.1.0 \n DeviceTree bindings of Linux kernel version: 6.16 \ndtschema version: 2025.02  \n\n" > /mnt/acs_results_template/acs_results/linux_tools/dt-validate.log
         dt-validate -s /usr/bin/processed_schema.json -m /home/root/fdt/fdt 2>> /mnt/acs_results_template/acs_results/linux_tools/dt-validate.log
         if [ ! -s /mnt/acs_results_template/acs_results/linux_tools/dt-validate.log ]; then
           echo "The FDT is compliant according to schema " >> /mnt/acs_results_template/acs_results/linux_tools/dt-validate.log
         fi
+        sed -i '1s/^/SystemReady devicetree band ACS v3.1.0 \nDeviceTree bindings of Linux kernel version: 6.16 \ndtschema version: 2025.02 \n\n/' /mnt/acs_results_template/acs_results/linux_tools/dt-validate.log
         # Run dt parser on dt-validate log to categorize failures
         /usr/bin/systemready-scripts/dt-parser.py /mnt/acs_results_template/acs_results/linux_tools/dt-validate.log --print 2>&1 | tee /mnt/acs_results_template/acs_results/linux_tools/dt-validate-parser.log
       else

--- a/common/log_parser/standalone_tests/logs_to_json.py
+++ b/common/log_parser/standalone_tests/logs_to_json.py
@@ -206,6 +206,12 @@ def parse_dt_validate_log(log_data):
 
                 subtest_number += 1
 
+    if not current_test["subtests"]:
+        sub = create_subtest(1, "dt-validate", "PASSED", reason="No warnings or errors")
+        current_test["subtests"].append(sub)
+        current_test["test_suite_summary"]["total_passed"] += 1
+        suite_summary["total_passed"] += 1
+
     # >>> REMOVE EMPTY REASON ARRAYS <<<
     for subtest in current_test["subtests"]:
         subres = subtest["sub_test_result"]
@@ -814,7 +820,7 @@ def parse_read_write_check_blk_devices_log(log_data):
         "suite_summary": suite_summary
     }
 
-# PARSER FOR CAPSULE UPDATE 
+# PARSER FOR CAPSULE UPDATE
 def parse_capsule_update_logs(capsule_update_log_path, capsule_on_disk_log_path, capsule_test_results_log_path):
     test_suite_key = "capsule_update"
     mapping = {
@@ -1113,10 +1119,12 @@ def parse_single_log(log_file_path):
         log_data = f.readlines()
 
     log_content = ''.join(log_data)
+    name = os.path.basename(log_file_path).lower()
 
     if re.search(r'selftests: dt: test_unprobed_devices.sh', log_content):
         return parse_dt_kselftest_log(log_data)
-    elif re.search(r'DeviceTree bindings of Linux kernel version', log_content):
+    elif ('dt-validate' in name
+            or re.search(r'DeviceTree bindings of Linux kernel version', log_content, re.I)):
         return parse_dt_validate_log(log_data)
     elif re.search(r'Running ethtool', log_content):
         return parse_ethtool_test_log(log_data)


### PR DESCRIPTION
	•	Updated `parse_single_log()` to detect dt-validate logs using the file name
	  or new header lines, not just the old "DeviceTree bindings" text.
	•	Added a check in `parse_dt_validate_log()` to mark the test as PASS when
	  there are no errors or warnings.
	•	This makes sure header-only or empty dt-validate logs are treated as
	  Compliant instead of "Not Compliant: Failed 1".


Change-Id: Iafc0ca6b2efab4fd6cd62c75d45653b0e8b6d999