### PR TITLE
bsa.nsh: replace el1physkip command with el1skiptrap cntpct

### DIFF
--- a/common/config/systemready-dt-band-source.cfg
+++ b/common/config/systemready-dt-band-source.cfg
@@ -54,7 +54,7 @@ FWTS_VERSION=26.01.00
 # Arm BSA ACS build tag/commit
 # UEFI SRC: https://github.com/ARM-software/sysarch-acs
 # Linux SRC: https://gitlab.arm.com/linux-arm/linux-acs
-BSA_ACS_TAG="307dc5fcfc06476450051724fbed8713a77d6755"
+BSA_ACS_TAG="a78da6629dae7343034d8e8e3671b3b56d7d8c29"
 BSA_LINUX_ACS_TAG="29e047131f2bb12a1f5303e009bf9ed2684663ee"
 
 # Arm PFDI ACS build tag/commit

--- a/common/uefi_scripts/bsa.nsh
+++ b/common/uefi_scripts/bsa.nsh
@@ -91,8 +91,8 @@ if exist FS%i:\acs_tests\bsa\Bsa.efi then
         echo "Running BSA in verbose mode"
         if exist FS%i:\acs_tests\bsa\bsa_dt.flag then
             #Executing for BSA SystemReady-devicetree-band. Execute only OS tests
-            echo "BSA Command: Bsa.efi  -v 1 -os -skip-dp-nic-ms -el1physkip -dtb BsaDevTree.dtb -f BsaVerboseTempResults.log"
-            FS%i:\acs_tests\bsa\Bsa.efi -v 1 -os -skip-dp-nic-ms -el1physkip -dtb BsaDevTree.dtb -f BsaVerboseTempResults.log
+            echo "BSA Command: Bsa.efi  -v 1 -os -skip-dp-nic-ms -el1skiptrap cntpct -dtb BsaDevTree.dtb -f BsaVerboseTempResults.log"
+            FS%i:\acs_tests\bsa\Bsa.efi -v 1 -os -skip-dp-nic-ms -el1skiptrap cntpct -dtb BsaDevTree.dtb -f BsaVerboseTempResults.log
         else
             echo "BSA Command: Bsa.efi -v 1 -skip-dp-nic-ms -f BsaVerboseTempResults.log"
             FS%i:\acs_tests\bsa\Bsa.efi -v 1 -skip-dp-nic-ms -f BsaVerboseTempResults.log
@@ -125,8 +125,8 @@ if exist FS%i:\acs_tests\bsa\Bsa.efi then
 :BsaRun
     if exist FS%i:\acs_tests\bsa\bsa_dt.flag then
        #Executing for BSA SystemReady-devicetree-band. Execute only OS tests
-       echo "BSA Command: Bsa.efi -os -dtb BsaDevTree.dtb -skip-dp-nic-ms -el1physkip -f BsaTempResults.log"
-       FS%i:\acs_tests\bsa\Bsa.efi -os -dtb BsaDevTree.dtb -skip-dp-nic-ms -el1physkip -f BsaTempResults.log
+       echo "BSA Command: Bsa.efi -os -dtb BsaDevTree.dtb -skip-dp-nic-ms -el1skiptrap cntpct -f BsaTempResults.log"
+       FS%i:\acs_tests\bsa\Bsa.efi -os -dtb BsaDevTree.dtb -skip-dp-nic-ms -el1skiptrap cntpct -f BsaTempResults.log
     else
         if "%1" == "false" then
             echo  "BSA Command: Bsa.efi -skip-dp-nic-ms -f BsaTempResults.log"


### PR DESCRIPTION
Update BSA execution commands in bsa.nsh to use `-el1skiptrap cntpct` instead of deprecated `-el1physkip`.


Change-Id: I8a978cce26c7b2fc5435dec93726df2a8ec6c9cd