### PR TITLE
(fix) common - Update the fwts tar download link to github fwts repo

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/fwts/fwts_26.01.00.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/fwts/fwts_26.01.00.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://src/main.c;beginline=1;endline=16;md5=79533a427253d19
 
 S = "${WORKDIR}/${BP}/fwts-${PV}"
 
-SRC_URI = "https://fwts.ubuntu.com/release/fwts-V${PV}.tar.gz;subdir=${BP} \
+SRC_URI = "https://github.com/fwts/fwts/archive/refs/tags/V${PV}.tar.gz;subdir=${BP} \
            file://0001-Add-correct-printf-qualifier-for-off_t.patch \
            file://0004-Define-__SWORD_TYPE-if-not-defined-by-libc.patch \
            file://0005-Undefine-PAGE_SIZE.patch \

--- a/common/patches/build_fwts_version_26.01.00.patch
+++ b/common/patches/build_fwts_version_26.01.00.patch
@@ -123,7 +123,7 @@ index 8634980e03..e11ac40bd7 100644
 -# Hash from: http://fwts.ubuntu.com/release/SHA256SUMS
 -sha256  17d1f0b9639e0f9b092ed8233be2d63d6c44ea8d2a76be0fb5902cc867961374  fwts-V21.11.00.tar.gz
 +# Hash from: https://fwts.ubuntu.com/release/SHA256SUMS
-+sha256  25565fd007b378bf29581eb0bc36a03a2f0c49326bb6084f980fee9c5921f289  fwts-V26.01.00.tar.gz
++sha256  25565fd007b378bf29581eb0bc36a03a2f0c49326bb6084f980fee9c5921f289  V26.01.00.tar.gz
  
  # Hash for license file
 -sha256  fbbea748555635dd8c7e6e2f99cddd778f5ee3f9e3510775183bf9799076e5e5  debian/copyright


### PR DESCRIPTION
 - Current fwts package download link "https://fwts.ubuntu.com/release" is down and resulting in systemready failures.
 - Use the github mirror "https://github.com/fwts/fwts/archive/refs/tags"w

Change-Id: If8b30576e7e9f8e941e5c7d125fae39b6fb89cd6