### PR TITLE
(fix): Match the networking checks heading b/w parser and result log

### DIFF
--- a/common/log_parser/standalone_tests/logs_to_json.py
+++ b/common/log_parser/standalone_tests/logs_to_json.py
@@ -979,7 +979,7 @@ def parse_single_log(log_file_path):
     elif ('dt-validate' in name
             or re.search(r'DeviceTree bindings of Linux kernel version', log_content, re.I)):
         return parse_dt_validate_log(log_data)
-    elif re.search(r'Running ethtool', log_content):
+    elif re.search(r'Running Networking Checks', log_content):
         return parse_ethtool_test_log(log_data)
     elif re.search(r'Read block devices tool', log_content):
         return parse_read_write_check_blk_devices_log(log_data)


### PR DESCRIPTION

- Update the ethtool-test.py result logs heading with log parser

Change-Id: Id20dcdaed119554fda0001cef03b6a40873e3f08