### PR TITLE
fix(ledge-efi):  force serial build to avoid intermittent link failure

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/ledge-efi/ledge-efi_git.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/ledge-efi/ledge-efi_git.bb
@@ -13,7 +13,7 @@ S = "${WORKDIR}/git"
 DEPENDS = "clang-native"
 
 do_compile() {
-    oe_runmake -C ${S}/efi_app
+    oe_runmake -j1 -C ${S}/efi_app
 }
 
 do_install[noexec] = "1"


### PR DESCRIPTION
- Build efi_app with -j1 to prevent the linker from running before all object files are generated.


Change-Id: I5f76f4757d1b400acc89dfb27931cc61816089b5