### PR TITLE
Enable multi-threaded compression for ACS live image

### DIFF
--- a/SystemReady-band/build-scripts/make_image.sh
+++ b/SystemReady-band/build-scripts/make_image.sh
@@ -167,7 +167,7 @@ prepare_disk_image ()
         rm $PLATDIR/$IMG_BB.xz
     fi
     echo "Compressing the image : $PLATDIR/$IMG_BB"
-    xz -z $PLATDIR/$IMG_BB
+    xz -T0 -z $PLATDIR/$IMG_BB
 
     if [ -f $PLATDIR/$IMG_BB.xz ]; then
         echo "Completed preparation of disk image for busybox boot"

--- a/SystemReady-devicetree-band/Yocto/build-scripts/build-systemready-dt-band-live-image.sh
+++ b/SystemReady-devicetree-band/Yocto/build-scripts/build-systemready-dt-band-live-image.sh
@@ -25,7 +25,7 @@ if [ $? -eq 0 ]; then
       cd $TOP_DIR/meta-woden/build/tmp/deploy/images/genericarm64
       rm systemready-dt_acs_live_image.wic.xz 2> /dev/null
       cp woden-image-genericarm64.rootfs.wic systemready-dt_acs_live_image.wic
-      xz -z systemready-dt_acs_live_image.wic
+      xz -T0 -z systemready-dt_acs_live_image.wic
       echo "The built image is at $TOP_DIR/meta-woden/build/tmp/deploy/images/genericarm64/systemready-dt_acs_live_image.wic.xz"
     fi
 fi


### PR DESCRIPTION
Add -T0 parameter to compression tool will reduce lots of waiting time.