### PR TITLE
(sr component upgrade) Update EDK2 and SCT source versions

### DIFF
--- a/common/config/systemready-band-source.cfg
+++ b/common/config/systemready-band-source.cfg
@@ -41,11 +41,12 @@ LINUX_KERNEL_VERSION=6.12
 
 # EDK2 build tag/commit
 # SRC: https://github.com/tianocore/edk2.git
-EDK2_SRC_VERSION=edk2-stable202508
+EDK2_SRC_VERSION=edk2-stable202511
 
 # EDK2-TEST build tag/commit
 # SRC: https://github.com/tianocore/edk2-test
-SCT_SRC_TAG=edk2-test-stable202509
+ # Jan26 end commit id
+SCT_SRC_TAG=91e998d2d77b26cccd1f4bf99938ff55c1606e8a
 
 # FWTS build tag/commit
 # The flag is not used for DT Yocto build, but is kept as reference to know which latest version is used


### PR DESCRIPTION
* SCT moved to Jan-2026 commit id: tianocore/edk2-test@91e998d
* edk2 build version moved to edk2-stable202511