### PR TITLE
Adding system_config.txt copy to ACS result directory

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -362,10 +362,14 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
         fi
       /usr/bin/log_parser/main_log_parser.sh /mnt/acs_results_template/acs_results /mnt/acs_tests/config/acs_config.txt /mnt/acs_tests/config/system_config.txt /mnt/acs_tests/config/acs_waiver.json
       fi
+      mkdir -p /mnt/acs_results_template/acs_results/acs_summary/config
       # Copying acs_waiver.json into result directory.
       if [ -f /mnt/acs_tests/config/acs_waiver.json ]; then
-        mkdir -p /mnt/acs_results_template/acs_results/acs_summary/config
-        cp /mnt/acs_tests/config/acs_waiver.json /mnt/acs_results_template/acs_results/acs_summary/config
+        cp /mnt/acs_tests/config/acs_waiver.json /mnt/acs_results_template/acs_results/acs_summary/config/
+      fi
+      # Copying system_config.txt into result directory
+      if [ -f /mnt/acs_tests/config/system_config.txt ]; then
+        cp /mnt/acs_tests/config/system_config.txt /mnt/acs_results_template/acs_results/acs_summary/config/
       fi
       echo "Please wait acs results are syncing on storage medium."
       sync /mnt

--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -289,10 +289,14 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
   sleep 60
   #copying acs_run_config.ini into results directory.
   mkdir -p /mnt/acs_results/acs_summary/config
-  cp /mnt/acs_tests/config/acs_run_config.ini /mnt/acs_results/acs_summary/config
+  cp /mnt/acs_tests/config/acs_run_config.ini /mnt/acs_results/acs_summary/config/
   # Copying acs_waiver.json into result directory.
   if [ -f /mnt/acs_tests/config/acs_waiver.json ]; then
-    cp /mnt/acs_tests/config/acs_waiver.json /mnt/acs_results/acs_summary/config
+    cp /mnt/acs_tests/config/acs_waiver.json /mnt/acs_results/acs_summary/config/
+  fi
+  # Copying system_config.txt into result directory
+  if [ -f /mnt/acs_tests/config/system_config.txt ]; then
+    cp /mnt/acs_tests/config/system_config.txt /mnt/acs_results/acs_summary/config/
   fi
   sync /mnt
 

--- a/common/linux_scripts/secure_init.sh
+++ b/common/linux_scripts/secure_init.sh
@@ -126,6 +126,18 @@ if [ -d "$RESULTS_DIR" ]; then
       rm -r $RESULTS_DIR/acs_summary
   fi
   /usr/bin/log_parser/main_log_parser.sh $RESULTS_DIR /mnt/acs_tests/config/acs_config.txt /mnt/acs_tests/config/system_config.txt /mnt/acs_tests/config/acs_waiver.json
+  # Creating config directory in the results (secure flow)
+  mkdir -p "$RESULTS_DIR/acs_summary/config"
+  # Copy waiver and system config into results
+  if [ -f /mnt/acs_tests/config/acs_waiver.json ]; then
+    cp /mnt/acs_tests/config/acs_waiver.json "$RESULTS_DIR/acs_summary/config/"
+  fi
+  if [ -f /mnt/acs_tests/config/system_config.txt ]; then
+    cp /mnt/acs_tests/config/system_config.txt "$RESULTS_DIR/acs_summary/config/"
+  fi
+  if [ -f /mnt/acs_tests/config/acs_run_config.ini ]; then
+    cp /mnt/acs_tests/config/acs_run_config.ini "$RESULTS_DIR/acs_summary/config/"
+  fi
   echo "Please wait acs results are syncing on storage medium."
   sync /mnt
   sleep 60


### PR DESCRIPTION
- Copying system_config.txt along with acs_waiver.json and acs_run_config.ini into acs_summary/config for debugging and to keep results self-contained.
- Aligns behavior across secure and non-secure init flows.

Fixes #525 