### PR TITLE
Updated the BSA/SBSA skip options based on rule based framework

### DIFF
--- a/common/config/acs_run_config.ini
+++ b/common/config/acs_run_config.ini
@@ -20,7 +20,7 @@ bsa_modules =
 # Add tests to run here.
 bsa_tests = 
 # Add tests you want to skip here.
-bsa_skip = 1500
+bsa_skip = 
 # Default value 
 bsa_verbose = 3
 
@@ -34,7 +34,7 @@ sbsa_level = 4
 # Add tests to run here.
 sbsa_tests = 
 # Add tests you want to skip here.
-sbsa_skip = 1500
+sbsa_skip = S_L3MM_01 
 # valid values 1,2,3,4,5
 sbsa_verbose = 3
 

--- a/common/uefi_scripts/bsa.nsh
+++ b/common/uefi_scripts/bsa.nsh
@@ -90,11 +90,11 @@ if exist FS%i:\acs_tests\bsa\Bsa.efi then
         echo "Running BSA in verbose mode"
         if exist FS%i:\acs_tests\bsa\bsa_dt.flag then
             #Executing for BSA SystemReady-devicetree-band. Execute only OS tests
-            echo "BSA Command: Bsa.efi  -v 1 -os -skip 1500 -skip-dp-nic-ms -dtb BsaDevTree.dtb -f BsaVerboseTempResults.log"
-            FS%i:\acs_tests\bsa\Bsa.efi -v 1 -os -skip 1500 -skip-dp-nic-ms -dtb BsaDevTree.dtb -f BsaVerboseTempResults.log
+            echo "BSA Command: Bsa.efi  -v 1 -os -skip-dp-nic-ms -dtb BsaDevTree.dtb -f BsaVerboseTempResults.log"
+            FS%i:\acs_tests\bsa\Bsa.efi -v 1 -os -skip-dp-nic-ms -dtb BsaDevTree.dtb -f BsaVerboseTempResults.log
         else
-            echo "BSA Command: Bsa.efi  -v 1 -skip 1500 -skip-dp-nic-ms -f BsaVerboseTempResults.log"
-            FS%i:\acs_tests\bsa\Bsa.efi -v 1 -skip 1500 -skip-dp-nic-ms -f BsaVerboseTempResults.log
+            echo "BSA Command: Bsa.efi -v 1 -skip-dp-nic-ms -f BsaVerboseTempResults.log"
+            FS%i:\acs_tests\bsa\Bsa.efi -v 1 -skip-dp-nic-ms -f BsaVerboseTempResults.log
         endif
         stall 200000
         if exist BsaVerboseTempResults.log then
@@ -130,16 +130,16 @@ if exist FS%i:\acs_tests\bsa\Bsa.efi then
 :BsaRun
     if exist FS%i:\acs_tests\bsa\bsa_dt.flag then
        #Executing for BSA SystemReady-devicetree-band. Execute only OS tests
-       echo "BSA Command: Bsa.efi  -os -skip 1500 -dtb BsaDevTree.dtb -skip-dp-nic-ms -f BsaTempResults.log"
-       FS%i:\acs_tests\bsa\Bsa.efi -os -skip 1500 -dtb BsaDevTree.dtb -skip-dp-nic-ms -f BsaTempResults.log
+       echo "BSA Command: Bsa.efi -os -dtb BsaDevTree.dtb -skip-dp-nic-ms -f BsaTempResults.log"
+       FS%i:\acs_tests\bsa\Bsa.efi -os -dtb BsaDevTree.dtb -skip-dp-nic-ms -f BsaTempResults.log
     else
         if "%1" == "false" then
-            echo  "BSA Command: Bsa.efi -skip 1500 -skip-dp-nic-ms -f BsaTempResults.log"
-            FS%i:\acs_tests\bsa\Bsa.efi -skip 1500 -skip-dp-nic-ms -f BsaTempResults.log
+            echo  "BSA Command: Bsa.efi -skip-dp-nic-ms -f BsaTempResults.log"
+            FS%i:\acs_tests\bsa\Bsa.efi -skip-dp-nic-ms -f BsaTempResults.log
         else
             if "%BsaCommand%" == "" then
-                echo "BsaCommand variable does not exist, running default command Bsa.efi -skip 1500 -skip-dp-nic-ms -f BsaTempResults.log"
-                FS%i:\acs_tests\bsa\Bsa.efi -skip 1500 -skip-dp-nic-ms -f BsaTempResults.log
+                echo "BsaCommand variable does not exist, running default command Bsa.efi -skip-dp-nic-ms -f BsaTempResults.log"
+                FS%i:\acs_tests\bsa\Bsa.efi -skip-dp-nic-ms -f BsaTempResults.log
             else
                 echo  "BSA Command: %BsaCommand% -skip-dp-nic-ms -f BsaTempResults.log "
                 FS%i:\acs_tests\bsa\%BsaCommand% -skip-dp-nic-ms -f BsaTempResults.log

--- a/common/uefi_scripts/sbsa.nsh
+++ b/common/uefi_scripts/sbsa.nsh
@@ -69,8 +69,8 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                     goto SbsaNormalMode
                 endif
 :SbsaVerboseRun
-                echo "SBSA Command: Sbsa.efi -v 1 -skip 1500,105 -skip-dp-nic-ms -f SbsaVerboseTempResults.log"
-                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -v 1 -skip 1500,105 -skip-dp-nic-ms -f SbsaVerboseTempResults.log
+                echo "SBSA Command: Sbsa.efi -v 1 -skip S_L3MM_01 -skip-dp-nic-ms -f SbsaVerboseTempResults.log"
+                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -v 1 -skip S_L3MM_01 -skip-dp-nic-ms -f SbsaVerboseTempResults.log
                 stall 200000
                 if exist FS%i:\acs_results\uefi\SbsaVerboseTempResults.log then
                     echo " SystemReady band ACS v3.1.0" > SbsaVerboseResults.log
@@ -101,16 +101,16 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             endif
 :SbsaNormalRun
             if "%1" == "false" then
-                echo "SBSA Command: Sbsa.efi -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log"
-                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log
+                echo "SBSA Command: Sbsa.efi -skip S_L3MM_01 -skip-dp-nic-ms -f SbsaTempResults.log"
+                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip S_L3MM_01 -skip-dp-nic-ms -f SbsaTempResults.log
             else
                 if "%SbsaCommand%" == "" then
-                    echo "SbsaCommand variable does not exist, running default command Sbsa.efi -skip 1500"
-                    echo "SBSA Command: Sbsa.efi -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log"
-                    FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log
+                    echo "SbsaCommand variable does not exist, running default command Sbsa.efi"
+                    echo "SBSA Command: Sbsa.efi -skip S_L3MM_01 -skip-dp-nic-ms -f SbsaTempResults.log"
+                    FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip S_L3MM_01 -skip-dp-nic-ms -f SbsaTempResults.log
                 else
-                    echo "SBSA Command: %SbsaCommand% -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log"
-                    FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip 1500,105 -skip-dp-nic-ms -f SbsaTempResults.log
+                    echo "SBSA Command: %SbsaCommand% -skip S_L3MM_01 -skip-dp-nic-ms -f SbsaTempResults.log"
+                    FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip S_L3MM_01 -skip-dp-nic-ms -f SbsaTempResults.log
                 endif
             endif
             stall 200000


### PR DESCRIPTION
- xbsa has moved to rule based orchestrator, scripts needs to be updated to skip based on rule id from test id
- exerciser module can't be skipped currently, so remove -skip 1500