### PR TITLE
(SR linux fix): Restrict USB4 tunnel detection fix ported to acs kernel 6.12

### DIFF
--- a/SystemReady-band/build-scripts/get_source.sh
+++ b/SystemReady-band/build-scripts/get_source.sh
@@ -136,6 +136,9 @@ get_linux-acs_src()
     git am $TOP_DIR/../common/patches/0001-SystemReady-Linux-${LINUX_KERNEL_VERSION}.patch
     git am $TOP_DIR/../common/patches/0001-disable-psci-checker.patch
     git am $TOP_DIR/patches/0001-usb_host_xhci_plat.patch
+    # The below patch is only for linux 6.12 for resolving the USB 3.0 related crash during linux boot
+    # For linux version greater than 6.12, this patch is not needed.
+    git am $TOP_DIR/patches/0001-xhci-restrict-usb4-tunnel-detection.patch
 
     #apply patches to linux source
     if [ $LINUX_KERNEL_VERSION == "6.4" ]; then

--- a/SystemReady-band/patches/0001-xhci-restrict-usb4-tunnel-detection.patch
+++ b/SystemReady-band/patches/0001-xhci-restrict-usb4-tunnel-detection.patch
@@ -1,0 +1,41 @@
+From 4c77425a2a4a5f9f3ab309869fc2acb8efced1fd Mon Sep 17 00:00:00 2001
+From: Chetan Singh <chetan.singh2@arm.com>
+Date: Fri, 13 Feb 2026 07:48:36 +0530
+Subject: [PATCH] xhci: restrict USB4 tunnel detection
+
+---
+ drivers/usb/host/xhci-hub.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/usb/host/xhci-hub.c b/drivers/usb/host/xhci-hub.c
+index 8d774f192..2fe3a9297 100644
+--- a/drivers/usb/host/xhci-hub.c
++++ b/drivers/usb/host/xhci-hub.c
+@@ -12,6 +12,7 @@
+ #include <linux/slab.h>
+ #include <linux/unaligned.h>
+ #include <linux/bitfield.h>
++#include <linux/pci.h>
+ 
+ #include "xhci.h"
+ #include "xhci-trace.h"
+@@ -770,9 +771,16 @@ static int xhci_exit_test_mode(struct xhci_hcd *xhci)
+ enum usb_link_tunnel_mode xhci_port_is_tunneled(struct xhci_hcd *xhci,
+ 						struct xhci_port *port)
+ {
++	struct usb_hcd *hcd;
+ 	void __iomem *base;
+ 	u32 offset;
+ 
++	/* Don't try and probe this capability for non-Intel hosts */
++	hcd = xhci_to_hcd(xhci);
++	if (!dev_is_pci(hcd->self.controller) ||
++	    to_pci_dev(hcd->self.controller)->vendor != PCI_VENDOR_ID_INTEL)
++		return USB_LINK_UNKNOWN;
++
+ 	base = &xhci->cap_regs->hc_capbase;
+ 	offset = xhci_find_next_ext_cap(base, 0, XHCI_EXT_CAPS_INTEL_SPR_SHADOW);
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
ACS Linux boot failure during USB enumeration is observed in a system, on further debugging it is related to USB4 tunnel detection linux fix not present in 6.12 version, port the fix to acs 6.12.0 version.

This resolves cases where devices behind the tunnel may not be detected and functional after boot.

Fix #616 