### PR TITLE
fix: split BSA "not tested" outcomes into explicit PAL/Not Implemented

### DIFF
--- a/common/log_parser/apply_waivers.py
+++ b/common/log_parser/apply_waivers.py
@@ -807,7 +807,7 @@ def apply_waivers(suite_name, json_file, waiver_file='waiver.json', output_json_
                             failed += 1
                     elif 'PAL NOT SUPPORTED' in r:
                         pal += 1
-                    elif 'NOT TESTED (TEST NOT IMPLEMENTED)' in r:
+                    elif 'TEST NOT IMPLEMENTED' in r:
                         notimpl += 1
                     elif 'SKIPPED' in r:
                         skipped += 1
@@ -990,9 +990,9 @@ def apply_waivers(suite_name, json_file, waiver_file='waiver.json', output_json_
                     suite_totals["Failed"] += 1
                 elif "PASSED(*PARTIAL)" in test_result or "PASSED (PARTIAL)" in test_result:
                     suite_totals["Passed (Partial)"] += 1
-                elif "NOT TESTED (TEST NOT IMPLEMENTED)" in test_result:
+                elif "TEST NOT IMPLEMENTED" in test_result:
                     suite_totals["Not Implemented"] += 1
-                elif "NOT TESTED (PAL NOT SUPPORTED)" in test_result:
+                elif "PAL NOT SUPPORTED" in test_result:
                     suite_totals["PAL Not Supported"] += 1
                 elif "SKIPPED" in test_result:
                     suite_totals["Skipped"] += 1

--- a/common/log_parser/bsa/json_to_html.py
+++ b/common/log_parser/bsa/json_to_html.py
@@ -315,7 +315,7 @@ def generate_html(suite_summary, test_results, chart_data, output_html_path, tes
                     <tr>
                         <td>{{ testcase.Test_case }}</td>
                         <td>{{ testcase.Test_case_description }}</td>
-                        <td class="{% if testcase.Test_result == 'PASSED' %}pass{% elif testcase.Test_result == 'FAILED (WITH WAIVER)' %}fail-waiver{% elif testcase.Test_result == 'FAILED' %}fail{% elif testcase.Test_result == 'WARNING' %}warning{% elif 'PASSED(*PARTIAL)' in testcase.Test_result %}passed-partial{% elif testcase.Test_result == 'SKIPPED' %}skipped{% elif 'NOT TESTED' in testcase.Test_result %}not-tested{% endif %}">
+                        <td class="{% if testcase.Test_result == 'PASSED' %}pass{% elif testcase.Test_result == 'FAILED (WITH WAIVER)' %}fail-waiver{% elif testcase.Test_result == 'FAILED' %}fail{% elif testcase.Test_result == 'WARNING' %}warning{% elif 'PASSED(*PARTIAL)' in testcase.Test_result %}passed-partial{% elif testcase.Test_result == 'SKIPPED' %}skipped{% elif testcase.Test_result in ['PAL NOT SUPPORTED', 'NOT TESTED (PAL NOT SUPPORTED)'] %}pal-not-supported{% elif testcase.Test_result in ['TEST NOT IMPLEMENTED', 'NOT TESTED (TEST NOT IMPLEMENTED)'] %}not-implemented{% elif 'NOT TESTED' in testcase.Test_result %}not-tested{% endif %}">
                             {{ testcase.Test_result }}
                         </td>
                         <td class="waiver-reason">
@@ -344,7 +344,7 @@ def generate_html(suite_summary, test_results, chart_data, output_html_path, tes
                                     <tr>
                                         <td>{{ subtest.sub_Test_Number }}</td>
                                         <td>{{ subtest.sub_Test_Description }}</td>
-                                        <td class="{% if subtest.sub_test_result == 'PASSED' %}pass{% elif subtest.sub_test_result == 'FAILED (WITH WAIVER)' %}fail-waiver{% elif subtest.sub_test_result == 'FAILED' %}fail{% elif subtest.sub_test_result == 'WARNING' %}warning{% elif 'PASSED(*PARTIAL)' in subtest.sub_test_result %}passed-partial{% elif subtest.sub_test_result == 'SKIPPED' %}skipped{% elif 'NOT TESTED' in subtest.sub_test_result %}not-tested{% endif %}">
+                                        <td class="{% if subtest.sub_test_result == 'PASSED' %}pass{% elif subtest.sub_test_result == 'FAILED (WITH WAIVER)' %}fail-waiver{% elif subtest.sub_test_result == 'FAILED' %}fail{% elif subtest.sub_test_result == 'WARNING' %}warning{% elif 'PASSED(*PARTIAL)' in subtest.sub_test_result %}passed-partial{% elif subtest.sub_test_result == 'SKIPPED' %}skipped{% elif subtest.sub_test_result in ['PAL NOT SUPPORTED', 'NOT TESTED (PAL NOT SUPPORTED)'] %}pal-not-supported{% elif subtest.sub_test_result in ['TEST NOT IMPLEMENTED', 'NOT TESTED (TEST NOT IMPLEMENTED)'] %}not-implemented{% elif 'NOT TESTED' in subtest.sub_test_result %}not-tested{% endif %}">
                                             {{ subtest.sub_test_result }}
                                         </td>
                                         <td class="waiver-reason">

--- a/common/log_parser/bsa/logs_to_json.py
+++ b/common/log_parser/bsa/logs_to_json.py
@@ -46,14 +46,14 @@ def classify_status(status_text):
         return formatted_result, summary_category
 
     # PAL not supported
-    if "NOT TESTED" in up and "PAL NOT SUPPORTED" in up:
-        formatted_result = "NOT TESTED (PAL NOT SUPPORTED)"
+    if "PAL NOT SUPPORTED" in up:
+        formatted_result = "PAL NOT SUPPORTED"
         summary_category = "PAL Not Supported"
         return formatted_result, summary_category
 
     # Test not implemented
-    if "NOT TESTED" in up and "TEST NOT IMPLEMENTED" in up:
-        formatted_result = "NOT TESTED (TEST NOT IMPLEMENTED)"
+    if "TEST NOT IMPLEMENTED" in up:
+        formatted_result = "TEST NOT IMPLEMENTED"
         summary_category = "Test Not Implemented"
         return formatted_result, summary_category
 


### PR DESCRIPTION

	-report PAL NOT SUPPORTED and TEST NOT IMPLEMENTED results from BSA/SBSA logs
	-update waiver summary counting to match new result strings (backward compatible)
	-style PAL/Not Implemented rows explicitly in BSA HTML output

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com
Change-Id: I5bffd63217428c5caf037bd2a39cfa127b02c154