### PR TITLE
Increase EFI partition size to avoid storage issues

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/wic/woden.wks.in
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/wic/woden.wks.in
@@ -1,5 +1,5 @@
 bootloader --ptable gpt --timeout=10 --append="rootfstype=ext4"
 
-part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER}" --label BOOT_ACS --active --align 1024 --use-uuid --size 360M
+part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER}" --label BOOT_ACS --active --align 1024 --use-uuid --size 512M
 
 part / --source rootfs --fstype=ext4 --label root --align 1024 --use-uuid


### PR DESCRIPTION
- Increase EFI partition size from 360MB to 512MB to avoid storage issues on partner platforms.
