### PR TITLE
Refresh Yocto ACS recipe metadata to match current upstream sources.

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-app/bsa-acs-app.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-app/bsa-acs-app.bb
@@ -1,6 +1,6 @@
 SUMMARY = "BSA ACS Linux application"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://sysarch-acs/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
+LIC_FILES_CHKSUM = "file://sysarch-acs/LICENSE;md5=e1cd0b49f4875bd7fdf5b963f4b0a147 \
 "
 
 SRC_URI = "git://github.com/ARM-software/sysarch-acs;destsuffix=sysarch-acs;protocol=https;branch=main;name=sysarch-acs \

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-drv/bsa-acs-drv.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-drv/bsa-acs-drv.bb
@@ -1,6 +1,6 @@
 SUMMARY = "BSA-ACS Linux driver"
 LICENSE = "GPLv2 & Apache-2.0"
-LIC_FILES_CHKSUM = "file://sysarch-acs/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
+LIC_FILES_CHKSUM = "file://sysarch-acs/LICENSE;md5=e1cd0b49f4875bd7fdf5b963f4b0a147 \
                     file://linux-acs/acs-drv/files/COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e \
 "
 COMPATIBLE_MACHINE:genericarm64 = "genericarm64"

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-uefi/bsa-acs.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-uefi/bsa-acs.bb
@@ -4,7 +4,7 @@ PROVIDES:remove = "virtual/uefi-firmware"
 PROVIDES:remove = "virtual/bootloader"
 
 LICENSE += "& Apache-2.0"
-LIC_FILES_CHKSUM += "file://ShellPkg/Application/sysarch-acs/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+LIC_FILES_CHKSUM += "file://ShellPkg/Application/sysarch-acs/LICENSE;md5=e1cd0b49f4875bd7fdf5b963f4b0a147"
 COMPATIBLE_MACHINE:genericarm64 = "genericarm64"
 
 SRC_URI += "git://github.com/ARM-software/sysarch-acs;destsuffix=edk2/ShellPkg/Application/sysarch-acs;protocol=https;branch=main;name=sysarch-acs \

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/ebbr-sct/ebbr-sct.bb
@@ -15,7 +15,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://bbr-acs/LICENSE.md;md5=2a944942e1496af1886903d274dedb13"
 
 SRC_URI += "git://github.com/ARM-software/bbr-acs;destsuffix=bbr-acs;protocol=https;branch=main;name=bbr-acs \
-            git://github.com/tianocore/edk2-test;destsuffix=edk2-test;protocol=https;nobranch=1;name=edk2-test \
+            git://github.com/tianocore/edk2-test;destsuffix=edk2-test;protocol=https;branch=master;name=edk2-test \
             gitsm://github.com/tianocore/edk2.git;destsuffix=edk2-test/edk2;protocol=https;nobranch=1;name=edk2 \
             file://sctversion.patch;patch=1;patchdir=edk2-test \
 "


### PR DESCRIPTION
- Update sysarch-acs LICENSE md5 checksums in the bsa-acs-app, bsa-acs-drv, and bsa-acs-uefi recipes.
- Pin the edk2-test source in the ebbr-sct recipe to the master branch instead of using nobranch fetch behavior.

These are metadata-only recipe updates with no functional code changes.

Change-Id: Iff75d6423e527a40d0d18b0b65f64c089188674a