### PR TITLE
SystemReady DT band: update to v3.1.2 release and align component tags

### DIFF
--- a/SystemReady-devicetree-band/README.md
+++ b/SystemReady-devicetree-band/README.md
@@ -27,9 +27,9 @@ SystemReady-devicetree band compliant platforms implement a minimum set of hardw
 The SystemReady-devicetree band compliance and testing requirements are specified in the [Arm SystemReady Requirements Specification (SRS)](https://developer.arm.com/documentation/den0109/latest)
 
 ## Latest Release details
- - Release version: v3.1.1
+ - Release version: v3.1.2
  - Quality: EAC
- - The latest pre-built release of SystemReady-devicetree band ACS is available for download here: [v25.12_3.1.1](prebuilt_images/v25.12_3.1.1)
+ - The latest pre-built release of SystemReady-devicetree band ACS is available for download here: [v26.03_3.1.2](prebuilt_images/v26.03_3.1.2)
  - The compliance suite is not a substitute for design verification.
  - To review the ACS logs, Arm licensees can contact Arm directly through their partner managers.
 
@@ -39,20 +39,21 @@ The SystemReady-devicetree band compliance and testing requirements are specifie
 
 | Test Suite                                                                                   | Test Suite Tag/Commit                                        | Specification Version |
 |----------------------------------------------------------------------------------------------|--------------------------------------------------------------|-----------------------|
-| [Base System Architecture (BSA)](https://github.com/ARM-software/sysarch-acs)                | 13248b722e9ca63522a475771e085b0a8d6d1e9d                     | BSA v1.2              |
-| [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs)                      | v25.12_EBBR_2.2.2                                            | EBBR v2.2, BBR v2.1   |
-| [Base Boot Security Requirements (BBSR)](https://github.com/ARM-software/bbr-acs)            | v25.12_BBSR_1.3.1                                            | BBSR v1.3             |
-| [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test)           | edk2-test-stable202509                                       |                       |
-| [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git)                      | v26.01.00                                                   |                       |
-| [Platform Fault Detection Interface (PFDI)](https://github.com/ARM-software/sysarch-acs)     | 13248b722e9ca63522a475771e085b0a8d6d1e9d                     | PFDI v1.0-BETA        |
+| [Base System Architecture (BSA)](https://github.com/ARM-software/sysarch-acs)                | 307dc5fcfc06476450051724fbed8713a77d6755                     | BSA v1.2              |
+| [Base Boot Requirements (BBR)](https://github.com/ARM-software/bbr-acs)                      | v26.03_EBBR_2.2.3                                            | EBBR v2.2, BBR v2.1   |
+| [Base Boot Security Requirements (BBSR)](https://github.com/ARM-software/bbr-acs)            | 29a6f10467c01b5c1146adb754d3f3db8d886779                     | BBSR v1.3             |
+| [UEFI Self Certification Tests (UEFI-SCT)](https://github.com/tianocore/edk2-test)           | 346be4f87d085646abdde22b3e50505b5929c43c                     |                       |
+| [Firmware Test Suite (FWTS)](http://kernel.ubuntu.com/git/hwe/fwts.git)                      | v26.01.00                                                    |                       |
+| [Platform Fault Detection Interface (PFDI)](https://github.com/ARM-software/sysarch-acs)     | v26.03_PFDI_0.9.0                                            | PFDI v1.0-BETA        |
+| [System Control and Management Interface (SCMI)](https://gitlab.arm.com/tests/scmi-tests)    | dd65898c866d47f5c46bcf3c619835428bd44af6                     | SCMI v3.2             |
 
 - Component details
 
 | Component                                                                   | Version           |
 |-----------------------------------------------------------------------------|-------------------|
 | [Linux Kernel](https://git.yoctoproject.org/linux-yocto/)                   | v6.18             |
-| [EDK2](https://github.com/tianocore/edk2.git)                               | edk2-stable202508 |
-| [DT bindings source](https://cdn.kernel.org/pub/linux/kernel/v6.x/)         | v6.18             |
+| [EDK2](https://github.com/tianocore/edk2.git)                               | edk2-stable202511 |
+| [DT bindings source](https://cdn.kernel.org/pub/linux/kernel/v6.x/)         | v6.19             |
 
 
 ### Prebuilt images

--- a/common/config/systemready-dt-band-source.cfg
+++ b/common/config/systemready-dt-band-source.cfg
@@ -54,28 +54,28 @@ FWTS_VERSION=26.01.00
 # Arm BSA ACS build tag/commit
 # UEFI SRC: https://github.com/ARM-software/sysarch-acs
 # Linux SRC: https://gitlab.arm.com/linux-arm/linux-acs
-BSA_ACS_TAG=""
-BSA_LINUX_ACS_TAG=""
+BSA_ACS_TAG="307dc5fcfc06476450051724fbed8713a77d6755"
+BSA_LINUX_ACS_TAG="29e047131f2bb12a1f5303e009bf9ed2684663ee"
 
 # Arm PFDI ACS build tag/commit
 # UEFI SRC: https://github.com/ARM-software/sysarch-acs
-PFDI_ACS_TAG=""
+PFDI_ACS_TAG="v26.03_PFDI_0.9.0"
 
 #Arm SCMI ACS build tag/commit
 #SCMI ACS SRC:https://gitlab.arm.com/tests/scmi-tests
-SCMI_ACS_TAG=""
+SCMI_ACS_TAG="dd65898c866d47f5c46bcf3c619835428bd44af6"
 
 # Arm BBR ACS build tag/commit
 # SRC: https://github.com/ARM-software/bbr-acs
-ARM_BBR_TAG=""
+ARM_BBR_TAG="v26.03_EBBR_2.2.3"
 
 # edk2-test-parser version
 # SRC: https://gitlab.arm.com/systemready/edk2-test-parser
-EDK2_TEST_PARSER_TAG=""
+EDK2_TEST_PARSER_TAG="e0c9331eeb077f1092bc0027c17de008fea73b88"
 
 # systemready-scripts tag/commit
 # SRC: https://gitlab.arm.com/systemready/systemready-scripts
-SYSTEMREADY_SCRIPTS_TAG=""
+SYSTEMREADY_SCRIPTS_TAG="8a37532d9bbd06f186c462a6f8f35dd0fe0adb92"
 
 # Latest commit where ledge efi http label enhancement is merged upstream
 LEDGE_EFI_TAG="d3062dd3b47282ea10f0e6e08858ca0c21596169"


### PR DESCRIPTION
- Update release version from v3.1.1 to v3.1.2
- Update prebuilt image reference to v26.03_3.1.2
- Align ACS components to latest tags/commits:
  - BSA ACS and Linux ACS commits updated
  - BBR updated to v26.03_EBBR_2.2.3
  - BBSR updated to specific commit
  - PFDI updated to v26.03_PFDI_0.9.0
  - SCMI ACS commit added
  - UEFI-SCT commit updated
- Update EDK2 to edk2-stable202511
- Update DT bindings to v6.19
- Populate systemready-dt-band-source.cfg with required ACS tags


Change-Id: Iec1998d91bf93020c9c24c97e627cf10e07de7de