### PR TITLE
Restore S_L3MM_01 for sbsa run

### DIFF
--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -257,7 +257,7 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
       if [ -f  /lib/modules/sbsa_acs.ko ]; then
         insmod /lib/modules/sbsa_acs.ko
         echo "${SR_VERSION}" > /mnt/acs_results/linux/SbsaResultsApp.log
-        echo "Running command $sbsa_command -skip S_L3_01 --skip-dp-nic-ms"
+        echo "Running command $sbsa_command --skip S_L3_01 --skip-dp-nic-ms"
         $sbsa_command --skip S_L3_01 --skip-dp-nic-ms >> /mnt/acs_results/linux/SbsaResultsApp.log
         dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/SbsaResultsKernel.log
         sync /mnt

--- a/common/uefi_scripts/sbsa.nsh
+++ b/common/uefi_scripts/sbsa.nsh
@@ -46,8 +46,8 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
         if "%1" == "" then
             FS%i:
             acs_tests\parser\Parser.efi -sbsa
-            echo "UEFI EE SBSA Command: %SbsaCommand% -skip S_L3MM_01,S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
-            FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip S_L3MM_01,S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
+            echo "UEFI EE SBSA Command: %SbsaCommand% -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
+            FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
             goto SbsaEE
         endif
         if exist FS%i:\acs_tests\bsa\sbsa\Sbsa.efi then
@@ -70,8 +70,8 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                     goto SbsaNormalMode
                 endif
 :SbsaVerboseRun
-                echo "SBSA Command: Sbsa.efi -v 1 -skip S_L3MM_01,S_L3_01 -skip-dp-nic-ms -f SbsaVerboseTempResults.log"
-                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -v 1 -skip S_L3MM_01,S_L3_01 -skip-dp-nic-ms -f SbsaVerboseTempResults.log
+                echo "SBSA Command: Sbsa.efi -v 1 -skip S_L3_01 -skip-dp-nic-ms -f SbsaVerboseTempResults.log"
+                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -v 1 -skip S_L3_01 -skip-dp-nic-ms -f SbsaVerboseTempResults.log
                 stall 200000
                 if exist FS%i:\acs_results\uefi\SbsaVerboseTempResults.log then
                     cp SbsaVerboseTempResults.log SbsaVerboseResults.log
@@ -100,16 +100,16 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             endif
 :SbsaNormalRun
             if "%1" == "false" then
-                echo "SBSA Command: Sbsa.efi -skip S_L3MM_01,S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
-                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip S_L3MM_01,S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
+                echo "SBSA Command: Sbsa.efi -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
+                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
             else
                 if "%SbsaCommand%" == "" then
                     echo "SbsaCommand variable does not exist, running default command Sbsa.efi"
-                    echo "SBSA Command: Sbsa.efi -skip S_L3MM_01,S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
-                    FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip S_L3MM_01,S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
+                    echo "SBSA Command: Sbsa.efi -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
+                    FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
                 else
-                    echo "SBSA Command: %SbsaCommand% -skip S_L3MM_01,S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
-                    FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip S_L3MM_01,S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
+                    echo "SBSA Command: %SbsaCommand% -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
+                    FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
                 endif
             endif
             stall 200000


### PR DESCRIPTION
 - Seems the S_L3MM_01 was incorrectly skipped due to change from test id based skip to rule based skip, restore the rule run

Change-Id: If911ab01d6703c149a223b112c2e19058738e5ac