### PR TITLE
fix(uefi): remove interactive verbose-mode prompt for BSA and SBSA

### DIFF
--- a/common/uefi_scripts/bsa.nsh
+++ b/common/uefi_scripts/bsa.nsh
@@ -69,45 +69,6 @@ endif
 
 #BSA_VERSION_PRINT_PLACEHOLDER
 if exist FS%i:\acs_tests\bsa\Bsa.efi then
-    echo "Press any key to start BSA in verbose mode."
-    echo "If no key is pressed then BSA will be run in normal mode"
-    FS%i:\acs_tests\bbr\SCT\stallforkey.efi 10
-    if %lasterror% == 0 then
-        if exist BsaVerboseResults.log then
-            echo "BSA ACS in verbose mode is already run."
-            echo "Press any key to start BSA ACS in verbose mode execution from the beginning."
-            echo "WARNING: Ensure you have backed up the existing logs."
-            FS%i:\acs_tests\bbr\SCT\stallforkey.efi 10
-            if %lasterror% == 0 then
-                #Backup the existing logs
-                rm -q BsaVerboseResults_previous_run.log
-                cp -r BsaVerboseResults.log BsaVerboseResults_previous_run.log
-                rm -q BsaVerboseResults.log
-                goto BsaVerboseRun
-            endif
-            goto BsaNormalRun
-        endif
-:BsaVerboseRun
-        echo "Running BSA in verbose mode"
-        if exist FS%i:\acs_tests\bsa\bsa_dt.flag then
-            #Executing for BSA SystemReady-devicetree-band. Execute only OS tests
-            echo "BSA Command: Bsa.efi  -v 1 -os -skip-dp-nic-ms -el1skiptrap cntpct -dtb BsaDevTree.dtb -f BsaVerboseTempResults.log"
-            FS%i:\acs_tests\bsa\Bsa.efi -v 1 -os -skip-dp-nic-ms -el1skiptrap cntpct -dtb BsaDevTree.dtb -f BsaVerboseTempResults.log
-        else
-            echo "BSA Command: Bsa.efi -v 1 -skip-dp-nic-ms -f BsaVerboseTempResults.log"
-            FS%i:\acs_tests\bsa\Bsa.efi -v 1 -skip-dp-nic-ms -f BsaVerboseTempResults.log
-        endif
-        stall 200000
-        if exist BsaVerboseTempResults.log then
-            cp BsaVerboseTempResults.log BsaVerboseResults.log
-            cp BsaVerboseTempResults.log temp/
-            rm BsaVerboseTempResults.log
-            reset
-        else
-            echo "There may be issues in writing of BSA Verbose logs. Please save the console output"
-        endif
-    endif
-:BsaNormalRun
     if exist BsaResults.log then
         echo "BSA ACS is already run."
         echo "Press any key to start BSA ACS execution from the beginning."

--- a/common/uefi_scripts/sbsa.nsh
+++ b/common/uefi_scripts/sbsa.nsh
@@ -51,39 +51,6 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
             goto SbsaEE
         endif
         if exist FS%i:\acs_tests\bsa\sbsa\Sbsa.efi then
-            echo "Press any key to start SBSA in verbose mode."
-            echo "If no key is pressed then SBSA will be run in normal mode"
-            FS%i:\acs_tests\bbr\SCT\stallforkey.efi 10
-            if %lasterror% == 0 then
-                if exist FS%i:\acs_results\uefi\SbsaVerboseResults.log then
-                    echo "SBSA ACS in verbose mode is already run."
-                    echo "Press any key to start SBSA ACS execution from the beginning."
-                    echo "WARNING: Ensure you have backed up the existing logs."
-                    FS%i:\acs_tests\bbr\SCT\stallforkey.efi 10
-                    if %lasterror% == 0 then
-                        #Backup the existing logs
-                        rm -q FS%i:\acs_results\uefi\SbsaVerboseResults_previous_run.log
-                        cp -r FS%i:\acs_results\uefi\SbsaVerboseResults.log FS%i:\acs_results\uefi\SbsaVerboseResults_previous_run.log
-                        rm -q FS%i:\acs_results\uefi\SbsaVerboseResults.log
-                        goto SbsaVerboseRun
-                    endif
-                    goto SbsaNormalMode
-                endif
-:SbsaVerboseRun
-                echo "SBSA Command: Sbsa.efi -v 1 -skip-dp-nic-ms -f SbsaVerboseTempResults.log"
-                FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -v 1 -skip-dp-nic-ms -f SbsaVerboseTempResults.log
-                stall 200000
-                if exist FS%i:\acs_results\uefi\SbsaVerboseTempResults.log then
-                    cp SbsaVerboseTempResults.log SbsaVerboseResults.log
-                    cp SbsaVerboseTempResults.log temp/
-                    rm SbsaVerboseTempResults.log
-                    reset
-                else
-                    echo "There may be issues in writing of SBSA Verbose logs. Please save the console output"
-                    reset
-                endif
-            endif
-:SbsaNormalMode
             if exist FS%i:\acs_results\uefi\SbsaResults.log then
                 echo "SBSA ACS is already run."
                 echo "Press any key to start SBSA ACS execution from the beginning."
@@ -94,11 +61,11 @@ for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
                     rm -q FS%i:\acs_results\uefi\SbsaResults_previous_run.log
                     cp -r FS%i:\acs_results\uefi\SbsaResults.log FS%i:\acs_results\uefi\SbsaResults_previous_run.log
                     rm -q FS%i:\acs_results\uefi\SbsaResults.log
-                    goto SbsaNormalRun
+                    goto SbsaRun
                 endif
                 goto Done
             endif
-:SbsaNormalRun
+:SbsaRun
             if "%1" == "false" then
                 echo "SBSA Command: Sbsa.efi -skip-dp-nic-ms -f SbsaTempResults.log"
                 FS%i:\acs_tests\bsa\sbsa\Sbsa.efi -skip-dp-nic-ms -f SbsaTempResults.log


### PR DESCRIPTION
-Remove the interactive UEFI Shell prompt that allowed BSA and SBSA to be started in verbose mode during automated runs.

Fixes #710

Change-Id: I6575b5ff937d80131d3ac81996abdf390ffc281b
