### PR TITLE
(improv) Readme refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,35 +32,6 @@ The SystemReady BBSR tests if the firmware meets the requirements specified by t
 
 For further details on BBSR ACS, please refer to [BBSR ACS Verification Guide](./docs/BBSR_ACS_Verification.md).
 
-## Limitations
-
-### BSA
-Validating the compliance of certain PCIe rules defined in the BSA specification require the PCIe end-point generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
-The details of the hardware or Verification IP which enable these exerciser tests platform specific and are beyond the scope of this document.
-
-The ACS image does not allow customizations, hence, the exerciser module is not included in the ACS image. To enable exerciser tests for greater coverage of PCIe rules, please refer to [BSA](https://github.com/ARM-software/bsa-acs) Or contact your Arm representative for details.
-
-### SBSA
-Validating the compliance of certain PCIe rules defined in the SBSA specification requires the PCIe end-point to generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
-The details of the hardware or Verification IP which enable these exerciser tests are platform specific and are beyond the scope of this document.
-
- - Some PCIe and Exerciser test are dependent on PCIe features supported by the test system.
-   Please fill the required API's with test system information.
-
-|APIs                         |Description                                                                   |Affected tests          |
-|-----------------------------|------------------------------------------------------------------------------|------------------------|
-|pal_pcie_dev_p2p_support     |Return 0 if the test system PCIe supports peer to peer transaction, else 1    |856, 857                |
-|pal_pcie_is_cache_present    |Return 1 if the test system supports PCIe address translation cache, else 0   |852                     |
-|pal_pcie_get_legacy_irq_map  |Return 0 if system legacy irq map is filled, else 1                           |850                     |
-
-   Below exerciser capabilities are required by exerciser test.
-   - MSI-X interrupt generation.
-   - Incoming Transaction Monitoring(order, type).
-   - Initiating transactions from and to the exerciser.
-   - Ability to check on BDF and register address seen for each configuration address along with access type.
-
- - SBSA Test 803 (Check ECAM Memory accessibility) execution time depends on the system PCIe hierarchy. For systems with multiple ECAMs the time taken to complete can be long which is normal. Please wait until the test completes.
-
 ## License
 
 Arm SystemReady ACS is distributed under Apache v2.0 License.

--- a/SystemReady-band/README.md
+++ b/SystemReady-band/README.md
@@ -1,7 +1,6 @@
 # SystemReady band ACS
 
 ## Table of Contents
-
 - [Introduction](#introduction)
 - [Latest Release details](#latest-release-details)
 - [Prebuilt Images](#prebuilt-images)
@@ -16,6 +15,7 @@
 - [Verification on Arm Neoverse N2 reference design](#verification-on-arm-neoverse-n2-reference-design)
   - [Software stack and Model](#software-stack-and-model)
   - [Model run command](#model-run-command)
+- [Current Limitations](#current-limitations)
 - [Security Implication](#security-implication)
 - [License](#license)
 - [Feedback, contributions, and support](#feedback-contributions-and-support)
@@ -30,10 +30,10 @@ The SystemReady band compliance and testing requirements are specified in the [A
 ## Latest Release details
  - Release version: v3.1.0
  - Quality: EAC
- - **The latest pre-built release of ACS is available for download here: [v25.10_3.1.0](prebuilt_images/v25.10_3.1.0)**
+ - The latest pre-built release of ACS is available for download here: [v25.10_3.1.0](prebuilt_images/v25.10_3.1.0)
  - The compliance suite is not a substitute for design verification.
  - To review the ACS logs, Arm licensees can contact Arm directly through their partner managers.
- - SystemReady-band Image Test Suite details
+ - **Image Test Suite details**
 
 | Test Suite                                                                                   | Test Suite Tag / Commit                                      | Specification Version |
 |----------------------------------------------------------------------------------------------|--------------------------------------------------------------|-----------------------|
@@ -45,17 +45,24 @@ The SystemReady band compliance and testing requirements are specified in the [A
 | [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git)                      | v25.01.00                                                    |                       |
 | [Server Base Manageability Requirements (SBMR)](https://github.com/ARM-software/sbmr-acs)    | 27803824d966df48f34ce5290599f616bc0de8e9                     | SBMR v2.0             |
 
+ - **Image Component details**
 
-## Prebuilt Images
+| Component                                                                   | Version           |
+|-----------------------------------------------------------------------------|-------------------|
+| [Linux Kernel](https://github.com/torvalds/linux.git)                       | v6.10             |
+| [EDK2](https://github.com/tianocore/edk2.git)                               | edk2-stable202508 |
+
+
+### Prebuilt Images
 - Prebuilt images for each release are available in the prebuilt_images folder.To access the prebuilt_images, click [prebuilt_images](prebuilt_images/).
 - The prebuilt images are archived after compression to the .xz format. On Linux, use the xz utility to uncompress the image <br />
   `xz -d  systemready_acs_live_image.img.xz` <br />
    On Windows, use the 7zip or a similar utility.
 - If you choose to use the prebuilt image, skip the build steps and navigate to the [Verification on Arm Neoverse N2 reference design](#verification-on-arm-neoverse-n2-reference-design).
 
-## Steps to Manually Build Image
+### Steps to Manually Build Image
 
-### Prerequisites
+#### Prerequisites
 Before starting the ACS build, ensure that the following requirements are met:
  - Ubuntu 20.04 or later LTS with at least 32GB of free disk space.
  - Use bash shell.
@@ -63,11 +70,11 @@ Before starting the ACS build, ensure that the following requirements are met:
  - Install `git` using `sudo apt install git`
  - `git config --global user.name "Your Name"` and `git config --global user.email "Your Email"` must be configured.
 
-### Code download
+#### Code download
 - To build a release version of the code, checkout the main branch with the appropriate release [tag](https://github.com/ARM-software/arm-systemready/tags).
 - To build the latest version of the code with bug fixes and new features, use the main branch.
 
-### Build Steps
+#### Build Steps
 1. Clone the arm-systemready repository <br />
  `git clone https://github.com/ARM-software/arm-systemready.git`
 
@@ -85,7 +92,7 @@ Before starting the ACS build, ensure that the following requirements are met:
 
 Note: The image is generated in a compressed (.xz) format. The image must be uncompressed before it is used.<br />
 
-### Build output
+#### Build output
 This image comprise of single FAT file system partition recognized by UEFI: <br />
 - 'BOOT_ACS' <br />
   Approximate size: 640 MB <br />
@@ -223,18 +230,15 @@ This image comprise of single FAT file system partition recognized by UEFI: <br 
 - Template of waiver.json can be found [here](https://github.com/ARM-software/arm-systemready/blob/main/docs/example_waiver.json)
 
 ## Verification on Arm Neoverse N2 reference design
-
 Note: UEFI EDK2 setting for "Console Preference": The default is "Graphical". When that is selected, Linux output will goes to the graphical console (HDMI monitor). To force serial console output, you may change the "Console Preference" to "Serial".
 
 ### Software stack and Model
-
 Follow the steps mentioned in [RD-N2 platform software user guide](https://neoverse-reference-design.docs.arm.com/en/latest/platforms/rdn2.html) to obtain RD-N2 FVP.
 
 #### Prerequisites
 sudo permission is required for  building RD-N2 software stack.
 
-#### For software stack build instructions, follow BusyBox Boot link under Supported Features by RD-N2 platform software stack section in the same guide.
-
+#### For software stack build instructions, follow BusyBox Boot link under Supported Features by RD-N2 platform software stack section in the same guide
 Note: After the download of software stack code, please do the below changes before starting the build steps.<br />
 RD-N2 should be built with the GIC changes as mentioned below as applicable.<br />
 - If the system supports LPIs (Interrupt ID > 8192) then firmware should support installation of handler for LPI interrupts.
@@ -248,7 +252,6 @@ RD-N2 should be built with the GIC changes as mentioned below as applicable.<br 
 
 
 ### Model run command
-
 1. Set the environment variable 'MODEL' <br />
   `export MODEL=<absolute path to the RD-N2 FVP binary/FVP_RD_N2>`
 
@@ -272,6 +275,36 @@ The execution continues from the test that is next in sequence of the test prior
 This is expected behavior and the progress of tests will continue after a 20-minute delay.
 
 
+## Current Limitations
+
+### BSA
+Validating the compliance of certain PCIe rules defined in the BSA specification require the PCIe end-point generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
+The details of the hardware or Verification IP which enable these exerciser tests platform specific and are beyond the scope of this document.
+
+The ACS image does not allow customizations, hence, the exerciser module is not included in the ACS image. To enable exerciser tests for greater coverage of PCIe rules, please refer to [SYSARCH-ACS Exerciser Guide](https://github.com/ARM-software/sysarch-acs/blob/main/docs/pcie/Exerciser.md) Or contact your Arm representative for details.
+
+### SBSA
+Validating the compliance of certain PCIe rules defined in the SBSA specification requires the PCIe end-point to generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
+The details of the hardware or Verification IP which enable these exerciser tests are platform specific and are beyond the scope of this document.
+
+ - Some PCIe and Exerciser test are dependent on PCIe features supported by the test system.
+   Please fill the required API's with test system information.
+
+|APIs                         |Description                                                                   |Affected tests          |
+|-----------------------------|------------------------------------------------------------------------------|------------------------|
+|pal_pcie_dev_p2p_support     |Return 0 if the test system PCIe supports peer to peer transaction, else 1    |856, 857                |
+|pal_pcie_is_cache_present    |Return 1 if the test system supports PCIe address translation cache, else 0   |852                     |
+|pal_pcie_get_legacy_irq_map  |Return 0 if system legacy irq map is filled, else 1                           |850                     |
+
+   Below exerciser capabilities are required by exerciser test.
+   - MSI-X interrupt generation.
+   - Incoming Transaction Monitoring(order, type).
+   - Initiating transactions from and to the exerciser.
+   - Ability to check on BDF and register address seen for each configuration address along with access type.
+
+ - SBSA Test 803 (Check ECAM Memory accessibility) execution time depends on the system PCIe hierarchy. For systems with multiple ECAMs the time taken to complete can be long which is normal. Please wait until the test completes.
+
+
 ## Security Implication
 Arm SystemReady band ACS test suite may run at higher privilege level. An attacker may utilize these tests as a means to elevate privilege which can potentially reveal the platform security assets. To prevent the leakage of Secure information, it is strongly recommended that the ACS test suite is run only on development platforms. If it is run on production systems, the system should be scrubbed after running the test suite.
 
@@ -279,7 +312,6 @@ Arm SystemReady band ACS test suite may run at higher privilege level. An attack
 SystemReady ACS is distributed under Apache v2.0 License.
 
 ## Feedback, contributions, and support
-
  - For feedback, use the GitHub Issue Tracker that is associated with this repository.
  - For support, send an email to support-systemready-acs@arm.com with details.
  - Arm licensees can contact Arm directly through their partner managers.

--- a/SystemReady-devicetree-band/README.md
+++ b/SystemReady-devicetree-band/README.md
@@ -1,7 +1,6 @@
 # SystemReady-devicetree band ACS
 
 ## Table of Contents
-
 - [Introduction](#introduction)
 - [Latest Release details](#latest-release-details)
 - [Prebuilt Images](#prebuilt-images)
@@ -15,6 +14,7 @@
 - [Verification on Open-Source FVP](#verification-on-open-source-fvp)
   - [Software stack and Model](#software-stack-and-model)
   - [Model run command](#model-run-command)
+- [Current Limitations](#current-limitations)
 - [Security Implication](#security-implication)
 - [License](#license)
 - [Feedback, contributions, and support](#feedback-contributions-and-support)
@@ -29,10 +29,11 @@ The SystemReady-devicetree band compliance and testing requirements are specifie
 ## Latest Release details
  - Release version: v3.1.0
  - Quality: EAC
- - **The latest pre-built release of SystemReady-devicetree band ACS is available for download here: [v25.10_3.1.0](prebuilt_images/v25.10_3.1.0)**
+ - The latest pre-built release of SystemReady-devicetree band ACS is available for download here: [v25.10_3.1.0](prebuilt_images/v25.10_3.1.0)
  - The compliance suite is not a substitute for design verification.
  - To review the ACS logs, Arm licensees can contact Arm directly through their partner managers.
  - SystemReady-devicetree-band Image Test Suite details
+ - **Image Test Suite details**
 
 | Test Suite                                                                                   | Test Suite Tag/Commit                                        | Specification Version |
 |----------------------------------------------------------------------------------------------|--------------------------------------------------------------|-----------------------|
@@ -43,16 +44,24 @@ The SystemReady-devicetree band compliance and testing requirements are specifie
 | [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git)                      | v25.01.00                                                    |                       |
 | [Platform Fault Detection Interface (PFDI)](https://github.com/ARM-software/sysarch-acs)     | v25.09_PFDI_0.8.0                                            | PFDI v1.0-BETA        |
 
-## Prebuilt images
+- **Image Component details**
+
+| Component                                                                   | Version           |
+|-----------------------------------------------------------------------------|-------------------|
+| [Linux Kernel](https://git.yoctoproject.org/linux-yocto/)                   | v6.12             |
+| [EDK2](https://github.com/tianocore/edk2.git)                               | edk2-stable202508 |
+
+
+### Prebuilt images
 - Prebuilt images for each release are available in the prebuilt_images folder.To access the prebuilt_images, click : [prebuilt_images](prebuilt_images/)
 - The prebuilt images are archived after compression to the .xz format. On Linux, use the xz utility to uncompress the image <br />
   `xz -d systemready-dt_acs_live_image.wic.xz`. <br />
    On Windows, use the 7zip or a similar utility.
 - If you choose to use the prebuilt image, skip the build steps, and navigate to the "Verification" section below.
   
-## Steps to Manually Build Image
+### Steps to Manually Build Image
 
-### Prerequisites
+#### Prerequisites
 Before starting the ACS build, ensure that the following requirements are met:
  - Ubuntu 20.04 or later LTS with at least 32GB of free disk space.
  - Use bash shell.
@@ -60,11 +69,11 @@ Before starting the ACS build, ensure that the following requirements are met:
  - Install `git` using `sudo apt install git`
  - `git config --global user.name "Your Name"` and `git config --global user.email "Your Email"` must be configured.
 
-### Code download
+#### Code download
 - To build a release version of the code, checkout the main branch with the appropriate release [tag](https://github.com/ARM-software/arm-systemready/tags).
 - To build the latest version of the code with bug fixes and new features, use the main branch.
 
-### Build Steps
+#### Build Steps
 1. Clone the arm-systemready repository <br />
  `git clone "https://github.com/ARM-software/arm-systemready.git"`
 
@@ -82,7 +91,7 @@ Before starting the ACS build, ensure that the following requirements are met:
 
 Note: The image is generated in a compressed (.xz) format. The image must be uncompressed before it is used.<br />
 
-### Build output
+#### Build output
 This image comprises of 2 FAT file system partition recognized by UEFI: <br />
 - '/' <br />
   Root partition for Linux which contains test-suites to run in Linux environment. <br/>
@@ -184,7 +193,6 @@ This image comprises of 2 FAT file system partition recognized by UEFI: <br />
  │ Linux Boot                                    │
  │*bbr/bsa                                       │
  │ BBSR Compliance (Automation)                  │
-
 ```
  - **Linux Boot** : This option will boot the ACS Linux kernel and run the default Linux tool (linux debug dump, fwts, linux bsa, linux sbsa (if selected))
    - noacs command line parameter: Edit the Linux Boot grub menu option and add **noacs** at the end of Linux Boot grub menu option, to boot into ACS Linux kernel without running the default Linux test suites.
@@ -216,13 +224,10 @@ This image comprises of 2 FAT file system partition recognized by UEFI: <br />
 - Template of waiver.json can be found [here](https://github.com/ARM-software/arm-systemready/blob/main/docs/example_waiver.json)
 
 ## Verification on Open-Source FVP
-
 Note: The default UEFI EDK2 setting for "Console Preference" is "Graphical". In this default setting, the Linux output goes only to the graphical console (HDMI monitor). To force serial console output, you may change "Console Preference" to "Serial".
 
 ### Software stack and Model
-
 The U-Boot firmware and QEMU can be built with [Buildroot](https://buildroot.org/).
-
 To download and build the firmware code, do the following:
 
 ```
@@ -232,17 +237,13 @@ make qemu_aarch64_ebbr_defconfig
 make
 ```
 
-When the build completes, it generates the firmware file <br />
-`output/images/flash.bin`, comprising TF-A, OP-TEE and the U-Boot bootloader. <br /> 
+When the build completes, it generates the firmware file `output/images/flash.bin`, comprising TF-A, OP-TEE and the U-Boot bootloader.
 A QEMU executable is also generated at `output/host/bin/qemu-system-aarch64`.
 
-Specific information for this Buildroot configuration is available in the file <br />
-`board/qemu/aarch64-ebbr/readme.txt`.
-
-More information on Buildroot is available in [The Buildroot user manual](https://buildroot.org/downloads/manual/manual.html).
+Specific information for this Buildroot configuration is available in the file `board/qemu/aarch64-ebbr/readme.txt`.
+More information on Buildroot is available in [The Buildroot user manual](http://buildroot.org/downloads/manual/manual.html).
 
 ### Model run command
-
 Launch the model using the following command: <br />
 
 ```
@@ -274,7 +275,6 @@ Launch the model using the following command: <br />
 ### Enabling Initcall debug prints in SystemReady-devicetree band Yocto Linux boot
 
 Enabling initcall debug prints allows the kernel to print traces of initcall functions. This feature is not enabled by default, but manually booting Linux with initcall_debug can assist users in debugging kernel issues.
-
 Edit the "Linux boot" boot option by pressing `e` in grub window and append the boot command with following command line options.
 
 ```
@@ -283,6 +283,14 @@ initcall_debug ignore_loglevel=1
 
 Press Ctrl+x to boot the Yocto linux with initcall debug prints enabled.
 
+## Current Limitations
+
+### BSA
+Validating the compliance of certain PCIe rules defined in the BSA specification require the PCIe end-point generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
+The details of the hardware or Verification IP which enable these exerciser tests platform specific and are beyond the scope of this document.
+
+The ACS image does not allow customizations, hence, the exerciser module is not included in the ACS image. To enable exerciser tests for greater coverage of PCIe rules, please refer to [BSA](https://github.com/ARM-software/bsa-acs) Or contact your Arm representative for details.
+
 ## Security Implication
 Arm SystemReady-devicetree band ACS test suite may run at higher privilege level. An attacker may utilize these tests as a means to elevate privilege which can potentially reveal the platform security assets. To prevent the leakage of Secure information, it is strongly recommended that the ACS test suite is run only on development platforms. If it is run on production systems, the system should be scrubbed after running the test suite.
 
@@ -290,7 +298,6 @@ Arm SystemReady-devicetree band ACS test suite may run at higher privilege level
 System Ready ACS is distributed under Apache v2.0 License.
 
 ## Feedback, contributions, and support
-
  - For feedback, use the GitHub Issue Tracker that is associated with this repository.
  - For support, send an email to "support-systemready-acs@arm.com" with details.
  - Arm licensees can contact Arm directly through their partner managers.
@@ -299,4 +306,3 @@ System Ready ACS is distributed under Apache v2.0 License.
 --------------
 
 *Copyright (c) 2022-2025, Arm Limited and Contributors. All rights reserved.*
-


### PR DESCRIPTION

 - component details added in each band readme to highlight linux and edk2
 - limitations moved to each bands to better capture limitations and expand in future to cover all test suites

Fixes #531