### PR TITLE
fix: align ACS report colors and bar charts across suites

### DIFF
--- a/common/log_parser/bbr/fwts/json_to_html.py
+++ b/common/log_parser/bbr/fwts/json_to_html.py
@@ -50,7 +50,7 @@ def generate_bar_chart_fwts(suite_summary):
         suite_summary['total_skipped'],
         suite_summary['total_warnings']
     ]
-    colors = ['#66bb6a', '#ef5350', '#f39c12', '#9e9e9e', '#ffc107', '#ffeb3b']
+    colors = ['#d4edda', '#f8d7da', '#f39c12', '#9e9e9e', '#ffe0b2', '#fff3cd']
 
     plt.figure(figsize=(12, 7))
     bars = plt.bar(labels, sizes, color=colors, edgecolor='black')

--- a/common/log_parser/bbr/sct/json_to_html.py
+++ b/common/log_parser/bbr/sct/json_to_html.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2024-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,13 +69,13 @@ def generate_bar_chart_improved(suite_summary):
     ]
     # Updated colors to include a color for 'Ignored'
     colors = [
-        '#66bb6a',  # Passed
-        '#ef5350',  # Failed
+        '#d4edda',  # Passed
+        '#f8d7da',  # Failed
         '#f39c12',  # Failed with Waiver
         '#9e9e9e',  # Aborted
-        '#ffc107',  # Skipped
-        '#ffeb3b',  # Warnings
-        '#b2bec3'   # Ignored (gray-ish)
+        '#ffe0b2',  # Skipped
+        '#fff3cd',  # Warnings
+        '#cccccc'   # Ignored (gray)
     ]
 
     plt.figure(figsize=(12, 7))
@@ -111,7 +111,7 @@ def generate_bar_chart_improved(suite_summary):
 # Function to generate HTML content for both summary and detailed pages
 def generate_html_improved(suite_summary, test_results, chart_data, output_html_path, is_summary_page=True):
     # Initialize Jinja2 environment
-    env = Environment()
+    env = Environment(autoescape=True)
     env.filters['determine_css_class'] = determine_css_class
 
     # Template for both summary and detailed pages with Waiver handling + 'Ignored'
@@ -166,7 +166,7 @@ def generate_html_improved(suite_summary, test_results, chart_data, output_html_
                 font-weight: bold;
             }
             .aborted {
-                background-color: #e0e0e0;
+                background-color: #9e9e9e;
                 font-weight: bold;
             }
             .skipped {

--- a/common/log_parser/bbr/tpm/json_to_html.py
+++ b/common/log_parser/bbr/tpm/json_to_html.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2024-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,13 +64,13 @@ def generate_bar_chart_improved(suite_summary):
     ]
 
     colors = [
-        '#66bb6a',  # Passed
-        '#ef5350',  # Failed
+        '#d4edda',  # Passed
+        '#f8d7da',  # Failed
         '#f39c12',  # Failed with Waiver
         '#9e9e9e',  # Aborted
-        '#ffc107',  # Skipped
-        '#ffeb3b',  # Warnings
-        '#b2bec3'   # Ignored (gray)
+        '#ffe0b2',  # Skipped
+        '#fff3cd',  # Warnings
+        '#cccccc'   # Ignored (gray)
     ]
 
     plt.figure(figsize=(12, 7))
@@ -108,7 +108,7 @@ def generate_bar_chart_improved(suite_summary):
 # Generate HTML using Jinja2, same format/structure as the SCT snippet
 # -----------------------------------------------------------------------------
 def generate_html_improved(suite_summary, test_results, chart_data, output_html_path, is_summary_page=True):
-    env = Environment()
+    env = Environment(autoescape=True)
     env.filters['determine_css_class'] = determine_css_class
 
     template = env.from_string("""
@@ -161,7 +161,7 @@ def generate_html_improved(suite_summary, test_results, chart_data, output_html_
                 font-weight: bold;
             }
             .aborted {
-                background-color: #e0e0e0;
+                background-color: #9e9e9e;
                 font-weight: bold;
             }
             .skipped {

--- a/common/log_parser/bsa/json_to_html.py
+++ b/common/log_parser/bsa/json_to_html.py
@@ -30,22 +30,45 @@ def get_case_insensitive(d, key, default=0):
 
 # Function to generate bar chart for test results
 def generate_bar_chart(suite_summary):
-    labels = ['Passed', 'Failed', 'Failed with Waiver', 'Aborted', 'Skipped', 'Warnings']
+    labels = [
+        'Passed',
+        'Failed',
+        'Failed with Waiver',
+        'Aborted',
+        'Skipped',
+        'Warnings',
+        'Passed (Partial)',
+        'Not Implemented',
+        'PAL Not Supported'
+    ]
     sizes = [
         suite_summary.get('total_passed', 0),
         suite_summary.get('total_failed', 0),
         suite_summary.get('total_failed_with_waiver', 0),
         suite_summary.get('total_aborted', 0),
         suite_summary.get('total_skipped', 0),
-        suite_summary.get('total_warnings', 0)
+        suite_summary.get('total_warnings', 0),
+        suite_summary.get('total_passed_partial', 0),
+        suite_summary.get('total_not_implemented', 0),
+        suite_summary.get('total_pal_not_supported', 0)
     ]
-    colors = ['#66bb6a', '#ef5350', '#f39c12', '#9e9e9e', '#ffc107', '#ffeb3b']  # Colors for each category
+    colors = [
+        '#d4edda',  # Passed
+        '#f8d7da',  # Failed
+        '#f39c12',  # Failed with Waiver
+        '#9e9e9e',  # Aborted
+        '#ffe0b2',  # Skipped
+        '#fff3cd',  # Warnings
+        '#f8b88b',  # Passed (Partial)
+        '#cfd8dc',  # Not Implemented
+        '#aed6f1'   # PAL Not Supported
+    ]  # Colors for each category
 
-    plt.figure(figsize=(12, 7))
+    plt.figure(figsize=(14, 7))
     bars = plt.bar(labels, sizes, color=colors, edgecolor='black')
 
     # Add percentage labels on top of the bars
-    total_tests = sum(sizes)
+    total_tests = suite_summary.get('total_rules_run', 0) or sum(sizes)
     for bar, size in zip(bars, sizes):
         yval = bar.get_height()
         percentage = (size / total_tests) * 100 if total_tests > 0 else 0
@@ -60,7 +83,7 @@ def generate_bar_chart(suite_summary):
 
     plt.title('Test Results Distribution', fontsize=18, fontweight='bold')
     plt.ylabel('Total Count', fontsize=14)
-    plt.xticks(fontsize=12)
+    plt.xticks(fontsize=11, rotation=30, ha='right')
     plt.yticks(fontsize=12)
     plt.tight_layout()
 

--- a/common/log_parser/os_tests/json_to_html.py
+++ b/common/log_parser/os_tests/json_to_html.py
@@ -62,7 +62,7 @@ def generate_bar_chart(suite_summary, show_extended=False):
             suite_summary.get('total_skipped', 0),
             suite_summary.get('total_warnings', 0)
         ]
-        colors = ['#66bb6a', '#ef5350', '#f39c12', '#95a5a6', '#f1c40f', '#f39c12']
+        colors = ['#d4edda', '#f8d7da', '#f39c12', '#9e9e9e', '#ffe0b2', '#fff3cd']
     else:
         labels = ['Passed', 'Failed', 'Skipped']
         sizes = [
@@ -70,7 +70,7 @@ def generate_bar_chart(suite_summary, show_extended=False):
             suite_summary.get('total_failed', 0),
             suite_summary.get('total_skipped', 0)
         ]
-        colors = ['#66bb6a', '#ef5350', '#f39c12']
+        colors = ['#d4edda', '#f8d7da', '#ffe0b2']
 
     plt.figure(figsize=(8, 6))
     bars = plt.bar(labels, sizes, color=colors, edgecolor='black')
@@ -182,6 +182,9 @@ def generate_html(suite_summary, test_results_list, output_html_path, is_summary
                 background-color: #f8d7da;
             }
             .skipped {
+                background-color: #ffe0b2;
+            }
+            .warning {
                 background-color: #fff3cd;
             }
             .info {
@@ -302,7 +305,7 @@ def generate_html(suite_summary, test_results_list, output_html_path, is_summary
                     {% if show_extended_summary %}
                     <tr>
                         <td>Warnings</td>
-                        <td class="info">{{ total_warnings }}</td>
+                        <td class="warning">{{ total_warnings }}</td>
                     </tr>
                     {% endif %}
                 </tbody>
@@ -356,7 +359,7 @@ def generate_html(suite_summary, test_results_list, output_html_path, is_summary
                     <tr>
                         <td>{{ subtest.sub_Test_Number }}</td>
                         <td>{{ subtest.sub_Test_Description }}</td>
-                        <td class="{% if subtest_status == 'PASSED' %}pass{% elif subtest_status == 'FAILED' %}fail{% elif subtest_status == 'SKIPPED' %}skipped{% else %}info{% endif %}">
+                        <td class="{% if subtest_status == 'PASSED' %}pass{% elif subtest_status == 'FAILED' %}fail{% elif subtest_status == 'SKIPPED' %}skipped{% elif subtest_status == 'WARNINGS' %}warning{% else %}info{% endif %}">
                             {{ subtest_status }}
                         </td>
                         {% set all_reasons = [] %}

--- a/common/log_parser/pfdi/json_to_html.py
+++ b/common/log_parser/pfdi/json_to_html.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,8 +32,8 @@ def generate_bar_chart(summary_dict):
         summary_dict.get("total_skipped", 0),
         summary_dict.get("total_warnings", 0),
     ]
-    colors = ["#66bb6a", "#ef5350", "#f39c12",
-              "#9e9e9e", "#ffc107", "#ffeb3b"]
+    colors = ["#d4edda", "#f8d7da", "#f39c12",
+              "#9e9e9e", "#ffe0b2", "#fff3cd"]
 
     plt.figure(figsize=(12, 7))
     bars = plt.bar(labels, sizes, edgecolor="black", color=colors)

--- a/common/log_parser/post_script/json_to_html.py
+++ b/common/log_parser/post_script/json_to_html.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,7 +42,7 @@ def generate_bar_chart(suite_summary):
         suite_summary.get('total_warnings', 0)
     ]
     # Same color array as FWTS
-    colors = ['#66bb6a', '#ef5350', '#f39c12', '#9e9e9e', '#ffc107', '#ffeb3b']
+    colors = ['#d4edda', '#f8d7da', '#f39c12', '#9e9e9e', '#ffe0b2', '#fff3cd']
 
     plt.figure(figsize=(12, 7))
     bars = plt.bar(labels, sizes, color=colors, edgecolor='black')

--- a/common/log_parser/sbmr/json_to_html.py
+++ b/common/log_parser/sbmr/json_to_html.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,7 +105,7 @@ def generate_bar_chart(suite_summary):
         suite_summary.get('total_skipped', 0),
         suite_summary.get('total_warnings', 0)
     ]
-    colors = ['#66bb6a', '#ef5350', '#f39c12', '#9e9e9e', '#ffc107', '#ffeb3b']
+    colors = ['#d4edda', '#f8d7da', '#f39c12', '#9e9e9e', '#ffe0b2', '#fff3cd']
 
     plt.figure(figsize=(12, 7))
     bars = plt.bar(labels, sizes, color=colors, edgecolor='black')
@@ -155,7 +155,7 @@ DETAIL_TEMPLATE = Template("""
         .fail { background-color: #f8d7da; font-weight: bold; }
         .fail-waiver { background-color: #f39c12; font-weight: bold; }
         .warning { background-color: #fff3cd; font-weight: bold; }
-        .aborted { background-color: #bdbdbd; font-weight: bold; }
+        .aborted { background-color: #9e9e9e; font-weight: bold; }
         .skipped { background-color: #ffe0b2; font-weight: bold; }
         .summary-table { margin: 0 auto; width: 80%; }
         .summary-table td.total-tests { text-align: center; }
@@ -338,7 +338,7 @@ SUMMARY_TEMPLATE = Template("""
         .fail { background-color: #f8d7da; font-weight: bold; }
         .fail-waiver { background-color: #f39c12; font-weight: bold; }
         .warning { background-color: #fff3cd; font-weight: bold; }
-        .aborted { background-color: #bdbdbd; font-weight: bold; }
+        .aborted { background-color: #9e9e9e; font-weight: bold; }
         .skipped { background-color: #ffe0b2; font-weight: bold; }
         .summary-table { margin: 0 auto; width: 80%; }
         .summary-table td.total-tests { text-align: center; }

--- a/common/log_parser/scmi/json_to_html.py
+++ b/common/log_parser/scmi/json_to_html.py
@@ -37,7 +37,7 @@ def generate_bar_chart(summary_dict):
         summary_dict.get("total_skipped", 0),
         summary_dict.get("total_warnings", 0),
     ]
-    colors = ["#66bb6a", "#ef5350", "#f39c12", "#9e9e9e", "#ffc107", "#ffeb3b"]
+    colors = ["#d4edda", "#f8d7da", "#f39c12", "#9e9e9e", "#ffe0b2", "#fff3cd"]
 
     plt.figure(figsize=(12, 7))
     bars = plt.bar(labels, sizes, edgecolor="black", color=colors)

--- a/common/log_parser/standalone_tests/json_to_html.py
+++ b/common/log_parser/standalone_tests/json_to_html.py
@@ -70,7 +70,7 @@ def generate_bar_chart(suite_summary):
         suite_summary.get('total_warnings', 0),
         suite_summary.get('total_failed_with_waiver', 0)
     ]
-    colors = ['#66bb6a', '#ef5350', '#f39c12', '#fff3cd']
+    colors = ['#d4edda', '#f8d7da', '#fff3cd', '#f39c12']
 
     plt.figure(figsize=(8, 6))
     bars = plt.bar(labels, sizes, color=colors, edgecolor='black')
@@ -161,6 +161,15 @@ def generate_html(suite_summary, test_results_list, output_html_path,
         }
         .warning {
             background-color: #fff3cd;
+        }
+        .aborted {
+            background-color: #9e9e9e;
+        }
+        .skipped {
+            background-color: #ffe0b2;
+        }
+        .unknown {
+            background-color: #cccccc;
         }
         .summary-table {
             margin: 0 auto;
@@ -322,7 +331,7 @@ def generate_html(suite_summary, test_results_list, output_html_path,
                 <tr>
                     <td>{{ subtest.sub_Test_Number }}</td>
                     <td>{{ subtest.sub_Test_Description }}</td>
-                    <td class="{% if status == 'PASSED' %}pass{% elif status == 'FAILED' %}fail{% elif status == 'FAILED_WITH_WAIVER' %}waiver{% elif status == 'WARNINGS' %}warning{% endif %}">
+                    <td class="{% if status == 'PASSED' %}pass{% elif status == 'FAILED' %}fail{% elif status == 'FAILED_WITH_WAIVER' %}waiver{% elif status == 'WARNINGS' %}warning{% elif status == 'ABORTED' %}aborted{% elif status == 'SKIPPED' %}skipped{% elif status == 'UNKNOWN' %}unknown{% endif %}">
                         {% if status == 'FAILED_WITH_WAIVER' %}
                             FAILED WITH WAIVER
                         {% else %}


### PR DESCRIPTION
	-standardize result cell colors for pass/fail/waiver/warn/skip/abort across suites
	-sync bar chart palettes to match table colors for each suite
	-extend BSA chart with all result categories and correct percentage basis/layout

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com