### PR TITLE
Changes in dt-validate log parsing

### DIFF
--- a/common/log_parser/standalone_tests/logs_to_json.py
+++ b/common/log_parser/standalone_tests/logs_to_json.py
@@ -149,6 +149,14 @@ def parse_dt_validate_log(log_data):
     test_suite_key = "dt_validate"
     mapping = test_suite_mapping[test_suite_key]
 
+    # Detect if dt-validate crashed with traceback while having no parsed entries
+    saw_traceback = any("Traceback (most recent call last):" in line for line in log_data)
+    no_entries = any(re.search(r"INFO\s+parse:\s*0\s+entries", line) for line in log_data)
+
+    # If both conditions are true, abort immediately — do not create JSON
+    if saw_traceback and no_entries:
+        sys.exit(1)
+
     suite_summary = {
         "total_passed": 0,
         "total_failed": 0,


### PR DESCRIPTION
	•	added detection for Traceback (most recent call last): in dt-validate logs
	•	added condition to check if both traceback and INFO parse: 0 entries exist
	•	modified logic to exit early (sys.exit(1)) without generating JSON when dt-validate crashes
	•	ensured only valid runs with actual validation results or clean passes create JSON output

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com
Change-Id: Ibcf02b76ae5365a2a761f9afb37959f83b1d6363