### PR TITLE
(fix) Fix environment spelling in docs and launch text

### DIFF
--- a/SystemReady-band/README.md
+++ b/SystemReady-band/README.md
@@ -155,7 +155,7 @@ This image comprise of single FAT file system partition recognized by UEFI: <br 
   - bootaa64.efi - grub executable
   - grub.cfg - grub config file
   - startup.nsh - uefi automation run startup file
-  - startup_ee.nsh - uefi execution enviroment startup file
+  - startup_ee.nsh - uefi execution environment startup file
 - acs_tests contains executable files and configs related for test suites
   - app directory contains CapsuleApp.efi
   - bbr directory contains SCT related bianries and sequence files
@@ -186,8 +186,8 @@ This image comprise of single FAT file system partition recognized by UEFI: <br 
  │ Linux Boot                                    │
  │*SystemReady band ACS (Automation)             │
  │ BBSR Compliance (Automation)                  │
- │ UEFI Execution Enviroment                     │
- │ Linux Execution Enviroment                    │
+ │ UEFI Execution Environment                    │
+ │ Linux Execution Environment                   │
  │ Linux Boot with SetVirtualAddressMap enabled  |
 ```
  - **Linux Boot** : This option will boot the ACS Linux kernel and run the default Linux tool (linux debug dump, fwts, linux bsa, linux sbsa (if selected))
@@ -196,9 +196,9 @@ This image comprise of single FAT file system partition recognized by UEFI: <br 
  - **SystemReady band ACS (Automation)** : This is **default** option and will run the automated compliance
    - UEFI compliance run - SCT, BSA UEFI, SBSA UEFI (if selected)
    - Boots to Linux and run Linux compliance run - SBMR IB, FWTS, BSA Linux, SBSA Linux (if selected)
- - **UEFI Execution Enviroment** : This option is introduced to manually run the selective UEFI test suites like SCT, BSA and SBSA with desired configuration.
- - **Linux Execution Enviroment** : This option is introduced to manually run the selective Linux test suites like FWTS, BSA and SBSA with desired configuration
-     For more details on the Execution Enviroment and acs run config, refer to the [SystemReady_Execution_Enviroment_and_Config_Guide](../docs/SystemReady_Execution_Enviroment_and_Config_Guide.md)
+ - **UEFI Execution Environment** : This option is introduced to manually run the selective UEFI test suites like SCT, BSA and SBSA with desired configuration.
+ - **Linux Execution Environment** : This option is introduced to manually run the selective Linux test suites like FWTS, BSA and SBSA with desired configuration
+   For more details on the Execution Environment and acs run config, refer to the [SystemReady_Execution_Environment_and_Config_Guide](../docs/SystemReady_Execution_Environment_and_Config_Guide.md)
    - UEFI compliance run - SCT, BSA UEFI, SBSA UEFI (if selected)
    - Boots to Linux and run Linux compliance run - SBMR IB, FWTS, BSA Linux, SBSA Linux (if selected)
  - **BBSR Compliance (Automation)** : This option will run the SCT and FWTS tests required for BBSR compliance, perform a Linux secure boot, and, if a TPM is present, evaluate the measured boot log. For the verification steps of BBSR ACS, refer to the [BBSR ACS Verification](../docs/BBSR_ACS_Verification.md).
@@ -209,7 +209,7 @@ This image comprise of single FAT file system partition recognized by UEFI: <br 
 
 - **acs_run_config.ini**: This file is used to manage the execution of various ACS test suites and supports passing parameters to them. <br />
 
-  Please refer to [SystemReady_Execution_Enviroment_and_Config_Guide](../docs/SystemReady_Execution_Enviroment_and_Config_Guide.md) on details of modifying the config file.
+  Please refer to [SystemReady_Execution_Environment_and_Config_Guide](../docs/SystemReady_Execution_Environment_and_Config_Guide.md) on details of modifying the config file.
  
 - **system_config.txt**: The file is used to collect below system information which is required for **ACS_Summary.html** report, It is recommned to fill this information before running the ACS image for complaince.
    - FW source code: Unknown

--- a/common/config/grub-buildroot.cfg
+++ b/common/config/grub-buildroot.cfg
@@ -16,10 +16,10 @@ menuentry 'SystemReady band ACS (Automation)' {
 menuentry 'BBSR Compliance (Automation)' {
     chainloader /EFI/BOOT/Shell.efi -nostartup bbsr_startup.nsh
 }
-menuentry 'UEFI Execution Enviroment' {
+menuentry 'UEFI Execution Environment' {
     chainloader /EFI/BOOT/Shell.efi -nostartup startup_ee.nsh
 }
-menuentry 'Linux Execution Enviroment' {
+menuentry 'Linux Execution Environment' {
     linux /Image rootwait  debug crashkernel=512M log_buf_len=1M print-fatal-signals=1 efi=debug acpi=on earlycon console=tty0 console=ttyS0  console=ttyAMA0 initcall_blacklist=psci_checker noacs
     initrd /ramdisk-buildroot.img
 }

--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -348,8 +348,8 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
   echo "Please press <Enter> to continue ..."
 else
   echo ""
-  echo "Linux Execution Enviroment can be used to run an acs test suite manually with desired options"
-  echo "The supported test suites for Linux enviroment are"
+  echo "Linux Execution Environment can be used to run an acs test suite manually with desired options"
+  echo "The supported test suites for Linux environment are"
   echo "  BSA"
   echo "  SBSA"
   echo "  FWTS"

--- a/common/uefi_scripts/startup_ee.nsh
+++ b/common/uefi_scripts/startup_ee.nsh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +22,8 @@ connect -r
 for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     if exist FS%i:\acs_tests\parser\Parser.efi then
         FS%i:
-        echo "UEFI Execution Enviroment can be used to run an acs test suite manually with desired options"
-        echo "The supported test suites for UEFI enviroment are"
+        echo "UEFI Execution Environment can be used to run an acs test suite manually with desired options"
+        echo "The supported test suites for UEFI environment are"
         echo "  BSA"
         echo "  SBSA"
         echo "  SCT"

--- a/docs/SystemReady_Execution_Environment_and_Config_Guide.md
+++ b/docs/SystemReady_Execution_Environment_and_Config_Guide.md
@@ -1,10 +1,10 @@
-# SystemReady Band Execution Enviroment and Configuration User Guide
+# SystemReady Band Execution Environment and Configuration User Guide
 
 ## Overview
 
-This guide provides details on the SR band Execution Enviroment and configuration-based feature integrated into the SystemReady-band image.
+This guide provides details on the SR band Execution Environment and configuration-based feature integrated into the SystemReady-band image.
 
-Execution Enviroment is used to run manually only a desired selected test suites, and with a configuration file the test suite run can be customized with required parameter.
+Execution Environment is used to run manually only a desired selected test suites, and with a configuration file the test suite run can be customized with required parameter.
 The configuration file can also be used to selectively enable/disable individual test suites in automation run. This allows for flexible and targeted testing.
 
 ---
@@ -147,17 +147,17 @@ config_enabled_for_automation_run = false
 
 ---
 
-## SR Execution Enviroment
+## SR Execution Environment
 
-The grub menu is updated to provide two more options for execution enviroment.
+The grub menu is updated to provide two more options for execution environment.
 On boot, users are presented with the following GRUB menu:
 
 ```
 Linux Boot
 SystemReady band ACS (Automation)
 BBSR Compliance (Automation)
-UEFI Execution Enviroment
-Linux Execution Enviroment
+UEFI Execution Environment
+Linux Execution Environment
 Set Virtual Address Map
 ```
 ---
@@ -165,8 +165,8 @@ Set Virtual Address Map
 - Linux Boot - Boots into the default Linux environment.
 - SystemReady band ACS (Automation) - Initiates the automation flow.
 - BBSR Compliance (Automation) -  - Launches the BBSR-specific testing environment.
-- UEFI Execution Enviroment - Allows manual execution of UEFI-based test suites using the config file.
-- Linux Execution Enviroment - Allows manual execution of Linux-based test suites using the config file. 
+- UEFI Execution Environment - Allows manual execution of UEFI-based test suites using the config file.
+- Linux Execution Environment - Allows manual execution of Linux-based test suites using the config file. 
 - Set Virtual Address Map - Technical option for configuring memory map behavior in UEFI.
 
 ## SystemReady band ACS (Automation) Flow
@@ -184,21 +184,21 @@ When selecting **SystemReady band ACS (Automation)**, the following behavior occ
 
 ---
 
-## Behavior of Linux Execution Enviroment and UEFI Execution Enviroment
+## Behavior of Linux Execution Environment and UEFI Execution Environment
 
-- **UEFI Execution Enviroment**
-  - Enters UEFI Shell with similar behavior to Linux Execution Enviroment.
+- **UEFI Execution Environment**
+  - Enters UEFI Shell with similar behavior to Linux Execution Environment.
   - Users can run UEFI test suites (like SCT, SCRT) manually.
   - Help/guidance is displayed in the shell to inform how to execute commands using config.
 
-- **Linux Execution Enviroment**
+- **Linux Execution Environment**
   - Boots into Linux shell where users can manually execute test suites.
   - The system reads the config file and allows manual control over which test suites to run based on the enabled sections and their parameters.
   - A help or run-guide is displayed to assist users in running the appropriate commands.
 
 ---
 
-## Manual Execution Instructions (Linux Execution Enviroment / UEFI Execution Enviroment)
+## Manual Execution Instructions (Linux Execution Environment / UEFI Execution Environment)
 
 - Users can manually view/edit the config file using:
   - `acs_tets/parser/Parser.efi` (UEFI shell)

--- a/docs/acs_test_tools_guide.md
+++ b/docs/acs_test_tools_guide.md
@@ -17,7 +17,7 @@ By following this guide, users can gain a clear understanding of the verificatio
 ## SystemReady Band
 
 
-| Test Suites      | Run Enviroment  | Execution                    | Results Path              |
+| Test Suites      | Run Environment | Execution                    | Results Path              |
 |------------------|-----------------|------------------------------|---------------------------|
 | BSA              | UEFI and Linux# | Automatic                    | acs_results/uefi/BsaResults.log  acs_results/linux_acs/BsaResultsKernel.log     |
 | SBSA             | UEFI and Linux# | Automatic (Conditional)*     | acs_results/uefi/SbsaResults.log  acs_results/linux_acs/SbsaResultsKernel.log        |
@@ -37,7 +37,7 @@ By following this guide, users can gain a clear understanding of the verificatio
 
 ## DeviceTree Band
 
-| Test Suites      | Run Enviroment  | Execution                    | Results Path              |
+| Test Suites      | Run Environment | Execution                    | Results Path              |
 |------------------|-----------------|------------------------------|---------------------------|
 | BSA              | UEFI and Linux# | Automatic                    | acs_results_template/acs_results/uefi/BsaResults.log  acs_results_template/acs_results/linux_acs/bsa_acs_app/BsaResultsKernel.log     |
 | SCT              | UEFI            | Automatic                    | acs_results_template/acs_results/sct_results/Overall/Summary.log       |


### PR DESCRIPTION
 - Correct Environment spelling across the SystemReady band README, execution guide, GRUB menu entries, and manual run helper text.
 - Rename the execution guide file to use the corrected spelling and update README links to the new path.
 - Update the existing copyright header in startup_ee.nsh to include 2026. Files that did not already contain copyright text were left without new copyright lines.

Fixes #729 

Change-Id: I3a955ce344368d40430de7726005a67636f56883