### PR TITLE
Skip PCI_MM_03 run as the test needs to ensure correct BAR memory access

### DIFF
--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -234,8 +234,8 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
         # display port, mass storage, network controller...SKIP them
         /bin/bsa --skip-dp-nic-ms >> /mnt/acs_results/linux/BsaResultsApp.log
       else
-        echo "Running command $bsa_command --skip-dp-nic-ms"
-        $bsa_command --skip-dp-nic-ms  >> /mnt/acs_results/linux/BsaResultsApp.log
+        echo "Running command $bsa_command --skip PCI_MM_03 --skip-dp-nic-ms"
+        $bsa_command --skip PCI_MM_03 --skip-dp-nic-ms  >> /mnt/acs_results/linux/BsaResultsApp.log
       fi
       dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/BsaResultsKernel.log
       sync /mnt
@@ -257,8 +257,8 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
       if [ -f  /lib/modules/sbsa_acs.ko ]; then
         insmod /lib/modules/sbsa_acs.ko
         echo "${SR_VERSION}" > /mnt/acs_results/linux/SbsaResultsApp.log
-        echo "Running command $sbsa_command --skip S_L3_01 --skip-dp-nic-ms"
-        $sbsa_command --skip S_L3_01 --skip-dp-nic-ms >> /mnt/acs_results/linux/SbsaResultsApp.log
+        echo "Running command $sbsa_command --skip S_L3_01,PCI_MM_03 --skip-dp-nic-ms"
+        $sbsa_command --skip S_L3_01,PCI_MM_03 --skip-dp-nic-ms >> /mnt/acs_results/linux/SbsaResultsApp.log
         dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/SbsaResultsKernel.log
         sync /mnt
         sleep 5


### PR DESCRIPTION
 - The current test maps the BAR memry region to NORMAL memmory and perform unaligned access
 - But in some cases, the BAR region might be mapped to a region which doesn't support unaligned access
 - Acess to such regions results in exception and breaks automation

Change-Id: Ic8055369d6881a2a6b5de7427af39a588f976ea1