### PR TITLE
Add network boot test to Standalone suite

### DIFF
--- a/common/log_parser/merge_jsons.py
+++ b/common/log_parser/merge_jsons.py
@@ -431,7 +431,7 @@ def merge_json_files(json_files, output_file):
         lookup_suite_key = suite_key.lower()
         standalone_aliases = {
             "dt_kselftest", "dt_validate", "ethtool_test",
-            "read_write_check_blk_devices", "psci", "capsule update"
+            "read_write_check_blk_devices", "psci", "capsule update", "network_boot"
         }
         if lookup_suite_key in standalone_aliases or lookup_suite_key.startswith("os_"):
             lookup_suite_key = "standalone"
@@ -719,7 +719,8 @@ def merge_json_files(json_files, output_file):
         "Suite_Name: Ethtool Test": "Suite_Name: Standalone",
         "Suite_Name: Read Write Check Block Devices": "Suite_Name: Standalone",
         "Suite_Name: PSCI": "Suite_Name: Standalone",
-        "Suite_Name: SMBIOS": "Suite_Name: Standalone"
+        "Suite_Name: SMBIOS": "Suite_Name: Standalone",
+        "Suite_Name: Network boot": "Suite_Name: Standalone"
     }
 
     def _entry_to_list(entry):


### PR DESCRIPTION
- Added network_boot to standalone_aliases and RENAME_SUITES_TO_STANDALONE mapping in merge_jsons.py to ensure it appears inside Standalone suite array instead of as a separate top-level suite in merged_results.json


Change-Id: I210d669bb9945139769ec2babb66e887d7447b5b