### PR TITLE
(fix sr-band): Skip PCI_MM_03 in both automation and custom acs runs

### DIFF
--- a/SystemReady-band/README.md
+++ b/SystemReady-band/README.md
@@ -277,18 +277,19 @@ This is expected behavior and the progress of tests will continue after a 20-min
 
 ## Current Limitations
 
-### BSA
+### BSA and SBSA
+
+#### Exerciser dependent rules
+
 Validating the compliance of certain PCIe rules defined in the BSA specification require the PCIe end-point generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
 The details of the hardware or Verification IP which enable these exerciser tests platform specific and are beyond the scope of this document.
-
 The ACS image does not allow customizations, hence, the exerciser module is not included in the ACS image. To enable exerciser tests for greater coverage of PCIe rules, please refer to [SYSARCH-ACS Exerciser Guide](https://github.com/ARM-software/sysarch-acs/blob/main/docs/pcie/Exerciser.md) Or contact your Arm representative for details.
 
-### SBSA
-Validating the compliance of certain PCIe rules defined in the SBSA specification requires the PCIe end-point to generate specific stimulus during the runtime of the test. Examples of such stimulus are  P2P, PASID, ATC, etc. The tests that requires these stimuli are grouped together in the exerciser module. The exerciser layer is an abstraction layer that enables the integration of hardware capable of generating such stimuli to the test framework.
-The details of the hardware or Verification IP which enable these exerciser tests are platform specific and are beyond the scope of this document.
-
- - Some PCIe and Exerciser test are dependent on PCIe features supported by the test system.
-   Please fill the required API's with test system information.
+Below exerciser capabilities are required by exerciser test.
+- MSI-X interrupt generation.
+- Incoming Transaction Monitoring(order, type).
+- Initiating transactions from and to the exerciser.
+- Ability to check on BDF and register address seen for each configuration address along with access type.
 
 |APIs                         |Description                                                                   |Affected tests          |
 |-----------------------------|------------------------------------------------------------------------------|------------------------|
@@ -296,13 +297,13 @@ The details of the hardware or Verification IP which enable these exerciser test
 |pal_pcie_is_cache_present    |Return 1 if the test system supports PCIe address translation cache, else 0   |852                     |
 |pal_pcie_get_legacy_irq_map  |Return 0 if system legacy irq map is filled, else 1                           |850                     |
 
-   Below exerciser capabilities are required by exerciser test.
-   - MSI-X interrupt generation.
-   - Incoming Transaction Monitoring(order, type).
-   - Initiating transactions from and to the exerciser.
-   - Ability to check on BDF and register address seen for each configuration address along with access type.
+#### SBSA Test 803 (Check ECAM Memory accessibility)
 
- - SBSA Test 803 (Check ECAM Memory accessibility) execution time depends on the system PCIe hierarchy. For systems with multiple ECAMs the time taken to complete can be long which is normal. Please wait until the test completes.
+- The execution time depends on the system PCIe hierarchy. On systems with multiple ECAMs, this test can take longer to complete, which is expected. Please wait until the test completes.
+
+#### PCIe rule PCI_MM_03 - temporarily skipped in ACS runs
+
+- On some systems, PCIe rule PCI_MM_03 triggers exceptions during BAR memory access. To avoid interrupting automation and custom runs, this rule is temporarily skipped in the ACS image. The issue is tracked in https://github.com/ARM-software/sysarch-acs/issues/282.
 
 
 ## Security Implication

--- a/common/linux_scripts/bsa.sh
+++ b/common/linux_scripts/bsa.sh
@@ -32,9 +32,9 @@ else
     insmod /lib/modules/bsa_acs.ko
     echo "SystemReady band ACS v3.1.1" > /mnt/acs_results/linux/BsaResultsApp.log
     if [ "$automation_enabled" == "False" ]; then
-      /bin/bsa --skip-dp-nic-ms >> /mnt/acs_results/linux/BsaResultsApp.log
+      /bin/bsa --skip PCI_MM_03 --skip-dp-nic-ms >> /mnt/acs_results/linux/BsaResultsApp.log
     else
-      $bsa_command --skip-dp-nic-ms >> /mnt/acs_results/linux/BsaResultsApp.log
+      $bsa_command --skip PCI_MM_03 --skip-dp-nic-ms >> /mnt/acs_results/linux/BsaResultsApp.log
     fi
     dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/BsaResultsKernel.log
     sync /mnt

--- a/common/linux_scripts/sbsa.sh
+++ b/common/linux_scripts/sbsa.sh
@@ -32,9 +32,9 @@ else
     insmod /lib/modules/sbsa_acs.ko
     echo "SystemReady band ACS v3.1.1" > /mnt/acs_results/linux/SbsaResultsApp.log
     if [ "$automation_enabled" == "False" ]; then
-      /bin/sbsa --skip-dp-nic-ms >> /mnt/acs_results/linux/SbsaResultsApp.log
+      /bin/sbsa --skip PCI_MM_03 --skip-dp-nic-ms >> /mnt/acs_results/linux/SbsaResultsApp.log
     else
-      $sbsa_command  --skip-dp-nic-ms >> /mnt/acs_results/linux/SbsaResultsApp.log
+      $sbsa_command --skip PCI_MM_03 --skip-dp-nic-ms >> /mnt/acs_results/linux/SbsaResultsApp.log
     fi
     dmesg | sed -n 'H; /PE_INFO/h; ${g;p;}' > /mnt/acs_results/linux/SbsaResultsKernel.log
     sync /mnt


### PR DESCRIPTION
  - Added --skip PCI_MM_03 to the BSA and SBSA launch paths so the rule is consistently skipped regardless of how ACS is invoked.
  - Updated the README limitation text to document the temporary skip and clarify the related wording for SBSA Test 803 and PCI_MM_03.

Fixes #716
 
Change-Id: I15817ea809faad484d6bb2a2791ac2ca9924d9ee