### PR TITLE
feat: Add network boot support to systmeready dt using ledge application

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/kas/woden.yml
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/kas/woden.yml
@@ -27,6 +27,12 @@ repos:
       meta-perl:
       meta-python:
 
+  meta-clang:
+    url: https://github.com/kraj/meta-clang.git
+    refspec: scarthgap
+    layers:
+      .:
+
   meta-secure-core:
     url: https://github.com/Wind-River/meta-secure-core
     refspec: scarthgap

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bootfs-files/bootfs-files.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bootfs-files/bootfs-files.bb
@@ -11,6 +11,7 @@ SRC_URI = " file://bsa.nsh \
             file://debug_dump.nsh \
             file://startup.nsh \
             file://pingtest.nsh \
+            file://https_boot.nsh \
             file://capsule_update.nsh \
             file://bbsr_startup.nsh \
             file://acs_config_dt.txt \
@@ -33,6 +34,7 @@ do_deploy() {
    cp debug_dump.nsh ${DEPLOYDIR}/
    cp startup.nsh ${DEPLOYDIR}/
    cp pingtest.nsh ${DEPLOYDIR}/
+   cp https_boot.nsh ${DEPLOYDIR}/
    cp capsule_update.nsh ${DEPLOYDIR}/
    cp bbsr_startup.nsh ${DEPLOYDIR}/
    cp acs_config_dt.txt ${DEPLOYDIR}/acs_config.txt

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/acs_https_network_boot.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/acs_https_network_boot.sh
@@ -1,0 +1,198 @@
+#!/bin/sh
+
+# @file
+# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# HTTPS/HTTP Network Boot preparation script for SystemReady-devicetree-band
+# - Reads HTTPS_BOOT_IMAGE_URL from /mnt/acs_tests/config/system_config.txt
+# - Ensures a system ESP exists
+# - Checks URL reachability with wget --spider
+# - Writes acs_https.conf.nsh for https_boot.nsh / ledge.efi
+# - Sets https_boot_pending.flag and reboots (only on full success)
+
+echo "============== Starting Network Boot Checks =============="
+
+HTTPS_CONFIG_DIR="/mnt/acs_tests/config"
+HTTPS_FLAG_DIR="/mnt/acs_tests/app"
+SYSTEM_CONFIG_FILE="${HTTPS_CONFIG_DIR}/system_config.txt"
+HTTPS_CONF_NSH="${HTTPS_CONFIG_DIR}/acs_https.conf.nsh"
+HTTPS_PENDING_FLAG="${HTTPS_FLAG_DIR}/https_boot_pending.flag"
+
+RESULTS_DIR="/mnt/acs_results_template/acs_results/network_boot"
+RESULTS_LOG="${RESULTS_DIR}/network_boot_results.log"
+
+detect_system_esp() {
+    # GPT partition type GUID for EFI System Partition (ESP)
+    ESP_GUID="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+
+    # Return 0 if at least one system ESP is detected
+    if command -v lsblk >/dev/null 2>&1; then
+        ESP_LINES="$(lsblk -rno NAME,PARTTYPE,PARTLABEL,MOUNTPOINT 2>/dev/null \
+            | awk 'tolower($0) !~ /boot_acs/ && (tolower($2) ~ /'"$ESP_GUID"'/ || tolower($3) ~ /efi system partition/ || tolower($4) ~ /\/boot\/efi|\/efi/ )')"
+        if [ -n "${ESP_LINES}" ]; then
+            echo "Detected potential system ESP partition(s):"
+            echo "${ESP_LINES}"
+            return 0
+        fi
+    fi
+
+    if command -v blkid >/dev/null 2>&1; then
+        ESP_BLKID="$(blkid 2>/dev/null | grep -vi 'BOOT_ACS' | grep -Ei "EFI System Partition|PARTUUID=.*$ESP_GUID")"
+        if [ -n "${ESP_BLKID}" ]; then
+            echo "Detected potential system ESP via blkid:"
+            echo "${ESP_BLKID}"
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+main() {
+    mkdir -p "${RESULTS_DIR}"
+    : > "${RESULTS_LOG}"
+    {
+        echo "[INFO] network_boot_checks"
+        date
+    } >> "${RESULTS_LOG}"
+
+    # Check BOOT_ACS mount
+    if ! mountpoint -q /mnt ; then
+        echo "/mnt is not a mountpoint; cannot access acs_tests/config, skipping Network boot setup."
+        {
+            echo "BOOT_ACS mount: FAILED (/mnt is not available; cannot access ACS configuration)"
+            echo "Network_Boot_Result: FAILED"
+        } >> "${RESULTS_LOG}"
+        return 0
+    fi
+
+    # Check system_config.txt
+    if [ ! -f "${SYSTEM_CONFIG_FILE}" ]; then
+        echo "system_config.txt not found at ${SYSTEM_CONFIG_FILE}; skipping Network boot setup."
+        {
+            echo "system_config.txt: FAILED ( not found at ${SYSTEM_CONFIG_FILE})"
+            echo "Network_Boot_Result: FAILED"
+        } >> "${RESULTS_LOG}"
+        return 0
+    fi
+
+    # Extract HTTPS_BOOT_IMAGE_URL
+    IMAGE_URL="$(grep -E '^[[:space:]]*HTTPS_BOOT_IMAGE_URL=' "${SYSTEM_CONFIG_FILE}" \
+                 | grep -v '^[[:space:]]*#' \
+                 | head -n 1 \
+                 | sed -e 's/^[[:space:]]*HTTPS_BOOT_IMAGE_URL=//' -e 's/^[[:space:]]*//')"
+
+    if [ -z "${IMAGE_URL}" ]; then
+        echo "HTTPS_BOOT_IMAGE_URL not set or commented in system_config.txt; skipping Network boot setup."
+        {
+            echo "Image URL: FAILED (not found or is commented out in system_config.txt)"
+            echo "Network_Boot_Result: FAILED"
+        } >> "${RESULTS_LOG}"
+        return 0
+    fi
+
+    echo "Found HTTPS_BOOT_IMAGE_URL=${IMAGE_URL} in system_config.txt"
+    echo "Image URL: PASSED (URL Found: ${IMAGE_URL})" >> "${RESULTS_LOG}"
+
+    # Ensure system ESP exists
+    if ! detect_system_esp; then
+        echo "ERROR: No EFI System Partition (ESP) detected on the system."
+        echo "Cannot proceed with network boot: ESP partition is a requirement."
+        {
+            echo "EFI System Partition (ESP): FAILED (not detected on the system; network boot requires a valid ESP)"
+            echo "Network_Boot_Result: FAILED"
+        } >> "${RESULTS_LOG}"
+        return 0
+    fi
+
+    echo "EFI System Partition (ESP): PASSED (detected ESP on the system)" >> "${RESULTS_LOG}"
+
+    # Parse scheme and hostpath
+    case "${IMAGE_URL}" in
+        http://* )
+            HTTPS_IMAGE_SCHEME="http"
+            HTTPS_IMAGE_HOSTPATH="${IMAGE_URL#http://}"
+            ;;
+        https://* )
+            HTTPS_IMAGE_SCHEME="https"
+            HTTPS_IMAGE_HOSTPATH="${IMAGE_URL#https://}"
+            ;;
+        * )
+            echo "Unsupported URL scheme in ${IMAGE_URL}. Expected http:// or https://"
+            {
+                echo "URL scheme: FAILED ( Unsupported URL in HTTPS_BOOT_IMAGE_URL (${IMAGE_URL}), expected http:// or https://)"
+                echo "Network_Boot_Result: FAILED"
+            } >> "${RESULTS_LOG}"
+            return 0
+            ;;
+    esac
+
+    if [ -z "${HTTPS_IMAGE_HOSTPATH}" ]; then
+        echo "Parsed HOSTPATH is empty, unable to configure Network boot."
+        {
+            echo "Image HOSTPATH: FAILED (Image URL is empty, cannot construct network boot URL)"
+            echo "Network_Boot_Result: FAILED"
+        } >> "${RESULTS_LOG}"
+        return 0
+    fi
+
+    echo "Image HOSTPATH: PASSED (Image URL is Valid)" >> "${RESULTS_LOG}"
+
+    # Wget reachability check
+    if command -v wget >/dev/null 2>&1; then
+        echo "Checking URL reachability with wget --spider: ${IMAGE_URL}"
+        if wget --spider --timeout=20 -q "${IMAGE_URL}"; then
+            echo "URL is accessible through wget."
+	    echo "Wget check on URL: PASSED (URL is reachable using wget --spider)" >> "${RESULTS_LOG}"
+        else
+            echo "WARNING: URL is NOT accessible through wget (wget --spider failed)."
+            {
+                echo "wget check on URL: FAILED (URL is not accessible using wget --spider)"
+                echo "Network_Boot_Result: FAILED"
+            } >> "${RESULTS_LOG}"
+            return 0
+        fi
+	fi
+
+    # Prepare https config and flag for UEFI https_boot.nsh
+    mkdir -p "${HTTPS_CONFIG_DIR}" "${HTTPS_FLAG_DIR}"
+
+    cat > "${HTTPS_CONF_NSH}" <<EOF
+# Auto-generated by acs_https_network_boot.sh for HTTPS/HTTP network boot
+set HTTPS_IMAGE_URL ${IMAGE_URL}
+set HTTPS_IMAGE_HOSTPATH ${HTTPS_IMAGE_HOSTPATH}
+set HTTPS_IMAGE_SCHEME ${HTTPS_IMAGE_SCHEME}
+EOF
+
+    sync
+
+    # Set flag for UEFI startup_dt.nsh to run https_boot.nsh on next boot
+    : > "${HTTPS_PENDING_FLAG}"
+    echo "Created flag ${HTTPS_PENDING_FLAG}"
+    echo "Rebooting system for Network boot via UEFI shell"
+    sync
+    sleep 5
+
+    if command -v reboot >/dev/null 2>&1; then
+        reboot -f
+    elif command -v systemctl >/dev/null 2>&1; then
+        systemctl reboot --force
+    else
+        echo b > /proc/sysrq-trigger
+    fi
+}
+
+main "$@"

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/acs_network_boot_parser.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/acs_network_boot_parser.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+# @file
+# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Ensure logs are created by minimal image
+
+RESULTS_DIR="/mnt/acs_results_template/acs_results/network_boot"
+RESULTS_LOG="${RESULTS_DIR}/network_boot_results.log"
+
+status="PASSED"
+
+mkdir -p "${RESULTS_DIR}"
+
+# Linux results log must exist
+if [ ! -f "${RESULTS_LOG}" ]; then
+    echo "network_boot_results.log: FAILED (not found under ${RESULTS_DIR})" | tee -a "${RESULTS_LOG}"
+    echo "Network_Boot_Result: FAILED" | tee -a "${RESULTS_LOG}"
+    exit 0
+fi
+
+cat "${RESULTS_LOG}"
+echo
+# Check LSBLK/BLKID/DMESG log presence
+if [ "${status}" = "PASSED" ]; then
+    if [ -f "${RESULTS_DIR}/lsblk.txt" ] && \
+       [ -f "${RESULTS_DIR}/blkid.txt" ] && \
+       [ -f "${RESULTS_DIR}/dmesg.txt" ]; then
+
+        echo "Logs captured: PASSED (lsblk, blkid and dmesg logs exist)" | tee -a "${RESULTS_LOG}"
+
+    else
+        echo "Logs captured: FAILED (expected lsblk.txt, blkid.txt, dmesg.txt)" \
+        | tee -a "${RESULTS_LOG}"
+
+        status="FAILED"
+    fi
+fi
+
+echo
+
+# Final PASS/FAIL result
+if [ "${status}" = "PASSED" ]; then
+    echo "Network_Boot_Result: PASSED" | tee -a "${RESULTS_LOG}"
+else
+    echo "Network_Boot_Result: FAILED" | tee -a "${RESULTS_LOG}"
+fi

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/systemd-init-install.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/systemd-init-install.bb
@@ -12,6 +12,8 @@ SRC_URI:append = " file://acs_run-before-login-prompt.service \
                    file://ethtool-test.py \
                    file://read_write_check_blk_devices.py \
                    file://device_driver_info.sh \
+                   file://acs_https_network_boot.sh \
+                   file://acs_network_boot_parser.sh \
                    file://log_parser \
                  "
 
@@ -32,5 +34,7 @@ do_install:append() {
   install -m 0770 ${WORKDIR}/ethtool-test.py                     ${D}${bindir}
   install -m 0770 ${WORKDIR}/read_write_check_blk_devices.py     ${D}${bindir}
   install -m 0770 ${WORKDIR}/device_driver_info.sh               ${D}${bindir}
+  install -m 0770 ${WORKDIR}/acs_https_network_boot.sh           ${D}${bindir}
+  install -m 0770 ${WORKDIR}/acs_network_boot_parser.sh          ${D}${bindir}
   cp -r ${WORKDIR}/log_parser                                    ${D}${bindir}/
 }

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/ledge-efi/files/ledge-efi-http-label.patch
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/ledge-efi/files/ledge-efi-http-label.patch
@@ -1,0 +1,64 @@
+diff --git a/efi_app/main.c b/efi_app/main.c
+index f47a19a..36e2885 100644
+--- a/efi_app/main.c
++++ b/efi_app/main.c
+@@ -13,13 +13,12 @@ static const struct efi_device_path END = {
+         .length   = sizeof(END),
+ };
+ 
+-static efi_status_t do_http_boot(efi_system_table *st, u16 *host, u32 args)
++static efi_status_t do_http_boot(efi_system_table *st, u16 *host, u16 *label, u32 args)
+ {
+ 	efi_guid_t glob_var_guid = EFI_GLOBAL_VARIABLE_GUID;
+ 	efi_guid_t rng_guid = EFI_RNG_PROTOCOL_GUID;
+ 	struct efi_device_path_uri *uridp;
+ 	efi_status_t ret = EFI_SUCCESS;
+-	u16 *label = u"LEDGE Image";
+ 	unsigned long data_len = 0;
+ 	struct efi_load_option lo;
+ 	efi_rng_protocol_t *rng;
+@@ -189,10 +188,11 @@ static void print_usage(void)
+ {
+ 	glob_st->con_out->output_string(glob_st->con_out, L"-h: help\n");
+ 	glob_st->con_out->output_string(glob_st->con_out, L"-u: URL of iso\n");
++	glob_st->con_out->output_string(glob_st->con_out, L"-l: Label for HTTP boot option\n");
+ 	glob_st->con_out->output_string(glob_st->con_out, L"-f: force HTTP\n");
+-	glob_st->con_out->output_string(glob_st->con_out, L"-b: Don't reboot automatcaily after adding HTTP options\n");
++	glob_st->con_out->output_string(glob_st->con_out, L"-b: Don't reboot automatically after adding HTTP options\n");
+ 	glob_st->con_out->output_string(glob_st->con_out, L"-k: Print Kernel version after http tests to trick LAVA\n");
+-	glob_st->con_out->output_string(glob_st->con_out, L"-s: Skip secire boot testing\n");
++	glob_st->con_out->output_string(glob_st->con_out, L"-s: Skip secure boot testing\n");
+ }
+ 
+ efi_status_t efi_main(void *handle, efi_system_table *st)
+@@ -201,6 +201,7 @@ efi_status_t efi_main(void *handle, efi_system_table *st)
+ 	u16 **argv = NULL;
+ 	u64 argc = 0;
+ 	u16 *host = L"validation-linaro-org.s3.eu-west-1.amazonaws.com/testdata/ledge/core-image-base-genericarm64.rootfs.img";
++	u16 *label = u"LEDGE Image";
+ 	int i;
+ 	u32 http_args = 0;
+ 	bool print_kmsg = false;
+@@ -231,6 +232,14 @@ efi_status_t efi_main(void *handle, efi_system_table *st)
+ 				st->con_out->output_string(st->con_out, L"Error: -u requires a URL\n");
+ 				return 1;
+ 			}
++		} else if (!u16_strcmp(argv[i], L"-l")) {
++			if (i + 1 < argc) {
++				label = argv[i + 1];
++				i++;
++			} else {
++				st->con_out->output_string(st->con_out, L"Error: -l requires a label\n");
++				return 1;
++			}
+ 		} else {
+ 			st->con_out->output_string(st->con_out, L"Unknown argument\n");
+ 			print_usage();
+@@ -249,7 +258,7 @@ efi_status_t efi_main(void *handle, efi_system_table *st)
+ 	if (ret != EFI_SUCCESS)
+ 		goto out;
+ 
+-	ret = do_http_boot(st, host, http_args);
++	ret = do_http_boot(st, host, label, http_args);
+ 	if (print_kmsg)
+ 		st->con_out->output_string(st->con_out, L"Tricking fastboot LAVA ... Linux version 1980\n");

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/ledge-efi/ledge-efi_git.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/ledge-efi/ledge-efi_git.bb
@@ -1,0 +1,29 @@
+SUMMARY = "Build ledge.efi from ts-testing repo and deploy for image use"
+LICENSE = "CLOSED"
+inherit deploy
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/:"
+
+# ts-testing repo
+SRC_URI = "git://gitlab.com/Linaro/trustedsubstrate/ts-testing.git;protocol=https;branch=main \
+           file://ledge-efi-http-label.patch \
+          "
+
+SRCREV = "${AUTOREV}"
+S = "${WORKDIR}/git"
+
+# Use host-side toolchain to emit a PE/COFF EFI application
+DEPENDS = "clang-native"
+
+do_compile() {
+    oe_runmake -C ${S}/efi_app
+}
+
+do_install[noexec] = "1"
+
+do_deploy() {
+    install -d ${DEPLOYDIR}
+    install -m 0644 ${S}/efi_app/ledge.efi ${DEPLOYDIR}/ledge.efi
+}
+
+addtask deploy after do_compile before do_build

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
@@ -22,6 +22,7 @@ IMAGE_INSTALL = "packagegroup-core-boot \
 EXTRA_IMAGEDEPENDS += "bsa-acs \
                        shell-app \
                        uefi-apps \
+                       ledge-efi \
                        update-vars \
                        ebbr-sct \
                        bootfs-files \
@@ -31,6 +32,8 @@ IMAGE_EFI_BOOT_FILES += "Bsa.efi;acs_tests/bsa/Bsa.efi \
                          bsa.nsh;acs_tests/bsa/bsa.nsh \
                          pfdi.efi;acs_tests/pfdi/pfdi.efi \
                          pfdi.nsh;acs_tests/pfdi/pfdi.nsh \
+                         https_boot.nsh;acs_tests/app/https_boot.nsh \
+                         ledge.efi;acs_tests/app/ledge.efi \
                          pingtest.nsh;acs_tests/debug/pingtest.nsh \
                          capsule_update.nsh;acs_tests/app/capsule_update.nsh \
                          bsa_dt.flag;acs_tests/bsa/bsa_dt.flag \
@@ -68,6 +71,12 @@ do_sign_images() {
     sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT DO_SIGN/acs_tests/app/CapsuleApp.efi --output DO_SIGN/acs_tests/app/CapsuleApp.efi
     sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT DO_SIGN/acs_tests/app/UpdateVars.efi --output DO_SIGN/acs_tests/app/UpdateVars.efi
     sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT DO_SIGN/Image --output DO_SIGN/Image
+
+    if [ -f DO_SIGN/acs_tests/app/ledge.efi ]; then
+        sbsign --key $TEST_DB1_KEY --cert $TEST_DB1_CRT DO_SIGN/acs_tests/app/ledge.efi --output DO_SIGN/acs_tests/app/ledge.efi
+    else
+        echo "WARNING: ledge.efi not found for signing (skipping)"
+    fi
 
     echo "Signing images complete."
     wic cp DO_SIGN/EFI ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.wic:1/

--- a/common/config/system_config.txt
+++ b/common/config/system_config.txt
@@ -8,3 +8,8 @@ Testlab assistance: Unknown
 
 #Add the number of interfaces to be compliant, if commented or "0", all existing interfaces must be compliant
 Total_number_of_network_controllers= 0
+
+# Uncomment the following line to enable network boot testing and replace the URL as required
+#HTTPS_BOOT_IMAGE_URL= <http/https URL>
+
+

--- a/common/uefi_scripts/https_boot.nsh
+++ b/common/uefi_scripts/https_boot.nsh
@@ -1,0 +1,121 @@
+# @file
+# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+# SPDX-License-Identifier : Apache-2.0
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo -off
+
+# Logs all actions to: \acs_results_template\acs_results\network_boot\https_network_boot_console.log
+if not exist \acs_results_template then
+  mkdir \acs_results_template
+endif
+if not exist \acs_results_template\acs_results then
+  mkdir \acs_results_template\acs_results
+endif
+if not exist \acs_results_template\acs_results\network_boot then
+  mkdir \acs_results_template\acs_results\network_boot
+endif
+
+set logdir \acs_results_template\acs_results\network_boot
+set logfile %logdir%\https_network_boot_console.log
+
+# start a console log
+echo [INFO] start_network_boot > %logfile%
+date >> %logfile%
+time >> %logfile%
+
+# load config
+if exist \acs_tests\config\acs_https.conf.nsh then
+  echo Loading config from \acs_tests\config\acs_https.conf.nsh >> %logfile%
+  \acs_tests\config\acs_https.conf.nsh
+else
+  echo [ERROR] Config missing at \acs_tests\config\acs_https.conf.nsh >> %logfile%
+  goto FailAndExit
+endif
+
+# log config variables if present
+if not "%HTTPS_IMAGE_URL%" == "" then
+  echo HTTPS_IMAGE_URL=%HTTPS_IMAGE_URL% >> %logfile%
+endif
+
+if not "%HTTPS_IMAGE_SCHEME%" == "" then
+  echo Scheme: %HTTPS_IMAGE_SCHEME% >> %logfile%
+else
+  echo Scheme: (unknown) >> %logfile%
+endif
+
+# validate URL/hostpath variables
+if "%HTTPS_IMAGE_HOSTPATH%" == "" then
+  if "%HTTPS_IMAGE_URL%" == "" then
+    echo [ERROR] No valid URL provided (HTTPS_IMAGE_HOSTPATH and HTTPS_IMAGE_URL empty) >> %logfile%
+  else
+    echo [ERROR] HTTPS_IMAGE_HOSTPATH not set. Provide a scheme-free host/path in the config. >> %logfile%
+    echo Example: raw.githubusercontent.com/owner/repo/path/file.img >> %logfile%
+  endif
+  goto FailAndExit
+endif
+
+echo HOSTPATH=%HTTPS_IMAGE_HOSTPATH% >> %logfile%
+
+# locate ledge.efi and set in-progress flag
+set rc 1
+
+for %j in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+  if exist FS%j:\acs_tests\app\ledge.efi then
+    FS%j:
+    echo ledge.efi found at \acs_tests\app\ledge.efi >> %logfile%
+
+    # create network_boot_in_progress flag
+    echo > \acs_tests\app\network_boot_in_progress.flag
+
+    # Decide arguments based on scheme:
+    # - http:  ledge.efi -s -u <hostpath> -f -l "ACS-Minimal Image"
+    # - else:  ledge.efi -s -u <hostpath> -l "ACS-Minimal Image"
+    if "%HTTPS_IMAGE_SCHEME%" == "http" then
+      echo Using HTTP mode (-f) >> %logfile%
+      \acs_tests\app\ledge.efi -s -u %HTTPS_IMAGE_HOSTPATH% -f -l "ACS-Minimal Image"
+    else
+      echo Using HTTPS/default mode (no -f) >> %logfile%
+      \acs_tests\app\ledge.efi -s -u %HTTPS_IMAGE_HOSTPATH% -l "ACS-Minimal Image"
+    endif
+
+    set rc %lasterror%
+
+    # If ledge.efi returns with error, clean flag and fallback to Linux
+    if not %rc% == 0 then
+      echo [ERROR] ledge.efi failed rc=%rc% >> %logfile%
+      if exist \acs_tests\app\network_boot_in_progress.flag then
+        rm \acs_tests\app\network_boot_in_progress.flag
+      endif
+      goto FailAndExit
+    endif
+
+    # If ledge.efi returns with rc=0, just log and exit
+    echo ledge.efi launched successfully (rc=0). >> %logfile%
+    exit 0
+  endif
+endfor
+
+echo [ERROR] No ledge.efi found under FS?:\acs_tests\app\ >> %logfile%
+echo Expected path like FS1:\acs_tests\app\ledge.efi >> %logfile%
+
+goto FailAndExit
+
+:FailAndExit
+echo Network boot failed, please check logs, exiting from the script >> %logfile%
+if exist \acs_tests\app\network_boot_in_progress.flag then
+  rm \acs_tests\app\network_boot_in_progress.flag
+endif
+echo > \acs_tests\app\network_boot_failed.flag
+exit 0

--- a/common/uefi_scripts/startup_dt.nsh
+++ b/common/uefi_scripts/startup_dt.nsh
@@ -26,6 +26,46 @@ for %x in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
   endif
 endfor
 
+#Start HTTPs Boot from uefi shell
+for %h in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+  if exist FS%h:\acs_tests\app\https_boot_pending.flag then
+    FS%h:
+    echo "HTTPS/HTTP network boot requested, launching https_boot.nsh..."
+
+    if exist \acs_tests\app\https_boot.nsh then
+      rm \acs_tests\app\https_boot_pending.flag
+      \acs_tests\app\https_boot.nsh
+    else
+      echo "[ERROR] https_boot.nsh not found under FS%h:\acs_tests\app\"
+      goto BootLinux
+    endif
+
+    goto DoneHTTPSBootCheck
+  endif
+endfor
+:DoneHTTPSBootCheck
+
+for %f in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+  if exist FS%f:\acs_tests\app\network_boot_failed.flag then
+    echo "HTTPS network boot previously failed. Cleaning flag and booting Linux..."
+    goto BootLinux
+  endif
+endfor
+
+for %x in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+  if exist FS%x:\acs_tests\app\network_boot_success.flag then
+    echo "HTTPS network boot previously completed. Skipping ACS tests and booting Linux..."
+    goto BootLinux
+  endif
+endfor
+
+for %y in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+  if exist FS%y:\acs_tests\app\network_boot_in_progress.flag then
+    echo "WARNING: network_boot_in_progress flag found. Network boot failed,  please check logs, booting Linux..."
+    goto BootLinux
+  endif
+endfor
+
 # Clearing Secure Boot Key
 for %d in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%d:\acs_tests\bbr\clear_secureboot.flag then


### PR DESCRIPTION
- Add acs_https_boot.sh and integrate into init flow
- Add https_boot.nsh and update startup_dt.nsh for boot flags
- Package and sign ledge.efi via new Yocto recipe
- Include https_boot and ledge.efi in bootfs and image EFI files
- Add HTTPS_BOOT_IMAGE_URL to system_config.txt


Change-Id: I10c32cbf4a3d6a529e3a82d875a01553fd7663d7