### PR TITLE
(improv):restrict testcase regex to numeric or dash ACS rule headers

### DIFF
--- a/common/log_parser/bsa/logs_to_json.py
+++ b/common/log_parser/bsa/logs_to_json.py
@@ -198,7 +198,7 @@ def main(input_files, output_file):
                 continue
 
             # RULE line (main or subtest, determined by indentation)
-            rule_line = re.match(r'^([A-Za-z0-9_]+)\s*:\s*([^:]+?)\s*:\s*(.*)$', line)
+            rule_line = re.match(r'^([A-Za-z0-9_]+)\s*:\s*(-|\d+)\s*:\s*(.*)$', line)
             if rule_line:
                 rule_id = rule_line.group(1).strip()
                 test_index = (rule_line.group(2) or "").strip() or "-"


### PR DESCRIPTION
	-limit testcase header matching to "<rule_id> : -|<number> : <description>"
	-ignore verbose info/debug colon-formatted lines like PE_INFO and val_pgt_create
	-improve parsing of raw BSA/SBSA logs by avoiding false testcase matches

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com

Change-Id: Ie061e60e46b862ed5dab85c31a328a92a02569ac