### PR TITLE
DT v3.1.1: Updated build tags for ACS and BBR components

### DIFF
--- a/common/config/systemready-dt-band-source.cfg
+++ b/common/config/systemready-dt-band-source.cfg
@@ -54,16 +54,16 @@ FWTS_VERSION=25.09.00
 # Arm BSA ACS build tag/commit
 # UEFI SRC: https://github.com/ARM-software/sysarch-acs
 # Linux SRC: https://gitlab.arm.com/linux-arm/linux-acs
-BSA_ACS_TAG=""
-BSA_LINUX_ACS_TAG=""
+BSA_ACS_TAG="13248b722e9ca63522a475771e085b0a8d6d1e9d"
+BSA_LINUX_ACS_TAG="f11d190dbe3ba2c47f3a30d3054ad9f3c57025b9"
 
 # Arm PFDI ACS build tag/commit
 # UEFI SRC: https://github.com/ARM-software/sysarch-acs
-PFDI_ACS_TAG=""
+PFDI_ACS_TAG="13248b722e9ca63522a475771e085b0a8d6d1e9d"
 
 # Arm BBR ACS build tag/commit
 # SRC: https://github.com/ARM-software/bbr-acs
-ARM_BBR_TAG=""
+ARM_BBR_TAG="v25.12_EBBR_2.2.2"
 
 # edk2-test-parser version
 # SRC: https://gitlab.arm.com/systemready/edk2-test-parser


### PR DESCRIPTION
Fixed the build tags for v3.1.1 DT release