### PR TITLE
(improv) Increase acs initramfs size

### DIFF
--- a/SystemReady-devicetree-band/Yocto/build-scripts/get_source.sh
+++ b/SystemReady-devicetree-band/Yocto/build-scripts/get_source.sh
@@ -77,7 +77,7 @@ copy_recipes()
     rm $TOP_DIR/meta-woden/poky/meta/recipes-kernel/linux/linux-yocto_6.6.bb
 
     #Increase the initramfs size to hold more storage drivers in ACS image
-    sed -i 's/INITRAMFS_MAXSIZE ??= "131072"/INITRAMFS_MAXSIZE ??= "193000"/' $TOP_DIR/meta-woden/poky/meta/conf/bitbake.conf
+    sed -i 's/INITRAMFS_MAXSIZE ??= "131072"/INITRAMFS_MAXSIZE ??= "196000"/' $TOP_DIR/meta-woden/poky/meta/conf/bitbake.conf
 
 
     #copy linux_yocto.bbappend with empty defconfig

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/edk2-test-parser/edk2-test-parser.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/edk2-test-parser/edk2-test-parser.bb
@@ -2,7 +2,7 @@ LICENSE = "BSD-2-Clause"
 LIC_FILES_CHKSUM = "file://edk2-test-parser/LICENSE;md5=c0550be4b3b9c0223efd0eaa70dc9085"
 S = "${WORKDIR}"
 
-SRC_URI = "git://git.gitlab.arm.com/systemready/edk2-test-parser.git;destsuffix=edk2-test-parser;protocol=https;branch=bbsr-yaml;name=edk2-test-parser \
+SRC_URI = "git://git.gitlab.arm.com/systemready/edk2-test-parser.git;destsuffix=edk2-test-parser;protocol=https;branch=main;name=edk2-test-parser \
 "
 
 SRCREV_edk2-test-parser = "${AUTOREV}"


### PR DESCRIPTION
 - during build yocto failed due to current inittamfs size limitation, increase size to 196000 km