### PR TITLE
dmicheck: Fix SMBIOS table size boundary check

### DIFF
--- a/SystemReady-band/build-scripts/get_source.sh
+++ b/SystemReady-band/build-scripts/get_source.sh
@@ -209,6 +209,7 @@ get_buildroot_src()
         exit 1
     fi
     pushd $TOP_DIR/buildroot/package/fwts
+        cp $TOP_DIR/patches/0001-dmicheck-fix-smbios-table-size-boundary-check.patch $TOP_DIR/buildroot/package/fwts
         echo "Applying Buildroot FWTS patch..."
         # patch buildroot config
         git apply $TOP_DIR/../common/patches/build_fwts_version_${FWTS_VERSION}.patch

--- a/SystemReady-band/patches/0001-dmicheck-fix-smbios-table-size-boundary-check.patch
+++ b/SystemReady-band/patches/0001-dmicheck-fix-smbios-table-size-boundary-check.patch
@@ -1,0 +1,13 @@
+diff --git a/src/dmi/dmicheck/dmicheck.c b/src/dmi/dmicheck/dmicheck.c
+index 1eab8360..621b0677 100644
+--- a/src/dmi/dmicheck/dmicheck.c
++++ b/src/dmi/dmicheck/dmicheck.c
+@@ -378,7 +378,7 @@ static int dmi_load_file_variable_size(
+ 		return FWTS_ERROR;
+ 
+ 	for (p = buf, total = count = 0; ; p += count) {
+-		if (total >= sz) {
++		if (total > sz) {
+ 			close(fd);
+ 			return FWTS_ERROR;
+ 		}


### PR DESCRIPTION
Allow actual SMBIOS table size to equal maximum size as permitted by the SMBIOS specification; only treat sizes exceeding the maximum as error.


