### PR TITLE
edk2: Update PFDI patch to use BaseFdtLib instead of FdtLib

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/pfdi-acs/files/edk2_pfdi.patch
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/pfdi-acs/files/edk2_pfdi.patch
@@ -35,5 +35,3 @@ index 94d95de0eb..dbd4453044 100644
  
    ShellPkg/Application/Shell/Shell.inf {
      <PcdsFixedAtBuild>
-
-


### PR DESCRIPTION
Replaced FdtLib references with BaseFdtLib for compatibility and to align with the latest edk2 build environment.