### PR TITLE
Enhanced BBSR compliance reporting to show mandatory suite details seperately

### DIFF
--- a/common/log_parser/merge_jsons.py
+++ b/common/log_parser/merge_jsons.py
@@ -680,19 +680,16 @@ def merge_json_files(json_files, output_file):
             elif "waiver" in low:
                 waiver_seen = True
 
-        if non_waived_list_bbsr:
-            parts = []
+        if non_waived_list_bbsr or missing_list_bbsr:
+            bbsr_comp = "Not Compliant"
+            reason_parts = []
             if missing_list_bbsr:
-                parts.append(f"missing suite(s): {', '.join(missing_list_bbsr)}")
+                reason_parts.append(f"not run: {', '.join(missing_list_bbsr)}")
             if non_waived_list_bbsr:
-                parts.append(f"non-waived fails in suite(s): {', '.join(non_waived_list_bbsr)}")
-            acs_results_summary["BBSR compliance results"] = (
-                "Not Compliant" + (f" ({'; '.join(parts)})" if parts else "")
-            )
-        elif missing_list_bbsr:
-            acs_results_summary["BBSR compliance results"] = (
-                f"Not Compliant (missing suite(s): {', '.join(missing_list_bbsr)})"
-            )
+                reason_parts.append(f"failed: {', '.join(non_waived_list_bbsr)}")
+            if reason_parts:
+                bbsr_comp += f" : Mandatory - ({'; '.join(reason_parts)})"
+            acs_results_summary["BBSR compliance results"] = bbsr_comp
         elif waiver_seen:
             acs_results_summary["BBSR compliance results"] = "Compliant with waivers"
         else:


### PR DESCRIPTION
- Modified merge_jsons.py to format BBSR results with mandatory suite breakdown
- Updated BBSR Compliance Result format: "Not Compliant : Mandatory - (not run: X; failed: Y)"
- Enhanced generate_acs_summary.py to parse new BBSR compliance format with regex extraction
- Redesigned HTML table to display BBSR compliance results in separate rows for main status and mandatory issues
- Added red color coding for mandatory failure rows in BBSR section
- Provides partners complete transparency on BBSR extension test status for better analysis and prioritization
- Format matches overall compliance structure for consistency across the report

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com
Change-Id: I63d60ca56f6ed2e1cd6c69234a076437f20c4d4f