### PR TITLE
Fixed system_config.txt parsing to exclude user-defined configuration…

### DIFF
--- a/common/log_parser/acs_info.py
+++ b/common/log_parser/acs_info.py
@@ -97,7 +97,10 @@ def parse_config(config_path):
         try:
             with open(config_path, 'r') as cf:
                 for line in cf:
-                    if ':' in line:
+                    # Stop parsing at the user-defined configs section
+                    if line.strip().startswith('# User-defined configs'):
+                        break
+                    if ':' in line and not line.strip().startswith('#'):
                         key, value = line.strip().split(':', 1)
                         config_info[key.strip()] = value.strip()
         except Exception as e:

--- a/common/log_parser/generate_acs_summary.py
+++ b/common/log_parser/generate_acs_summary.py
@@ -91,7 +91,10 @@ def parse_config(config_path):
         if config_path and os.path.exists(config_path):
             with open(config_path, 'r') as config_file:
                 for line in config_file:
-                    if ':' in line:
+                    # Stop parsing at the user-defined configs section
+                    if line.strip().startswith('# User-defined configs'):
+                        break
+                    if ':' in line and not line.strip().startswith('#'):
                         key, value = line.strip().split(':', 1)
                         config_info[key.strip()] = value.strip()
         else:


### PR DESCRIPTION
… section

- Modified acs_info.py parse_config() to stop parsing at '# User-defined configs' marker
- Modified generate_acs_summary.py parse_config() to stop parsing at '# User-defined configs' marker
- Added logic to skip comment lines during config file parsing
- Prevents user-defined configs like HTTPS_BOOT_IMAGE_URL and Total_number_of_network_controllers from appearing in system info
- Ensures only system information fields are included in acs_info.json, merged_results.json, and HTML summary
- Maintains clean separation between system metadata and test configuration parameters

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com
Change-Id: I96250af30c275a924b1101a841075dd389143c77