### PR TITLE
Fix metadata extraction for SMBIOS, POWER_WAKEUP, and smccc test suites

### DIFF
--- a/common/log_parser/merge_jsons.py
+++ b/common/log_parser/merge_jsons.py
@@ -431,7 +431,7 @@ def merge_json_files(json_files, output_file):
         lookup_suite_key = suite_key.lower()
         standalone_aliases = {
             "dt_kselftest", "dt_validate", "ethtool_test",
-            "read_write_check_blk_devices", "psci", "capsule update", "network_boot"
+            "read_write_check_blk_devices", "psci", "capsule update", "network_boot", "smbios"
         }
         if lookup_suite_key in standalone_aliases or lookup_suite_key.startswith("os_"):
             lookup_suite_key = "standalone"

--- a/common/log_parser/test_categoryDT.json
+++ b/common/log_parser/test_categoryDT.json
@@ -86,7 +86,7 @@
   "catID: 8": [
     {
       "Suite": "BSA",
-      "Test Suite": "Wakeup semantic",
+      "Test Suite": "POWER_WAKEUP",
       "specName": "BSA",
       "rel Import. to main readiness": "Minor",
       "Waivable": "yes",
@@ -98,7 +98,7 @@
   "catID: 9": [
     {
       "Suite": "BSA",
-      "Test Suite": "Memory Map",
+      "Test Suite": "MEM_MAP",
       "specName": "BSA",
       "rel Import. to main readiness": "Minor",
       "Waivable": "yes",
@@ -301,7 +301,7 @@
   ],
   "catID: 26": [
     {
-      "Suite": "SCT",
+      "Suite": "Standalone",
       "Test Suite": "SMBIOS",
       "specName": "UEFI",
       "rel Import. to main readiness": "Minor",
@@ -501,6 +501,18 @@
       "SRS scope": "Recommended",
       "FunctionID": 1,
       "Main Readiness Grouping": "boot readiness"
+    }
+  ],
+  "catID: 43": [
+    {
+      "Suite": "FWTS",
+      "Test Suite": "smccc",
+      "specName": "BBR",
+      "rel Import. to main readiness": "Minor",
+      "Waivable": "no",
+      "SRS scope": "Required",
+      "FunctionID": 4,
+      "Main Readiness Grouping": "security readiness"
     }
   ]
 }


### PR DESCRIPTION
- Added smbios to standalone_aliases in merge_jsons.py
- Renamed Wakeup semantic to POWER_WAKEUP in test_categoryDT.json
- Added catID 43 for FWTS->smccc mapping in test_categoryDT.json

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com
Change-Id: I87f9dbcf6321108e4d457242dea9574f9d20bd52