### PR TITLE
Downgrade Linux kernel version from v6.16 to v6.12 for Systemready-band 

### DIFF
--- a/SystemReady-band/build-scripts/build-buildroot.sh
+++ b/SystemReady-band/build-scripts/build-buildroot.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @file
-# Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ BUILDROOT_DEFCONFIG=$TOP_DIR/$BUILDROOT_PATH/configs/buildroot_defconfig
 OUTDIR=$TOP_DIR/output
 ARCH=arm64
 CROSS_COMPILE=${TOP_DIR}/tools/arm-gnu-toolchain-13.2.rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
-KDIR="${TOP_DIR}/linux-6.16/out" 
+KDIR="${TOP_DIR}/linux-${LINUX_KERNEL_VERSION}/out" 
 
 do_build ()
 {

--- a/common/config/systemready-band-source.cfg
+++ b/common/config/systemready-band-source.cfg
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2022-2026, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -37,7 +37,7 @@
 
 # Linux kernel build tag/commit
 # SRC: https://github.com/torvalds/linux.git
-LINUX_KERNEL_VERSION=6.16
+LINUX_KERNEL_VERSION=6.12
 
 # EDK2 build tag/commit
 # SRC: https://github.com/tianocore/edk2.git


### PR DESCRIPTION
Downgrade Linux kernel version from v6.16 to v6.12 for Systemready-band 

Fixes  #568