### PR TITLE
pfdi parser: As pfdi is using same rule based fwk as bsa, use bsa parser

### DIFF
--- a/common/log_parser/main_log_parser.sh
+++ b/common/log_parser/main_log_parser.sh
@@ -329,11 +329,11 @@ if [ $YOCTO_FLAG_PRESENT -eq 1 ]; then
 
     if check_file "$PFDI_LOG" "CM"; then
         PFDI_PROCESSED=1
-        if python3 "$SCRIPTS_PATH/pfdi/logs_to_json.py" \
+        if python3 "$SCRIPTS_PATH/bsa/logs_to_json.py" \
                 "$PFDI_LOG" \
                 "$PFDI_JSON"; then
             apply_waivers "PFDI" "$PFDI_JSON"
-            python3 "$SCRIPTS_PATH/pfdi/json_to_html.py" \
+            python3 "$SCRIPTS_PATH/bsa/json_to_html.py" \
                     "$PFDI_JSON" \
                     "$HTMLS_DIR/pfdi_detailed.html" \
                     "$HTMLS_DIR/pfdi_summary.html"


### PR DESCRIPTION

* Latest PFDI ACS is updated to follow a rule based reporting same as xbsa
* xbsa parser can be used for parsing pfdi log as well


---------------------- Running tests ------------------------

    *** Running PFDI tests ***

R0040 : 11 : Check if X5 to X17 are preserved
   Result:  PASSED

R0053 : 1 : Check PFDI Version is returned
   Result:  PASSED

R0060 : 4 : Check PFDI Feature function support
   Result:  PASSED
