### PR TITLE
edk2-test: upgrade; kernel: fix CONFIG_TCG_CRB handling

### DIFF
--- a/SystemReady-band/build-scripts/build-linux.sh
+++ b/SystemReady-band/build-scripts/build-linux.sh
@@ -58,6 +58,11 @@ do_build ()
     echo "Building using defconfig..."
     cp arch/arm64/configs/defconfig $LINUX_OUT_DIR/.config
     arch=$(uname -m)
+    if [[ $arch = "aarch64" ]]; then
+        make ARCH=arm64 O=$LINUX_OUT_DIR olddefconfig
+    else
+        make ARCH=arm64 CROSS_COMPILE=$TOP_DIR/$GCC O=$LINUX_OUT_DIR olddefconfig
+    fi
     #Configurations needed for FWTS
     sed -i 's/# CONFIG_EFI_TEST is not set/CONFIG_EFI_TEST=y/g' $LINUX_OUT_DIR/.config
     sed -i 's/# CONFIG_DMI_SYSFS is not set/CONFIG_DMI_SYSFS=y/g' $LINUX_OUT_DIR/.config

--- a/common/config/systemready-band-source.cfg
+++ b/common/config/systemready-band-source.cfg
@@ -45,8 +45,8 @@ EDK2_SRC_VERSION=edk2-stable202511
 
 # EDK2-TEST build tag/commit
 # SRC: https://github.com/tianocore/edk2-test
- # Jan26 end commit id
-SCT_SRC_TAG=ac270e9732583099ca3cb32d96708456f53b7a42
+ # March 3rd commit id
+SCT_SRC_TAG=346be4f87d085646abdde22b3e50505b5929c43c
 
 # FWTS build tag/commit
 FWTS_VERSION=26.01.00

--- a/common/config/systemready-dt-band-source.cfg
+++ b/common/config/systemready-dt-band-source.cfg
@@ -45,7 +45,7 @@ EDK2_SRC_TAG=edk2-stable202511
 
 # EDK2-TEST build tag/commit
 # SRC: https://github.com/tianocore/edk2-test
-SCT_SRC_TAG=ac270e9732583099ca3cb32d96708456f53b7a42
+SCT_SRC_TAG=346be4f87d085646abdde22b3e50505b5929c43c
 
 # FWTS build tag/commit
 # The flag is not used for SR build, but is kept as reference to know which latest version is used


### PR DESCRIPTION
- Upgrade edk2-test to latest commit to include EFI Runtime Properties Table check.

- Fix CONFIG_TCG_CRB enablement in defconfig-based builds by applying overrides after olddefconfig and re-running olddefconfig to ensure final .config reflects requested settings.

