### PR TITLE
(improv) reduce xbsa temp results copy time

### DIFF
--- a/SystemReady-band/build-scripts/build-bsaefi.sh
+++ b/SystemReady-band/build-scripts/build-bsaefi.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,6 +63,7 @@ do_build()
     echo "    URL(sysarch-acs) = $(git remote get-url origin)" >> "${SYSTEMREADY_COMMIT_LOG}"
     echo "    commit(sysarch-acs) = $(git rev-parse HEAD)" >> "${SYSTEMREADY_COMMIT_LOG}"
     echo "" >> "${SYSTEMREADY_COMMIT_LOG}"
+    git apply $TOP_DIR/patches/bsa_srversion.patch
     popd
     source ./edksetup.sh
     make -C BaseTools/Source/C

--- a/SystemReady-band/build-scripts/build-sbsaefi.sh
+++ b/SystemReady-band/build-scripts/build-sbsaefi.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,6 +63,7 @@ do_build()
     echo "    URL(sysarch-acs) = $(git remote get-url origin)" >> "${SYSTEMREADY_COMMIT_LOG}"
     echo "    commit(sysarch-acs) = $(git rev-parse HEAD)" >> "${SYSTEMREADY_COMMIT_LOG}"
     echo "" >> "${SYSTEMREADY_COMMIT_LOG}"
+    git apply $TOP_DIR/patches/sbsa_srversion.patch
     popd
     source ./edksetup.sh
     make -C BaseTools/Source/C

--- a/SystemReady-band/build-scripts/get_source.sh
+++ b/SystemReady-band/build-scripts/get_source.sh
@@ -238,19 +238,6 @@ get_edk2-test-parser_src()
     echo "Downloading edk2-test-parser source code. TAG : $EDK2_TEST_PARSER_TAG"
     git clone https://git.gitlab.arm.com/systemready/edk2-test-parser.git
     pushd $TOP_DIR/edk2-test-parser/
-    git checkout $EDK2_TEST_PARSER_TAG
-    echo "EDK2 Parser" >> "${SYSTEMREADY_COMMIT_LOG}"
-    echo "    URL(edk2-test-parser) = $(git remote get-url origin)" >> "${SYSTEMREADY_COMMIT_LOG}"
-    echo "    commit(edk2-test-parser) = $(git rev-parse HEAD)" >> "${SYSTEMREADY_COMMIT_LOG}"
-    echo "" >> "${SYSTEMREADY_COMMIT_LOG}"
-    popd
-}
-
-get_edk2-test-parser_src()
-{
-    echo "Downloading edk2-test-parser source code. TAG : $EDK2_TEST_PARSER_TAG"
-    git clone https://git.gitlab.arm.com/systemready/edk2-test-parser.git
-    pushd $TOP_DIR/edk2-test-parser/
     if [ -n "$EDK2_TEST_PARSER_TAG" ]; then
         git checkout $EDK2_TEST_PARSER_TAG
     fi

--- a/SystemReady-band/patches/bsa_srversion.patch
+++ b/SystemReady-band/patches/bsa_srversion.patch
@@ -1,0 +1,12 @@
+diff --git a/apps/uefi/bsa_main.c b/apps/uefi/bsa_main.c
+index 4458fe5..80f964c 100644
+--- a/apps/uefi/bsa_main.c
++++ b/apps/uefi/bsa_main.c
+@@ -158,6 +158,7 @@ execute_tests()
+         goto exit_acs;
+     }
+ 
++    val_print(ACS_PRINT_TEST, "\n\n SystemReady band ACS v3.1.1 RC-final", 0);
+     val_print(ACS_PRINT_TEST, "\n\n BSA Architecture Compliance Suite", 0);
+     val_print(ACS_PRINT_TEST, "\n          Version %d.", BSA_ACS_MAJOR_VER);
+     val_print(ACS_PRINT_TEST, "%d.", BSA_ACS_MINOR_VER);

--- a/SystemReady-band/patches/sbsa_srversion.patch
+++ b/SystemReady-band/patches/sbsa_srversion.patch
@@ -1,0 +1,12 @@
+diff --git a/apps/uefi/sbsa_main.c b/apps/uefi/sbsa_main.c
+index 1695605..d644135 100644
+--- a/apps/uefi/sbsa_main.c
++++ b/apps/uefi/sbsa_main.c
+@@ -163,6 +163,7 @@ execute_tests()
+         goto exit_acs;
+     }
+ 
++    val_print(ACS_PRINT_ERR, "\n\n SystemReady band ACS v3.1.1 RC-final\n", 0);
+     val_print(ACS_PRINT_ERR, "\n\n SBSA Architecture Compliance Suite\n", 0);
+     val_print(ACS_PRINT_ERR, "    Version %d.", SBSA_ACS_MAJOR_VER);
+     val_print(ACS_PRINT_ERR, "%d.", SBSA_ACS_MINOR_VER);

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-uefi/bsa-acs.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-uefi/bsa-acs.bb
@@ -9,6 +9,7 @@ COMPATIBLE_MACHINE:genericarm64 = "genericarm64"
 
 SRC_URI += "git://github.com/ARM-software/sysarch-acs;destsuffix=edk2/ShellPkg/Application/sysarch-acs;protocol=https;branch=main;name=sysarch-acs \
             git://github.com/tianocore/edk2-libc;destsuffix=edk2/edk2-libc;protocol=https;branch=master;name=edk2-libc \
+            file://bsa_dtversion.patch;patch=1;patchdir=ShellPkg/Application/sysarch-acs \
             "
 
 SRCREV_sysarch-acs = "${AUTOREV}"

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-uefi/files/bsa_dtversion.patch
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-uefi/files/bsa_dtversion.patch
@@ -1,0 +1,12 @@
+diff --git a/apps/uefi/bsa_main.c b/apps/uefi/bsa_main.c
+index 4458fe5..80f964c 100644
+--- a/apps/uefi/bsa_main.c
++++ b/apps/uefi/bsa_main.c
+@@ -158,6 +158,7 @@ execute_tests()
+         goto exit_acs;
+     }
+ 
++    val_print(ACS_PRINT_TEST, "\n\n SystemReady devicetree band ACS v3.1.2 RC-final", 0);
+     val_print(ACS_PRINT_TEST, "\n\n BSA Architecture Compliance Suite", 0);
+     val_print(ACS_PRINT_TEST, "\n          Version %d.", BSA_ACS_MAJOR_VER);
+     val_print(ACS_PRINT_TEST, "%d.", BSA_ACS_MINOR_VER);

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/pfdi-acs/files/pfdi_dtversion.patch
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/pfdi-acs/files/pfdi_dtversion.patch
@@ -1,0 +1,12 @@
+diff --git a/apps/uefi/pfdi_main.c b/apps/uefi/pfdi_main.c
+index f8842b7..7b89ce0 100644
+--- a/apps/uefi/pfdi_main.c
++++ b/apps/uefi/pfdi_main.c
+@@ -97,6 +97,7 @@ execute_tests()
+       goto exit_close;
+   }
+ 
++  val_print(ACS_PRINT_TEST, "\n\n SystemReady devicetree band ACS v3.1.2 RC-final", 0);
+   val_print(ACS_PRINT_TEST, "\n\n PFDI Architecture Compliance Suite", 0);
+   val_print(ACS_PRINT_TEST, "\n          Version %d.", PFDI_ACS_MAJOR_VER);
+   val_print(ACS_PRINT_TEST, "%d.", PFDI_ACS_MINOR_VER);

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/pfdi-acs/pfdi-acs.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/pfdi-acs/pfdi-acs.bb
@@ -8,6 +8,7 @@ COMPATIBLE_MACHINE:genericarm64 = "genericarm64"
 
 SRC_URI += "git://github.com/ARM-software/sysarch-acs;destsuffix=edk2/ShellPkg/Application/sysarch-acs;protocol=https;branch=main;name=sysarch-acs \
             git://github.com/tianocore/edk2-libc;destsuffix=edk2/edk2-libc;protocol=https;branch=master;name=edk2-libc \
+            file://pfdi_dtversion.patch;patch=1;patchdir=ShellPkg/Application/sysarch-acs \
             "
 
 SRCREV_sysarch-acs = "${AUTOREV}"

--- a/common/log_parser/main_log_parser.sh
+++ b/common/log_parser/main_log_parser.sh
@@ -45,7 +45,7 @@ LOGS_PATH=$1
 ACS_CONFIG_PATH=$2
 SYSTEM_CONFIG_PATH=$3
 WAIVER_JSON=$4
-POST_SCRIPT_LOG="$LOGS_PATH/post-script/post-script.log"
+POST_SCRIPT_LOG="$LOGS_PATH/post-scripts/post-script.log"
 
 if [ $YOCTO_FLAG_PRESENT -eq 1 ]; then
     test_category="/usr/bin/log_parser/test_categoryDT.json"

--- a/common/uefi_scripts/bsa.nsh
+++ b/common/uefi_scripts/bsa.nsh
@@ -17,8 +17,6 @@
 # limitations under the License.
 
 echo -off
-set DT_Version " SystemReady devicetree band ACS v3.1.2 RC0"
-set SR_Version " SystemReady band ACS v3.1.1 RC0"
 
 for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%i:\yocto_image.flag then
@@ -101,13 +99,7 @@ if exist FS%i:\acs_tests\bsa\Bsa.efi then
         endif
         stall 200000
         if exist BsaVerboseTempResults.log then
-            if exist FS%i:\acs_tests\bsa\bsa_dt.flag then
-                echo %DT_Version% > BsaVerboseResults.log
-            else
-                echo %SR_Version% > BsaVerboseResults.log
-            endif
-            stall 200000
-            type BsaVerboseTempResults.log >> BsaVerboseResults.log
+            cp BsaVerboseTempResults.log BsaVerboseResults.log
             cp BsaVerboseTempResults.log temp/
             rm BsaVerboseTempResults.log
             reset
@@ -152,13 +144,7 @@ if exist FS%i:\acs_tests\bsa\Bsa.efi then
     stall 200000
 :BsaEE
     if exist BsaTempResults.log then
-        if exist FS%i:\acs_tests\bsa\bsa_dt.flag then
-            echo %DT_Version% > BsaResults.log
-        else
-            echo %SR_Version% > BsaResults.log
-        endif
-        stall 200000
-        type BsaTempResults.log >> BsaResults.log
+        cp BsaTempResults.log BsaResults.log
         cp BsaTempResults.log temp/
         rm BsaTempResults.log
         reset

--- a/common/uefi_scripts/pfdi.nsh
+++ b/common/uefi_scripts/pfdi.nsh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 echo -off
+
 for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%i:\yocto_image.flag then
         if exist FS%i:\acs_results_template\acs_results then
@@ -64,9 +65,7 @@ if exist FS%i:\acs_tests\pfdi\pfdi.efi then
         FS%i:\acs_tests\pfdi\pfdi.efi -v 1 -f pfdiverbosetempresults.log
         stall 200000
         if exist pfdiverbosetempresults.log then
-            echo " SystemReady devicetree band ACS v3.1.2 RC0" > pfdiverboseresults.log
-            stall 200000
-            type pfdiverbosetempresults.log >> pfdiverboseresults.log
+            cp pfdiverbosetempresults.log pfdiverboseresults.log
             cp pfdiverbosetempresults.log temp/
             rm pfdiverbosetempresults.log
             reset
@@ -96,9 +95,7 @@ if exist FS%i:\acs_tests\pfdi\pfdi.efi then
 
     stall 200000
     if exist pfditempresults.log then
-        echo " SystemReady devicetree band ACS v3.1.2 RC0" > pfdiresults.log
-        stall 200000
-        type pfditempresults.log >> pfdiresults.log
+        cp pfditempresults.log pfdiresults.log
         cp pfditempresults.log temp/
         rm pfditempresults.log
         reset

--- a/common/uefi_scripts/sbsa.nsh
+++ b/common/uefi_scripts/sbsa.nsh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 echo -off
+
 for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%i:\acs_results then
         if "%1" == "true" then
@@ -73,9 +74,7 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                 FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -v 1 -skip S_L3MM_01 -skip-dp-nic-ms -f SbsaVerboseTempResults.log
                 stall 200000
                 if exist FS%i:\acs_results\uefi\SbsaVerboseTempResults.log then
-                    echo " SystemReady band ACS v3.1.1 RC0" > SbsaVerboseResults.log
-                    stall 200000
-                    type SbsaVerboseTempResults.log >> SbsaVerboseResults.log
+                    cp SbsaVerboseTempResults.log SbsaVerboseResults.log
                     cp SbsaVerboseTempResults.log temp/
                     rm SbsaVerboseTempResults.log
                     reset
@@ -116,9 +115,7 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             stall 200000
 :SbsaEE
             if exist FS%i:\acs_results\uefi\SbsaTempResults.log then
-                echo " SystemReady band ACS v3.1.1 RC0" > SbsaResults.log
-                stall 200000
-                type SbsaTempResults.log >> SbsaResults.log
+                cp SbsaTempResults.log SbsaResults.log
                 cp SbsaTempResults.log temp/
                 rm SbsaTempResults.log
                 reset


### PR DESCRIPTION
 To print Systemready version in xBSA logs uefi echo command is used
 followed by type cmd to copy logs from temResults to Results.log, but
 type cmd is time intensive, replace the mechanism to use xbsa patch to
 directly print version from app and then use cp cmd

Also minor fixes to post-script path

Change-Id: Id3843d7e4d8311f232c3a7b042ec43805e33e87d