### PR TITLE
Updated sbsa version patch based on latest sysarch-acs

### DIFF
--- a/SystemReady-band/patches/sbsa_srversion.patch
+++ b/SystemReady-band/patches/sbsa_srversion.patch
@@ -1,12 +1,12 @@
 diff --git a/apps/uefi/sbsa_main.c b/apps/uefi/sbsa_main.c
-index d684462..7f9c883 100644
+index 9beb188..2af3e4d 100644
 --- a/apps/uefi/sbsa_main.c
 +++ b/apps/uefi/sbsa_main.c
-@@ -162,6 +162,7 @@ execute_tests()
+@@ -168,6 +168,7 @@ execute_tests()
          goto exit_acs;
      }
  
 +    val_print(INFO, "\n\n SystemReady band ACS v3.1.1", 0);
-     val_print(ERROR, "\n\n SBSA Architecture Compliance Suite\n");
-     val_print(ERROR, "    Version %d.", SBSA_ACS_MAJOR_VER);
-     val_print(ERROR, "%d.", SBSA_ACS_MINOR_VER);
+     val_print(INFO, "\n\n SBSA Architecture Compliance Suite\n");
+     val_print(INFO, "    Version %d.", SBSA_ACS_MAJOR_VER);
+     val_print(INFO, "%d.", SBSA_ACS_MINOR_VER);


### PR DESCRIPTION
 - Latest verbosity change in print dump was resulting in build failure