### PR TITLE
fix: record SCMI suite-level access gaps with reasons

### DIFF
--- a/common/log_parser/scmi/json_to_html.py
+++ b/common/log_parser/scmi/json_to_html.py
@@ -100,6 +100,7 @@ def build_html(overall_summary, test_results, chart_b64, dest_html, suite_name, 
     .result-summary h2{border-bottom:2px solid #27ae60;padding-bottom:10px;margin-bottom:20px;}
 
     .test-suite-header{font-size:22px;font-weight:bold;color:#34495e;margin-top:30px;}
+    .suite-reason{margin:8px 0 12px 0;font-size:15px;}
     .reason{text-align:center;}
     .waiver-reason{text-align:center;}
   </style>
@@ -130,6 +131,7 @@ def build_html(overall_summary, test_results, chart_b64, dest_html, suite_name, 
 <div class="detailed-summary">
 {% for suite in test_results %}
   <div class="test-suite-header">Test Suite: {{ suite.Test_suite }}</div>
+  <div class="suite-reason"><strong>Reason:</strong> {{ suite.reason | default('N/A') }}</div>
   <table>
     <thead>
       <tr>


### PR DESCRIPTION
  -detect "Calling agent have no access to <PROTO> protocol" lines
  -store reason at suite level and clear testcases for that suite
  -always expose suite reason in SCMI JSON/HTML (default N/A)

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com
Change-Id: I832da2b7e03733b9bb51bbdeccc4de8ce413e51d