### PR TITLE
Add SecureBoot attribute check warning patch

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
@@ -64,6 +64,7 @@ do_configure() {
     cp -r ${S}/bbr-acs/bbsr/sct-tests/PlatformResetAttackMitigationPsciTest uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/
 
     git apply --ignore-whitespace --ignore-space-change ${S}/bbr-acs/bbsr/patches/0001-BBSR-Patch-for-UEFI-SCT-Build.patch
+    git apply --ignore-whitespace --ignore-space-change ${S}/bbr-acs/bbsr/patches/0001-UEFI-SCT-SecureBoot-change-attribute-check-to-warning.patch
 
 }
 


### PR DESCRIPTION
Integrated 0001-UEFI-SCT-SecureBoot-change-attribute-check-to-warning.patch to align with BBSR 1.3 recommendation.
