### PR TITLE
init.sh: pass explicit SBBR/EBBR config to edk2-test-parser

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2023-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2023-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -385,7 +385,7 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
         echo "Running edk2-test-parser tool "
         mkdir -p /mnt/acs_results_template/acs_results/edk2-test-parser
         cd /usr/bin/edk2-test-parser
-        ./parser.py --md /mnt/acs_results_template/acs_results/edk2-test-parser/edk2-test-parser.log /mnt/acs_results_template/acs_results/sct_results/Overall/Summary.ekl \
+        ./parser.py --md /mnt/acs_results_template/acs_results/edk2-test-parser/edk2-test-parser.log --config EBBR.yaml /mnt/acs_results_template/acs_results/sct_results/Overall/Summary.ekl \
               /mnt/acs_results_template/acs_results/sct_results/Sequence/EBBR.seq > /dev/null 2>&1
         echo "edk2-test-parser run completed"
       else

--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -270,7 +270,7 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
     echo "Running edk2-test-parser tool "
     mkdir -p /mnt/acs_results/edk2-test-parser
     cd /usr/bin/edk2-test-parser
-    ./parser.py --md /mnt/acs_results/edk2-test-parser/edk2-test-parser.log /mnt/acs_results/sct_results/Overall/Summary.ekl /mnt/acs_results/sct_results/Sequence/SBBR.seq > /dev/null 2>&1
+    ./parser.py --md /mnt/acs_results/edk2-test-parser/edk2-test-parser.log --config SBBR.yaml /mnt/acs_results/sct_results/Overall/Summary.ekl /mnt/acs_results/sct_results/Sequence/SBBR.seq > /dev/null 2>&1
     cd -
     echo "edk2-test-parser run completed"
     sync /mnt


### PR DESCRIPTION
Update init.sh to explicitly pass the SBBR/EBBR YAML configuration file to edk2-test-parser instead of relying on implicit defaults.

This ensures the parser applies the correct rule set when generating results for SBBR and EBBR test runs.


Change-Id: I039b0d7bc2511c3fba0bb1fd2cb61abba54cfdd1