### PR TITLE
(fix) yocto bsa-acs-app recipe include path updated

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-app/bsa-acs-app.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-app/bsa-acs-app.bb
@@ -13,7 +13,7 @@ TARGET_CC_ARCH += "${LDFLAGS}"
 do_compile() {
     cd  ${S}/sysarch-acs/apps/linux/bsa-acs-app
     cp  ${S}/sysarch-acs/val/src/rule_enum_string_map.c .
-    ${CC} *.c -Iinclude -I${S}/sysarch-acs/ -I${S}/sysarch-acs/val -o ${S}/bsa
+    ${CC} *.c -Iinclude -I${S}/sysarch-acs -I${S}/sysarch-acs/val/include -o ${S}/bsa
 }
 
 do_install() {


### PR DESCRIPTION
 - The changes is needed based on latest sysarch-acs include path change

Change-Id: I7169521a4e084fba8de520f5685376b3a754499b