### PR TITLE
shipping cpufreq/cppc_cpufreq.ko driver to SR ACS image

### DIFF
--- a/SystemReady-band/build-scripts/build-linux.sh
+++ b/SystemReady-band/build-scripts/build-linux.sh
@@ -129,6 +129,8 @@ do_package ()
     cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/char/tpm/tpm_tis_spi.ko $TOP_DIR/ramdisk/drivers
     cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/char/tpm/tpm_tis_i2c_cr50.ko $TOP_DIR/ramdisk/drivers
     cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/spi/spi-tegra210-quad.ko $TOP_DIR/ramdisk/drivers
+    cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/drivers/cpufreq/cppc_cpufreq.ko $TOP_DIR/ramdisk/drivers
+
 }
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )

--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -49,6 +49,7 @@ echo "Starting disk drivers"
 insmod /lib/modules/xhci-pci-renesas.ko
 insmod /lib/modules/nvme-core.ko
 insmod /lib/modules/nvme.ko
+insmod /lib/modules/cppc_cpufreq.ko
 
 sleep 5
 


### PR DESCRIPTION
- CONFIG_ACPI_CPPC_CPUFREQ is built as part of SR ACS image 
- shipping cpufreq/cppc_cpufreq.ko driver to SR ACS image