### PR TITLE
fix: move S_L3_01 skip rule from scripts to acs_run_config.ini

### DIFF
--- a/common/config/acs_run_config.ini
+++ b/common/config/acs_run_config.ini
@@ -37,7 +37,7 @@ sbsa_level = 4
 # Add selected rules to run here.
 sbsa_select_rules = 
 # Add rules which you want to skip here.
-sbsa_skip_rules = 
+sbsa_skip_rules = S_L3_01
 # valid values 1,2,3,4,5
 sbsa_verbose = 3
 

--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -246,7 +246,6 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
     fi
   fi
 
-
   # Linux SBSA Execution
   echo "Running Linux SBSA tests"
   if [ "$automation_enabled" == "True" ]; then
@@ -257,8 +256,8 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
       if [ -f  /lib/modules/sbsa_acs.ko ]; then
         insmod /lib/modules/sbsa_acs.ko
         echo "${SR_VERSION}" > /mnt/acs_results/linux/SbsaResultsApp.log
-        echo "Running command $sbsa_command --skip S_L3_01,PCI_MM_03 --skip-dp-nic-ms"
-        $sbsa_command --skip S_L3_01,PCI_MM_03 --skip-dp-nic-ms >> /mnt/acs_results/linux/SbsaResultsApp.log
+        echo "Running command $sbsa_command --skip PCI_MM_03 --skip-dp-nic-ms"
+        $sbsa_command --skip PCI_MM_03 --skip-dp-nic-ms >> /mnt/acs_results/linux/SbsaResultsApp.log
         dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/SbsaResultsKernel.log
         sync /mnt
         sleep 5

--- a/common/uefi_scripts/sbsa.nsh
+++ b/common/uefi_scripts/sbsa.nsh
@@ -46,8 +46,8 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
         if "%1" == "" then
             FS%i:
             acs_tests\parser\Parser.efi -sbsa
-            echo "UEFI EE SBSA Command: %SbsaCommand% -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
-            FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
+            echo "UEFI EE SBSA Command: %SbsaCommand% -skip-dp-nic-ms -f SbsaTempResults.log"
+            FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip-dp-nic-ms -f SbsaTempResults.log
             goto SbsaEE
         endif
         if exist FS%i:\acs_tests\bsa\sbsa\Sbsa.efi then
@@ -70,8 +70,8 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                     goto SbsaNormalMode
                 endif
 :SbsaVerboseRun
-                echo "SBSA Command: Sbsa.efi -v 1 -skip S_L3_01 -skip-dp-nic-ms -f SbsaVerboseTempResults.log"
-                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -v 1 -skip S_L3_01 -skip-dp-nic-ms -f SbsaVerboseTempResults.log
+                echo "SBSA Command: Sbsa.efi -v 1 -skip-dp-nic-ms -f SbsaVerboseTempResults.log"
+                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -v 1 -skip-dp-nic-ms -f SbsaVerboseTempResults.log
                 stall 200000
                 if exist FS%i:\acs_results\uefi\SbsaVerboseTempResults.log then
                     cp SbsaVerboseTempResults.log SbsaVerboseResults.log
@@ -100,16 +100,16 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             endif
 :SbsaNormalRun
             if "%1" == "false" then
-                echo "SBSA Command: Sbsa.efi -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
-                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
+                echo "SBSA Command: Sbsa.efi -skip-dp-nic-ms -f SbsaTempResults.log"
+                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip-dp-nic-ms -f SbsaTempResults.log
             else
                 if "%SbsaCommand%" == "" then
                     echo "SbsaCommand variable does not exist, running default command Sbsa.efi"
-                    echo "SBSA Command: Sbsa.efi -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
-                    FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
+                    echo "SBSA Command: Sbsa.efi -skip-dp-nic-ms -f SbsaTempResults.log"
+                    FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip-dp-nic-ms -f SbsaTempResults.log
                 else
-                    echo "SBSA Command: %SbsaCommand% -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log"
-                    FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip S_L3_01 -skip-dp-nic-ms -f SbsaTempResults.log
+                    echo "SBSA Command: %SbsaCommand% -skip-dp-nic-ms -f SbsaTempResults.log"
+                    FS%i:\acs_tests\bsa\sbsa\%SbsaCommand% -skip-dp-nic-ms -f SbsaTempResults.log
                 endif
             endif
             stall 200000


### PR DESCRIPTION
- Removes UEFI hardcoded --skip to avoid overlapping
- Update Linux and UEFI scripts to match the handling


Change-Id: Ib1bbe5c698fa00d4fbf9c3a9f4997f3e211a5b26