### PR TITLE
fix: hide SCMI "not run" detail row in ACS summary

### DIFF
--- a/common/log_parser/generate_acs_summary.py
+++ b/common/log_parser/generate_acs_summary.py
@@ -249,9 +249,7 @@ def read_overall_compliance_from_merged_json(merged_json_path):
     # Derive SCMI details for the Extensions table (without storing in merged JSON)
     scmi_details = {"not_run": [], "failed": []}
     scmi_low = (scmi_result or "").lower()
-    if scmi_low.startswith("not run"):
-        scmi_details["not_run"] = ["SCMI"]
-    elif "not compliant" in scmi_low:
+    if "not compliant" in scmi_low:
         scmi_details["failed"] = ["SCMI"]
 
     return overall_result, bbsr_result, scmi_result, mandatory_details, recommended_details, bbsr_details, scmi_details


### PR DESCRIPTION
	-stop emitting SCMI detail row for Not Run so only failures show breakdowns
	-keep SCMI compliance line unchanged; still show failed details when Not Compliant
	-align SCMI summary rendering with BBSR style expectations

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com
Change-Id: I2c2d440c7c8736a6eb2a2989b1dd801d76da0bb6