### PR TITLE
Changes in commit log path during build phase

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bootfs-files/bootfs-files.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bootfs-files/bootfs-files.bb
@@ -36,7 +36,7 @@ do_deploy() {
    cp capsule_update.nsh ${DEPLOYDIR}/
    cp bbsr_startup.nsh ${DEPLOYDIR}/
    cp acs_config_dt.txt ${DEPLOYDIR}/acs_config.txt
-   cp systemready-commit.log ${DEPLOYDIR}/
+   cp system_config.txt ${DEPLOYDIR}/
    cp ${S}/../../../armv8a-oe-linux/ebbr-sct/1.0/bbr-acs/bbsr/config/BBSRStartup.nsh  ${DEPLOYDIR}/bbsr_SctStartup.nsh
 
    # create and copy necessary flags to deploy directory

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -382,8 +382,8 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
         cp /mnt/acs_tests/config/system_config.txt /mnt/acs_results_template/acs_results/acs_summary/config/
       fi
       # Copying systemready-commit.log into result directory
-      if [ -f /mnt/acs_tests/config/systemready-commit.log ]; then
-        cp /mnt/acs_tests/config/systemready-commit.log /mnt/acs_results_template/acs_results/acs_summary/config/
+      if [ -f /mnt/acs_tests/systemready-commit.log ]; then
+        cp /mnt/acs_tests/systemready-commit.log /mnt/acs_results_template/acs_results/acs_summary/config/
       fi
       echo "Please wait acs results are syncing on storage medium."
       sync /mnt

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
@@ -39,7 +39,6 @@ IMAGE_EFI_BOOT_FILES += "Bsa.efi;acs_tests/bsa/Bsa.efi \
                          startup.nsh;EFI/BOOT/startup.nsh \
                          acs_config.txt;acs_tests/config/acs_config.txt \
                          system_config.txt;acs_tests/config/system_config.txt \
-                         systemready-commit.log;acs_tests/config/systemready-commit.log \
                          bbsr_startup.nsh;EFI/BOOT/bbsr_startup.nsh \
                          bbsr_SctStartup.nsh;acs_tests/bbr/bbsr_SctStartup.nsh \
                          CapsuleApp.efi;acs_tests/app/CapsuleApp.efi \
@@ -88,6 +87,8 @@ do_dir_deploy() {
     wic cp ${DEPLOY_DIR_IMAGE}/bbr ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/acs_tests/
     wic cp ${DEPLOY_DIR_IMAGE}/bbsr-keys ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/acs_tests/
     wic cp ${DEPLOY_DIR_IMAGE}/core-image-initramfs-boot-genericarm64.cpio.gz ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/
+    # Copy commit file to /acs_tests
+    wic cp ${SYSTEMREADY_COMMIT_LOG} ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/acs_tests/
 
     do_sign_images;
 
@@ -153,8 +154,6 @@ do_dir_deploy() {
     # remove additional startup.nsh from /boot partition
     wic rm ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/startup.nsh
 
-   # Copy commit file to deploy dir
-   cp ${SYSTEMREADY_COMMIT_LOG} ${DEPLOYDIR}/
 
 }
 

--- a/common/linux_scripts/secure_init.sh
+++ b/common/linux_scripts/secure_init.sh
@@ -139,8 +139,8 @@ if [ -d "$RESULTS_DIR" ]; then
     cp /mnt/acs_tests/config/acs_run_config.ini "$RESULTS_DIR/acs_summary/config/"
   fi
   # Copying systemready-commit.log into result directory
-  if [ -f /mnt/acs_tests/config/systemready-commit.log ]; then
-    cp /mnt/acs_tests/config/systemready-commit.log "$RESULTS_DIR/acs_summary/config/"
+  if [ -f /mnt/acs_tests/systemready-commit.log ]; then
+    cp /mnt/acs_tests/systemready-commit.log "$RESULTS_DIR/acs_summary/config/"
   fi
 
   echo "Please wait acs results are syncing on storage medium."


### PR DESCRIPTION
- Modified the logic to directly copy commit log from source during last recipe woden-image.bb build to get commit details on other test suites
- For dt-validate run as part of post script, generated .stamp to avoid cache regen