### PR TITLE
Fixed BSA subtest failure double-counting in compliance calculation

### DIFF
--- a/common/log_parser/bsa/logs_to_json.py
+++ b/common/log_parser/bsa/logs_to_json.py
@@ -152,14 +152,15 @@ def main(input_files, output_file):
             raw_line = lines[i]
             i += 1
 
-            # Detect indentation level (count leading spaces)
-            indent_match = re.match(r'^(\s*)', raw_line)
+            # Strip timestamp [....] if present (keep spaces after timestamp for indentation detection)
+            line_no_timestamp = re.sub(r'^\s*\[.*?\]\s?', '', raw_line)
+
+            # NOW detect indentation level (count leading spaces AFTER timestamp removal)
+            indent_match = re.match(r'^(\s*)', line_no_timestamp)
             indent_spaces = len(indent_match.group(1)) if indent_match else 0
             is_indented = indent_spaces > 0
 
-            # Strip timestamp [....] if present, but preserve other leading spaces for now
-            line_no_timestamp = re.sub(r'^\s*\[.*?\]\s*', '', raw_line)
-            # Now strip only the leading spaces
+            # Strip the leading spaces to get clean line
             line = line_no_timestamp.strip()
 
             if not line:

--- a/common/log_parser/merge_jsons.py
+++ b/common/log_parser/merge_jsons.py
@@ -148,15 +148,12 @@ def count_fails_in_json(data):
                         total_failed += 1
 
             # Also count subtests under testcases (BSA structure)
-            for subtest in testcase.get("subtests", []):
-                sub_result = subtest.get("sub_test_result", "")
-                if isinstance(sub_result, str):
-                    if "FAILED" in sub_result.upper() or "FAILURE" in sub_result.upper() or "FAIL" in sub_result.upper():
-                        any_subtests_found = True
-                        if "(WITH WAIVER)" in sub_result.upper():
-                            total_failed_with_waiver += 1
-                        else:
-                            total_failed += 1
+            subtests_in_testcase = testcase.get("subtests", [])
+            # Only set flag if subtests array is non-empty
+            if subtests_in_testcase:
+                any_subtests_found = True
+            # NOTE: For BSA, don't count individual subtest failures
+            # The testcase failure status above already captures it
         # Standard structure: subtests at suite level
         subtests = suite_entry.get("subtests", [])
         if subtests:


### PR DESCRIPTION
- Modified count_fails_in_json() in merge_jsons.py to prevent counting individual subtest failures
- BSA testcase FAILED status already captures failed subtests; removed redundant subtest counting loop
- Only sets any_subtests_found flag when subtests exist, avoiding double-counting
- Ensures merged JSON failure count matches ACS Summary (e.g., testcase with failed subtest counts as 1, not 2)
- Fix isolated to BSA/SBSA structure; does not affect FWTS, SCT, SBMR, or standalone suite counting

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com
Change-Id: Ib33e917eb7591119e9c3a09651f833a2187c2ce8