### PR TITLE
Update SR run config based on xBSA rbx design

### DIFF
--- a/common/config/acs_run_config.ini
+++ b/common/config/acs_run_config.ini
@@ -15,26 +15,29 @@ automation_scrt_run = true
 [BSA]
 # This variable Enable/Disable BSA run(Valid values true or false).
 automation_bsa_run = true
-# Valid values 0, 100, 200, 300, ........, 900.
+# Valid values PE, GIC, SMMU, MEM_MAP, PERIPHERAL, TIMER, WATCHDOG, PCIE, POWER_WAKEUP.
 bsa_modules = 
-# Add tests to run here.
-bsa_tests = 
-# Add tests you want to skip here.
-bsa_skip = 
+# Valid values are 1
+bsa_level = 1
+# Add selected rules to run here.
+bsa_select_rules = 
+# Add rules which you want to skip here.
+bsa_skip_rules = 
 # Default value 
 bsa_verbose = 3
 
 [SBSA]
 # This variable Enable/Disable SBSA run(Valid values true or false).
 automation_sbsa_run = false
-# Valid values 0, 100, 200, 300 .........., 1300
+# Valid values PE, GIC, SMMU, MEM_MAP, PERIPHERAL, TIMER, WATCHDOG, PCIE,
+# POWER_WAKEUP, ETE, GPU, MPAM, RAS, PMU
 sbsa_modules = 
-# Valid values are 3,4,5,6,7,fr.
+# Valid values are 3,4,5,6,7,8.
 sbsa_level = 4
-# Add tests to run here.
-sbsa_tests = 
-# Add tests you want to skip here.
-sbsa_skip = 
+# Add selected rules to run here.
+sbsa_select_rules = 
+# Add rules which you want to skip here.
+sbsa_skip_rules = 
 # valid values 1,2,3,4,5
 sbsa_verbose = 3
 

--- a/common/parser/Parser.py
+++ b/common/parser/Parser.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,19 +32,20 @@ def process_bsa(config):
         return []
 
     cmd = ['/bin/bsa']
-  #  modules = config.get('BSA', 'bsa_modules', fallback=None)
-  #  tests = config.get('BSA', 'bsa_tests', fallback=None)
-    skip = config.get('BSA', 'bsa_skip', fallback=None)
+    level = config.get('BSA', 'bsa_level', fallback=None)
+    skip = config.get('BSA', 'bsa_skip_rules', fallback=None)
     verbose = config.get('BSA', 'bsa_verbose', fallback=None)
 
     #if modules:
     #    cmd.append(f'-m {modules}')
     #if tests:
     #    cmd.append(f'-t {",".join(tests.split(","))}')
+    if level:
+        cmd.append(f'-l {level}')
     if skip:
         cmd.append(f'--skip {skip}')
     if verbose:
-        cmd.append(f' -v{verbose}')
+        cmd.append(f' -v {verbose}')
 
     return cmd
 
@@ -54,18 +55,16 @@ def process_sbsa(config):
         return []
 
     cmd = ['/bin/sbsa']
-  #  modules = config.get('SBSA', 'sbsa_modules', fallback=None)
     level = config.get('SBSA', 'sbsa_level', fallback=None)
-  #  tests = config.get('SBSA', 'sbsa_tests', fallback=None)
-    skip = config.get('SBSA', 'sbsa_skip', fallback=None)
+    skip = config.get('SBSA', 'sbsa_skip_rules', fallback=None)
     verbose = config.get('SBSA', 'sbsa_verbose', fallback=None)
 
    # if modules:
    #     cmd.append(f'-m {modules}')
-    if level:
-        cmd.append(f'-l {level}')
    # if tests:
    #     cmd.append(f'-t {",".join(tests.split(","))}')
+    if level:
+        cmd.append(f'-l {level}')
     if skip:
         cmd.append(f'--skip {skip}')
     if verbose:

--- a/common/parser/Parser_app.c
+++ b/common/parser/Parser_app.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,7 @@
  typedef struct {
      BOOLEAN BsaEnabled;
      CHAR16* BsaModules;
+     CHAR16 *BsaLevel;
      CHAR16* BsaTests;
      CHAR16* BsaSkip;
      CHAR16* BsaVerbose;
@@ -265,6 +266,7 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
      // Initialize BSA config
      BsaConfig->BsaEnabled = FALSE;
      BsaConfig->BsaModules = NULL;
+     BsaConfig->BsaLevel = NULL;
      BsaConfig->BsaTests = NULL;
      BsaConfig->BsaSkip = NULL;
      BsaConfig->BsaVerbose = NULL;
@@ -371,12 +373,17 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
                          if (BsaConfig->BsaModules != NULL) {
                              StrCpyS(BsaConfig->BsaModules, (StrLen(Value) + 1), Value);
                          }
-                     } else if (StrnCmp(Key, L"bsa_tests", 9) == 0) {
+                     } else if (StrnCmp(Key, L"bsa_level", 10) == 0) {
+                         BsaConfig->BsaLevel = AllocatePool((StrLen(Value) + 1) * sizeof(CHAR16));
+                         if (BsaConfig->BsaLevel != NULL) {
+                             StrCpyS(BsaConfig->BsaLevel, (StrLen(Value) + 1), Value);
+                         }
+                     } else if (StrnCmp(Key, L"bsa_select_rules", 9) == 0) {
                          BsaConfig->BsaTests = AllocatePool((StrLen(Value) + 1) * sizeof(CHAR16));
                          if (BsaConfig->BsaTests != NULL) {
                              StrCpyS(BsaConfig->BsaTests, (StrLen(Value) + 1), Value);
                          }
-                     } else if (StrnCmp(Key, L"bsa_skip", 8) == 0) {
+                     } else if (StrnCmp(Key, L"bsa_skip_rules", 8) == 0) {
                          BsaConfig->BsaSkip = AllocatePool((StrLen(Value) + 1) * sizeof(CHAR16));
                          if (BsaConfig->BsaSkip != NULL) {
                              StrCpyS(BsaConfig->BsaSkip, (StrLen(Value) + 1), Value);
@@ -415,6 +422,9 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
          if (BsaConfig->BsaModules != NULL && *BsaConfig->BsaModules != L'\0') {
              CommandStringLength += StrLen(L" -m ") + StrLen(BsaConfig->BsaModules);
          }
+         if (BsaConfig->BsaLevel != NULL && *BsaConfig->BsaLevel != L'\0') {
+             CommandStringLength += StrLen(L" -l ") + StrLen(BsaConfig->BsaLevel);
+         }
          if (BsaConfig->BsaTests != NULL && *BsaConfig->BsaTests != L'\0') {
              CommandStringLength += StrLen(L" -t ") + StrLen(BsaConfig->BsaTests);
          }
@@ -437,6 +447,10 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
          if (BsaConfig->BsaModules != NULL && *BsaConfig->BsaModules != L'\0') {
              StrCatS(CommandString, CommandStringLength, L" -m ");
              StrCatS(CommandString, CommandStringLength, BsaConfig->BsaModules);
+         }
+         if (BsaConfig->BsaLevel != NULL && *BsaConfig->BsaLevel != L'\0') {
+             StrCatS(CommandString, CommandStringLength, L" -l ");
+             StrCatS(CommandString, CommandStringLength, BsaConfig->BsaLevel);
          }
          if (BsaConfig->BsaTests != NULL && *BsaConfig->BsaTests != L'\0') {
              StrCatS(CommandString, CommandStringLength, L" -t ");
@@ -504,16 +518,19 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
      if (BsaCommandString == NULL) {
          Print(L"Failed to generate BSA command string\n");
          if (BsaConfig->BsaModules != NULL && *BsaConfig->BsaModules != L'\0') {
-         FreePool(BsaConfig->BsaModules);
+             FreePool(BsaConfig->BsaModules);
+         }
+         if (BsaConfig->BsaLevel != NULL && *BsaConfig->BsaLevel != L'\0') {
+             FreePool(BsaConfig->BsaLevel);
          }
          if (BsaConfig->BsaTests != NULL && *BsaConfig->BsaTests != L'\0') {
-         FreePool(BsaConfig->BsaTests);
+             FreePool(BsaConfig->BsaTests);
          }
          if (BsaConfig->BsaSkip != NULL && *BsaConfig->BsaSkip != L'\0') {
-         FreePool(BsaConfig->BsaSkip);
+             FreePool(BsaConfig->BsaSkip);
          }
          if (BsaConfig->BsaVerbose != NULL && *BsaConfig->BsaVerbose != L'\0') {
-         FreePool(BsaConfig->BsaVerbose);
+             FreePool(BsaConfig->BsaVerbose);
          }
          FreePool(BsaConfig);
          FreePool(ConfigFileContent);
@@ -563,16 +580,19 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
      // Clean up
      //FreePool(BsaCommandString);
      if (BsaConfig->BsaModules != NULL && *BsaConfig->BsaModules != L'\0') {
-     FreePool(BsaConfig->BsaModules);
+         FreePool(BsaConfig->BsaModules);
+     }
+     if (BsaConfig->BsaLevel != NULL && *BsaConfig->BsaLevel != L'\0') {
+         FreePool(BsaConfig->BsaLevel);
      }
      if (BsaConfig->BsaTests != NULL && *BsaConfig->BsaTests != L'\0') {
-     FreePool(BsaConfig->BsaTests);
+         FreePool(BsaConfig->BsaTests);
      }
      if (BsaConfig->BsaSkip != NULL && *BsaConfig->BsaSkip != L'\0') {
-     FreePool(BsaConfig->BsaSkip);
+         FreePool(BsaConfig->BsaSkip);
      }
      if (BsaConfig->BsaVerbose != NULL && *BsaConfig->BsaVerbose != L'\0') {
-     FreePool(BsaConfig->BsaVerbose);
+         FreePool(BsaConfig->BsaVerbose);
      }
      FreePool(BsaConfig);
      FreePool(ConfigFileContent);
@@ -637,19 +657,19 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
      {
          Print(L"Failed to generate SBSA command string\n");
          if (SbsaConfig->SbsaModules != NULL && *SbsaConfig->SbsaModules != L'\0') {
-         FreePool(SbsaConfig->SbsaModules);
+             FreePool(SbsaConfig->SbsaModules);
          }
          if (SbsaConfig->SbsaLevel != NULL && *SbsaConfig->SbsaLevel != L'\0') {
-         FreePool(SbsaConfig->SbsaLevel);
+             FreePool(SbsaConfig->SbsaLevel);
          }
          if (SbsaConfig->SbsaTests != NULL && *SbsaConfig->SbsaTests != L'\0') {
-         FreePool(SbsaConfig->SbsaTests);
+             FreePool(SbsaConfig->SbsaTests);
          }
          if (SbsaConfig->SbsaSkip != NULL && *SbsaConfig->SbsaSkip != L'\0') {
-         FreePool(SbsaConfig->SbsaSkip);
+             FreePool(SbsaConfig->SbsaSkip);
          }
          if (SbsaConfig->SbsaVerboseMode != NULL && *SbsaConfig->SbsaVerboseMode != L'\0') {
-         FreePool(SbsaConfig->SbsaVerboseMode);
+             FreePool(SbsaConfig->SbsaVerboseMode);
          }
          FreePool(SbsaConfig);
          FreePool(ConfigFileContent);
@@ -703,19 +723,19 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
      // Clean up
      //FreePool(SbsaCommandString);
      if (SbsaConfig->SbsaModules != NULL && *SbsaConfig->SbsaModules != L'\0') {
-     FreePool(SbsaConfig->SbsaModules);
+         FreePool(SbsaConfig->SbsaModules);
      }
      if (SbsaConfig->SbsaLevel != NULL && *SbsaConfig->SbsaLevel != L'\0') {
-     FreePool(SbsaConfig->SbsaLevel);
+         FreePool(SbsaConfig->SbsaLevel);
      }
      if (SbsaConfig->SbsaTests != NULL && *SbsaConfig->SbsaTests != L'\0') {
-     FreePool(SbsaConfig->SbsaTests);
+         FreePool(SbsaConfig->SbsaTests);
      }
      if (SbsaConfig->SbsaSkip != NULL && *SbsaConfig->SbsaSkip != L'\0') {
-     FreePool(SbsaConfig->SbsaSkip);
+         FreePool(SbsaConfig->SbsaSkip);
      }
      if (SbsaConfig->SbsaVerboseMode != NULL && *SbsaConfig->SbsaVerboseMode != L'\0') {
-     FreePool(SbsaConfig->SbsaVerboseMode);
+         FreePool(SbsaConfig->SbsaVerboseMode);
      }
      FreePool(SbsaConfig);
      FreePool(ConfigFileContent);
@@ -872,7 +892,7 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
                              StrCpyS(SbsaConfig->SbsaLevel, (StrLen(Value) + 1), Value);
                          }
                      }
-                     else if (StrnCmp(Key, L"sbsa_tests", 10) == 0)
+                     else if (StrnCmp(Key, L"sbsa_select_rules", 10) == 0)
                      {
                          SbsaConfig->SbsaTests = AllocatePool((StrLen(Value) + 1) * sizeof(CHAR16));
                          if (SbsaConfig->SbsaTests != NULL)
@@ -880,7 +900,7 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
                              StrCpyS(SbsaConfig->SbsaTests, (StrLen(Value) + 1), Value);
                          }
                      }
-                     else if (StrnCmp(Key, L"sbsa_skip", 9) == 0)
+                     else if (StrnCmp(Key, L"sbsa_skip_rules", 9) == 0)
                      {
                          SbsaConfig->SbsaSkip = AllocatePool((StrLen(Value) + 1) * sizeof(CHAR16));
                          if (SbsaConfig->SbsaSkip != NULL)
@@ -941,11 +961,6 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
          if (SbsaConfig->SbsaVerboseMode != NULL && *SbsaConfig->SbsaVerboseMode != L'\0') {
              CommandStringLength += StrLen(L" -v ") + StrLen(SbsaConfig->SbsaVerboseMode);
          }
-         //                      StrLen(L" -m ") + StrLen(SbsaConfig->SbsaModules) +
-         //                      StrLen(L" -l ") + StrLen(SbsaConfig->SbsaLevel) +
-         //                      StrLen(L" -t ") + StrLen(SbsaConfig->SbsaTests) +
-         //                      StrLen(L" -skip ") + StrLen(SbsaConfig->SbsaSkip) +
-         //                      StrLen(L" ") + StrLen(SbsaConfig->SbsaVerboseMode) + 1;
  
          CommandString = AllocatePool(CommandStringLength * sizeof(CHAR16));
          if (CommandString == NULL)
@@ -955,24 +970,24 @@ INTN EFIAPI run_bbsr_sct_logic(UINTN Argc, IN CHAR16 **Argv);
  
          StrCpyS(CommandString, CommandStringLength, L"sbsa.efi");
          if (SbsaConfig->SbsaModules != NULL && *SbsaConfig->SbsaModules != L'\0') {
-         StrCatS(CommandString, CommandStringLength, L" -m ");
-         StrCatS(CommandString, CommandStringLength, SbsaConfig->SbsaModules);
+             StrCatS(CommandString, CommandStringLength, L" -m ");
+             StrCatS(CommandString, CommandStringLength, SbsaConfig->SbsaModules);
          }
          if (SbsaConfig->SbsaLevel != NULL && *SbsaConfig->SbsaLevel != L'\0') {
-         StrCatS(CommandString, CommandStringLength, L" -l ");
-         StrCatS(CommandString, CommandStringLength, SbsaConfig->SbsaLevel);
+             StrCatS(CommandString, CommandStringLength, L" -l ");
+             StrCatS(CommandString, CommandStringLength, SbsaConfig->SbsaLevel);
          }
          if (SbsaConfig->SbsaTests != NULL && *SbsaConfig->SbsaTests != L'\0') {
-         StrCatS(CommandString, CommandStringLength, L" -t ");
-         StrCatS(CommandString, CommandStringLength, SbsaConfig->SbsaTests);
+             StrCatS(CommandString, CommandStringLength, L" -t ");
+             StrCatS(CommandString, CommandStringLength, SbsaConfig->SbsaTests);
          }
          if (SbsaConfig->SbsaSkip != NULL && *SbsaConfig->SbsaSkip != L'\0') {
-         StrCatS(CommandString, CommandStringLength, L" -skip ");
-         StrCatS(CommandString, CommandStringLength, SbsaConfig->SbsaSkip);
+             StrCatS(CommandString, CommandStringLength, L" -skip ");
+             StrCatS(CommandString, CommandStringLength, SbsaConfig->SbsaSkip);
          }
          if (SbsaConfig->SbsaVerboseMode != NULL && *SbsaConfig->SbsaVerboseMode != L'\0') {
-         StrCatS(CommandString, CommandStringLength, L" -v ");
-         StrCatS(CommandString, CommandStringLength, SbsaConfig->SbsaVerboseMode);
+             StrCatS(CommandString, CommandStringLength, L" -v ");
+             StrCatS(CommandString, CommandStringLength, SbsaConfig->SbsaVerboseMode);
          }
      }
  

--- a/docs/SystemReady_Execution_Enviroment_and_Config_Guide.md
+++ b/docs/SystemReady_Execution_Enviroment_and_Config_Guide.md
@@ -32,16 +32,17 @@ automation_scrt_run = true
 [BSA]
 automation_bsa_run = true
 bsa_modules = 
-bsa_tests = 
-bsa_skip = 1500
+bsa_level = 1
+bsa_select_rules = 
+bsa_skip_rules = 
 bsa_verbose = 3
 
 [SBSA]
 automation_sbsa_run = false
 sbsa_modules = 
 sbsa_level = 4
-sbsa_tests = 
-sbsa_skip = 1500
+sbsa_select_rules = 
+sbsa_skip_rules = 
 sbsa_verbose = 3
 
 [FWTS]


### PR DESCRIPTION
 - Now xbsa acs are rules based and not test based, update SR run config to skip and select based on rules
 - Add level for BSA
 - Modules select is now string based and not module ID based

Change-Id: I830bc393dd747300e797b4fba727d595f698346c