### PR TITLE
bbsr-keys: allow partner-provided keys via KEYS_DIR override

### DIFF
--- a/SystemReady-band/README.md
+++ b/SystemReady-band/README.md
@@ -84,10 +84,17 @@ Before starting the ACS build, ensure that the following requirements are met:
 3. Run get_source.sh to download all related sources and tools for the build. Provide the sudo permission when prompted <br />
  `./build-scripts/get_source.sh` <br />
 
-4. To start the build of the ACS live image, execute the below step <br />
+4. (Optional) To use custom secure boot keys instead of the generated defaults, set `KEYS_DIR` to the directory containing your key files. Required files are: `NullPK.auth`, `TestPK1.auth`, `TestPK1.crt`, `TestPK1.der`, `TestPK1.key`, `TestKEK1.auth`, `TestKEK1.crt`, `TestKEK1.der`, `TestKEK1.key`, `TestDB1.auth`, `TestDB1.crt`, `TestDB1.der`, `TestDB1.key`, `TestDBX1.auth`, `TestDBX1.crt`, `TestDBX1.der`, `TestDBX1.key`. If `KEYS_DIR` is unset or incomplete, the build generates default test keys. For key generation guidance, see the [Secure Boot Test Key Generation Guide](https://github.com/tianocore/edk2-test/blob/master/uefi-sct/Doc/UserGuide/SecureBootTestKeyGenerationAndSetupGuide.md). <br />
+   - `KEYS_DIR` may be defined in `common/config/systemready-band-source.cfg` or overridden by the environment variable.
+   - `KEYS_DIR` must be an absolute path. Relative paths are not supported.
+   - Example: `KEYS_DIR=/absolute/path/to/your/keys`
+   - If all required files already exist in `KEYS_DIR`, the build reuses them and skips regeneration.
+   - Complete `KEYS_DIR` content is required for partner-provided or production key workflows. <br />
+
+5. To start the build of the ACS live image, execute the below step <br />
  `./build-scripts/build-systemready-band-live-image.sh`
 
-5. If all the above steps are successful, then the  bootable image will be available at <br />
+6. If all the above steps are successful, then the  bootable image will be available at <br />
    `/path-to-arm-systemready/SystemReady-band/output/systemready_acs_live_image.img.xz`
 
 Note: The image is generated in a compressed (.xz) format. The image must be uncompressed before it is used.<br />

--- a/SystemReady-band/build-scripts/build-bbsr-keys.sh
+++ b/SystemReady-band/build-scripts/build-bbsr-keys.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2021-2024, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,16 +23,98 @@
 # KEYS_DIR - directory where secure boot keys are generated
 
 TOP_DIR=`pwd`
-KEYS_DIR=$TOP_DIR/bbsr-keys
+DEFAULT_KEYS_DIR=$TOP_DIR/bbsr-keys
+
+# Source the configuration file to get KEYS_DIR from systemready-band-source.cfg
+CFG_FILE="$TOP_DIR/../common/config/systemready-band-source.cfg"
+if [ -f "$CFG_FILE" ]; then
+    . "$CFG_FILE"
+    if [ -n "$KEYS_DIR" ]; then
+        echo "INFO: Sourced KEYS_DIR from config: KEYS_DIR=$KEYS_DIR"
+    fi
+fi
+
+# The user can point to an external KEYS_DIR to provide partner-provided keys.
+# KEYS_DIR can be set in systemready-band-source.cfg or overridden via environment variable.
+# If KEYS_DIR points to an existing external location, use those keys.
+# Otherwise, generate keys in the workdir.
+GEN_DIR="$DEFAULT_KEYS_DIR"
+ENFORCE_EXTERNAL_KEYS=0
+
+# Use the default directory if KEYS_DIR is unset.
+if [ -z "$KEYS_DIR" ]; then
+    KEYS_DIR="$DEFAULT_KEYS_DIR"
+fi
+
+# Remove trailing slash if present
+KEYS_DIR="${KEYS_DIR%/}"
+
+# KEYS_DIR must be an absolute path for external partner-provided keys.
+if [ -n "$KEYS_DIR" ] && [ "${KEYS_DIR#/}" = "$KEYS_DIR" ]; then
+    echo "WARNING: KEYS_DIR=$KEYS_DIR is not an absolute path; using default test key directory $DEFAULT_KEYS_DIR"
+    KEYS_DIR="$DEFAULT_KEYS_DIR"
+fi
+
+# Check if external KEYS_DIR exists and is a valid directory
+if [ -n "$KEYS_DIR" ] && [ "$KEYS_DIR" != "$DEFAULT_KEYS_DIR" ]; then
+    if [ ! -d "$KEYS_DIR" ]; then
+        echo "WARNING: KEYS_DIR=$KEYS_DIR does not exist, using default test key directory $DEFAULT_KEYS_DIR"
+        KEYS_DIR="$DEFAULT_KEYS_DIR"
+    else
+        echo "INFO: Found KEYS_DIR at $KEYS_DIR, checking for required key files"
+        ENFORCE_EXTERNAL_KEYS=1
+    fi
+fi
+
+# Check if all required key files exist in KEYS_DIR
+REQUIRED_FILES="NullPK.auth TestDB1.auth TestDB1.crt TestDB1.der TestDB1.key TestDBX1.auth TestDBX1.crt TestDBX1.der TestDBX1.key TestKEK1.auth TestKEK1.crt TestKEK1.der TestKEK1.key TestPK1.auth TestPK1.crt TestPK1.der TestPK1.key"
+ALL_FILES_PRESENT=1
+MISSING=""
+
+if [ $ENFORCE_EXTERNAL_KEYS -eq 1 ]; then
+    for file in $REQUIRED_FILES; do
+        if [ ! -f "$KEYS_DIR/$file" ]; then
+            ALL_FILES_PRESENT=0
+            MISSING="$MISSING $file"
+            echo "WARNING: missing key file: $KEYS_DIR/$file"
+        fi
+    done
+fi
 
 # set the path to pick up the local efitools
 export PATH="$TOP_DIR/efitools:$PATH"
 
 do_build()
 {
+    # Handle case where KEYS_DIR was overwritten by framework.sh sourcing config again
+    if [ ! -d "$KEYS_DIR" ] && [ "$KEYS_DIR" != "$DEFAULT_KEYS_DIR" ]; then
+        echo "WARNING: KEYS_DIR=$KEYS_DIR does not exist, using default test key directory $DEFAULT_KEYS_DIR"
+        KEYS_DIR="$DEFAULT_KEYS_DIR"
+        ENFORCE_EXTERNAL_KEYS=0
+    fi
+
+    if [ $ALL_FILES_PRESENT -eq 1 ] && [ $ENFORCE_EXTERNAL_KEYS -eq 1 ]; then
+        echo "do_build: bbsr-keys: keys already present in KEYS_DIR=$KEYS_DIR"
+        # if external directory differs, copy contents into workdir
+        if [ "$KEYS_DIR" != "$DEFAULT_KEYS_DIR" ]; then
+            echo "copying existing keys into build directory"
+            mkdir -p "$DEFAULT_KEYS_DIR"
+            cp -r "$KEYS_DIR"/* "$DEFAULT_KEYS_DIR/"
+        fi
+        echo "skipping key generation"
+        return 0
+    fi
+
+    # If external keys were enforced but incomplete, fail the build
+    if [ $ENFORCE_EXTERNAL_KEYS -eq 1 ] && [ $ALL_FILES_PRESENT -eq 0 ]; then
+        echo "KEYS_DIR not provided or incomplete, please generate required keys"
+        echo "ERROR: missing keys in $KEYS_DIR:$MISSING; please provide all required keys or unset KEYS_DIR"
+        exit 1
+    fi
+
     echo "do_build: bbsr-keys"
-    mkdir -p $KEYS_DIR
-    pushd $KEYS_DIR
+    mkdir -p "$KEYS_DIR"
+    pushd "$KEYS_DIR"
 
     # generate TestPK1: DER and signed siglist
     NAME=TestPK1
@@ -84,4 +166,3 @@ do_package()
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $DIR/framework.sh $@
-

--- a/SystemReady-band/build-scripts/build-bsaefi.sh
+++ b/SystemReady-band/build-scripts/build-bsaefi.sh
@@ -44,7 +44,14 @@ CROSS_COMPILE=$TOP_DIR/$GCC
 UEFI_LIBC_PATH=edk2-libc
 OUTDIR=${TOP_DIR}/output
 BSA_EFI_PATH=edk2/Build/Shell/DEBUG_GCC/AARCH64/
-KEYS_DIR=$TOP_DIR/bbsr-keys
+DEFAULT_KEYS_DIR=$TOP_DIR/bbsr-keys
+
+# Handle KEYS_DIR: Use configured value or default
+if [ -z "$KEYS_DIR" ]; then
+    KEYS_DIR="$DEFAULT_KEYS_DIR"
+fi
+# Remove trailing slash if present
+KEYS_DIR="${KEYS_DIR%/}"
 SYSTEMREADY_COMMIT_LOG="${OUTDIR}/systemready-commit.log"
 
 do_build()
@@ -100,8 +107,23 @@ do_package ()
     echo "Packaging BSA... $VARIANT";
     # Copy binaries to output folder
     cp $TOP_DIR/$BSA_EFI_PATH/Bsa.efi $OUTDIR/Bsa.efi
+
+    # Verify that required key files exist
+    if [ ! -f "$KEYS_DIR/TestDB1.key" ] || \
+       [ ! -f "$KEYS_DIR/TestDB1.crt" ]; then
+        echo "ERROR: Required key files not found"
+        echo "  KEYS_DIR=$KEYS_DIR"
+        echo "  Missing: $KEYS_DIR/TestDB1.key or"
+        echo "           $KEYS_DIR/TestDB1.crt"
+        echo "  Please run build-bbsr-keys.sh first"
+        exit 1
+    fi
+
     # sign Bsa.efi with db key
-    sbsign --key $KEYS_DIR/TestDB1.key --cert $KEYS_DIR/TestDB1.crt $OUTDIR/Bsa.efi --output $OUTDIR/Bsa.efi
+    sbsign --key "$KEYS_DIR/TestDB1.key" \
+        --cert "$KEYS_DIR/TestDB1.crt" \
+        "$OUTDIR/Bsa.efi" \
+        --output "$OUTDIR/Bsa.efi"
 }
 
 exit_fun() {

--- a/SystemReady-band/build-scripts/build-grub.sh
+++ b/SystemReady-band/build-scripts/build-grub.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # @file
-# Copyright (c) 2021-2024, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,14 @@ arch=$(uname -m)
 GRUB_TARGET=aarch64-none-linux-gnu
 GRUB_PATH=grub
 GRUB_PLAT_CONFIG_FILE=${TOP_DIR}/build-scripts/config/grub_prefix.cfg
-KEYS_DIR=$TOP_DIR/bbsr-keys
+DEFAULT_KEYS_DIR=$TOP_DIR/bbsr-keys
+
+# Handle KEYS_DIR: Use configured value or default
+if [ -z "$KEYS_DIR" ]; then
+    KEYS_DIR="$DEFAULT_KEYS_DIR"
+fi
+# Remove trailing slash if present
+KEYS_DIR="${KEYS_DIR%/}"
 
 do_build ()
 {
@@ -105,7 +112,22 @@ do_package ()
 {
     # sign grub with db key
     pushd $TOP_DIR/$GRUB_PATH
-    sbsign --key $KEYS_DIR/TestDB1.key --cert $KEYS_DIR/TestDB1.crt output/grubaa64.efi --output output/grubaa64.efi
+
+    # Verify that required key files exist
+    if [ ! -f "$KEYS_DIR/TestDB1.key" ] || \
+       [ ! -f "$KEYS_DIR/TestDB1.crt" ]; then
+        echo "ERROR: Required key files not found"
+        echo "  KEYS_DIR=$KEYS_DIR"
+        echo "  Missing: $KEYS_DIR/TestDB1.key or"
+        echo "           $KEYS_DIR/TestDB1.crt"
+        echo "  Please run build-bbsr-keys.sh first"
+        exit 1
+    fi
+
+    sbsign --key "$KEYS_DIR/TestDB1.key" \
+        --cert "$KEYS_DIR/TestDB1.crt" \
+        output/grubaa64.efi \
+        --output output/grubaa64.efi
     popd
 }
 

--- a/SystemReady-band/build-scripts/build-linux.sh
+++ b/SystemReady-band/build-scripts/build-linux.sh
@@ -46,8 +46,15 @@ TOP_DIR=`pwd`
 
 LINUX_ARCH=arm64
 LINUX_IMAGE_TYPE=Image
-KEYS_DIR=$TOP_DIR/bbsr-keys
+DEFAULT_KEYS_DIR=$TOP_DIR/bbsr-keys
 SRBAND_DEFCONFIG=$TOP_DIR/../common/config/srband_defconfig
+
+# Handle KEYS_DIR: Use configured value or default
+if [ -z "$KEYS_DIR" ]; then
+    KEYS_DIR="$DEFAULT_KEYS_DIR"
+fi
+# Remove trailing slash if present
+KEYS_DIR="${KEYS_DIR%/}"
 
 do_build ()
 {
@@ -109,8 +116,22 @@ do_package ()
     cp $TOP_DIR/$LINUX_PATH/$LINUX_OUT_DIR/arch/$LINUX_ARCH/boot/$LINUX_IMAGE_TYPE \
     ${OUTDIR}/$LINUX_IMAGE_TYPE
 
+    # Verify that required key files exist
+    if [ ! -f "$KEYS_DIR/TestDB1.key" ] || \
+       [ ! -f "$KEYS_DIR/TestDB1.crt" ]; then
+        echo "ERROR: Required key files not found"
+        echo "  KEYS_DIR=$KEYS_DIR"
+        echo "  Missing: $KEYS_DIR/TestDB1.key or"
+        echo "           $KEYS_DIR/TestDB1.crt"
+        echo "  Please run build-bbsr-keys.sh first"
+        exit 1
+    fi
+
     # Sign the kernel with DB key
-    sbsign --key $KEYS_DIR/TestDB1.key --cert $KEYS_DIR/TestDB1.crt ${OUTDIR}/$LINUX_IMAGE_TYPE --output ${OUTDIR}/$LINUX_IMAGE_TYPE
+    sbsign --key "$KEYS_DIR/TestDB1.key" \
+        --cert "$KEYS_DIR/TestDB1.crt" \
+        "${OUTDIR}/$LINUX_IMAGE_TYPE" \
+        --output "${OUTDIR}/$LINUX_IMAGE_TYPE"
 
     #Copy drivers for packaging into Ramdisk
     mkdir -p $TOP_DIR/ramdisk/drivers

--- a/SystemReady-band/build-scripts/build-parser-app.sh
+++ b/SystemReady-band/build-scripts/build-parser-app.sh
@@ -25,13 +25,21 @@ GCC_VERSION="${GCC_TOOLS_VERSION}"
 APP_NAME="parser"
 GCC_PREFIX="aarch64-none-linux-gnu-"
 TOP_DIR=$(pwd)
-TOOLCHAIN_PATH="$TOP_DIR/tools/arm-gnu-toolchain-${GCC_VERSION}-x86_64-aarch64-none-linux-gnu/bin"
+GNUTOOLS_VER="${GCC_VERSION}-x86_64-aarch64-none-linux-gnu"
+TOOLCHAIN_PATH="$TOP_DIR/tools/arm-gnu-toolchain-${GNUTOOLS_VER}/bin"
 GCC_BIN="$TOOLCHAIN_PATH/$GCC_PREFIX"
 EDK2_DIR="$TOP_DIR/edk2"
 LIBC_DIR="$EDK2_DIR/edk2-libc"
 APP_PATH="$EDK2_DIR/ShellPkg/Application/$APP_NAME"
-KEYS_DIR=$TOP_DIR/bbsr-keys
+DEFAULT_KEYS_DIR=$TOP_DIR/bbsr-keys
 CONFIG_PARSER_EFI=${TOP_DIR}/parser/Parser.efi
+
+# Handle KEYS_DIR: Use configured value or default
+if [ -z "$KEYS_DIR" ]; then
+    KEYS_DIR="$DEFAULT_KEYS_DIR"
+fi
+# Remove trailing slash if present
+KEYS_DIR="${KEYS_DIR%/}"
 
 do_build()
 {
@@ -63,9 +71,11 @@ source ./edksetup.sh --reconfig
 make -C BaseTools/Source/C
 
 echo "Building Parser.efi..."
-build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc -m ShellPkg/Application/$APP_NAME/Parser.inf
+build -a AARCH64 -t GCC -p ShellPkg/ShellPkg.dsc \
+    -m ShellPkg/Application/$APP_NAME/Parser.inf
 
-cp "$EDK2_DIR/Build/Shell/DEBUG_GCC/AARCH64/Parser.efi" "$TOP_DIR/$APP_NAME/Parser.efi"
+PARSER_EFI="$EDK2_DIR/Build/Shell/DEBUG_GCC/AARCH64/Parser.efi"
+cp "$PARSER_EFI" "$TOP_DIR/$APP_NAME/Parser.efi"
 git reset --hard
 
 popd
@@ -79,9 +89,24 @@ do_package ()
 
     echo "Signing Parser Application... "
     pushd $TOP_DIR
+
+    # Verify that required key files exist
+    if [ ! -f "$KEYS_DIR/TestDB1.key" ] || \
+       [ ! -f "$KEYS_DIR/TestDB1.crt" ]; then
+        echo "ERROR: Required key files not found"
+        echo "  KEYS_DIR=$KEYS_DIR"
+        echo "  Missing: $KEYS_DIR/TestDB1.key or"
+        echo "           $KEYS_DIR/TestDB1.crt"
+        echo "  Please run build-bbsr-keys.sh first"
+        exit 1
+    fi
+
     # sign Parser.efi with db key
-    sbsign --key $KEYS_DIR/TestDB1.key --cert $KEYS_DIR/TestDB1.crt $CONFIG_PARSER_EFI --output $TOP_DIR/output/Parser.efi
-    
+    sbsign --key "$KEYS_DIR/TestDB1.key" \
+        --cert "$KEYS_DIR/TestDB1.crt" \
+        "$CONFIG_PARSER_EFI" \
+        --output "$TOP_DIR/output/Parser.efi"
+
     popd
 
 }

--- a/SystemReady-band/build-scripts/build-sbsaefi.sh
+++ b/SystemReady-band/build-scripts/build-sbsaefi.sh
@@ -44,7 +44,14 @@ CROSS_COMPILE=$TOP_DIR/$GCC
 UEFI_LIBC_PATH=edk2-libc
 OUTDIR=${TOP_DIR}/output
 SBSA_EFI_PATH=edk2/Build/Shell/DEBUG_GCC/AARCH64/
-KEYS_DIR=$TOP_DIR/bbsr-keys
+DEFAULT_KEYS_DIR=$TOP_DIR/bbsr-keys
+
+# Handle KEYS_DIR: Use configured value or default
+if [ -z "$KEYS_DIR" ]; then
+    KEYS_DIR="$DEFAULT_KEYS_DIR"
+fi
+# Remove trailing slash if present
+KEYS_DIR="${KEYS_DIR%/}"
 SYSTEMREADY_COMMIT_LOG="${OUTDIR}/systemready-commit.log"
 
 do_build()
@@ -99,8 +106,23 @@ do_package ()
     echo "Packaging SBSA...";
     # Copy binaries to output folder
     cp $TOP_DIR/$SBSA_EFI_PATH/Sbsa.efi $OUTDIR/Sbsa.efi
+
+    # Verify that required key files exist
+    if [ ! -f "$KEYS_DIR/TestDB1.key" ] || \
+       [ ! -f "$KEYS_DIR/TestDB1.crt" ]; then
+        echo "ERROR: Required key files not found"
+        echo "  KEYS_DIR=$KEYS_DIR"
+        echo "  Missing: $KEYS_DIR/TestDB1.key or"
+        echo "           $KEYS_DIR/TestDB1.crt"
+        echo "  Please run build-bbsr-keys.sh first"
+        exit 1
+    fi
+
     # sign Sbsa.efi with db key
-    sbsign --key $KEYS_DIR/TestDB1.key --cert $KEYS_DIR/TestDB1.crt $OUTDIR/Sbsa.efi --output $OUTDIR/Sbsa.efi
+    sbsign --key "$KEYS_DIR/TestDB1.key" \
+        --cert "$KEYS_DIR/TestDB1.crt" \
+        "$OUTDIR/Sbsa.efi" \
+        --output "$OUTDIR/Sbsa.efi"
 }
 
 exit_fun() {

--- a/SystemReady-band/build-scripts/build-uefi.sh
+++ b/SystemReady-band/build-scripts/build-uefi.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,8 +43,15 @@ UEFI_PATH=edk2
 UEFI_TOOLCHAIN=GCC5
 UEFI_BUILD_MODE=RELEASE
 PATCH_DIR=$TOP_DIR/../patches
-KEYS_DIR=$TOP_DIR/bbsr-keys
+DEFAULT_KEYS_DIR=$TOP_DIR/bbsr-keys
 UEFI_SHELL_PATH=edk2/Build/Shell/RELEASE_GCC5/AARCH64
+
+# Handle KEYS_DIR: Use configured value or default
+if [ -z "$KEYS_DIR" ]; then
+    KEYS_DIR="$DEFAULT_KEYS_DIR"
+fi
+# Remove trailing slash if present
+KEYS_DIR="${KEYS_DIR%/}"
 
  if [[ $arch != "aarch64" ]]; then
     CROSS_COMPILE=$TOP_DIR/$GCC
@@ -98,8 +105,25 @@ do_package ()
 
     echo "Signing Shell Application... "
     pushd $TOP_DIR
+
+    # Verify that required key files exist
+    if [ ! -f "$KEYS_DIR/TestDB1.key" ] || \
+       [ ! -f "$KEYS_DIR/TestDB1.crt" ]; then
+        echo "ERROR: Required key files not found"
+        echo "  KEYS_DIR=$KEYS_DIR"
+        echo "  Missing: $KEYS_DIR/TestDB1.key or"
+        echo "           $KEYS_DIR/TestDB1.crt"
+        echo "  Please run build-bbsr-keys.sh first"
+        exit 1
+    fi
+
     # sign Shell.efi with db key
-    sbsign --key $KEYS_DIR/TestDB1.key --cert $KEYS_DIR/TestDB1.crt $TOP_DIR/$UEFI_SHELL_PATH/Shell_EA4BB293-2D7F-4456-A681-1F22F42CD0BC.efi --output $TOP_DIR/$UEFI_SHELL_PATH/Shell_EA4BB293-2D7F-4456-A681-1F22F42CD0BC.efi
+    SHELL_EFI="$TOP_DIR/$UEFI_SHELL_PATH"
+    SHELL_EFI="${SHELL_EFI}/Shell_EA4BB293-2D7F-4456-A681-1F22F42CD0BC.efi"
+    sbsign --key "$KEYS_DIR/TestDB1.key" \
+        --cert "$KEYS_DIR/TestDB1.crt" \
+        "$SHELL_EFI" \
+        --output "$SHELL_EFI"
 
     popd
 

--- a/SystemReady-band/build-scripts/framework.sh
+++ b/SystemReady-band/build-scripts/framework.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2021-2024, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,17 @@ TOP_DIR=`pwd`
 BAND=$1
 CLEAN_BUILD=$3
 
+PRECONFIG_KEYS_DIR="$KEYS_DIR"
 . $TOP_DIR/../common/config/systemready-band-source.cfg
+if [ -n "$PRECONFIG_KEYS_DIR" ] && [ -z "$KEYS_DIR" ]; then
+    KEYS_DIR="$PRECONFIG_KEYS_DIR"
+fi
+unset PRECONFIG_KEYS_DIR
+
+# Ensure KEYS_DIR is set to a sensible default if the config left it empty
+if [ -z "$KEYS_DIR" ]; then
+    KEYS_DIR="$TOP_DIR/bbsr-keys"
+fi
 
 set -E
 

--- a/SystemReady-devicetree-band/README.md
+++ b/SystemReady-devicetree-band/README.md
@@ -87,10 +87,17 @@ Before starting the ACS build, ensure that the following requirements are met:
 3. Run get_source.sh to download all the related sources and tools for the build. Provide sudo permission when prompted <br />
  `./build-scripts/get_source.sh` <br />
 
-4. To start the build of the SystemReady-devicetree band ACS live image, execute the below step <br />
+4. (Optional) To use custom secure boot keys instead of the generated defaults, set `KEYS_DIR` to the directory containing your key files. Required files are: `NullPK.auth`, `TestPK1.auth`, `TestPK1.crt`, `TestPK1.der`, `TestPK1.key`, `TestKEK1.auth`, `TestKEK1.crt`, `TestKEK1.der`, `TestKEK1.key`, `TestDB1.auth`, `TestDB1.crt`, `TestDB1.der`, `TestDB1.key`, `TestDBX1.auth`, `TestDBX1.crt`, `TestDBX1.der`, `TestDBX1.key`. If `KEYS_DIR` is unset or incomplete, the build generates default test keys. For key generation guidance, see the [Secure Boot Test Key Generation Guide](https://github.com/tianocore/edk2-test/blob/master/uefi-sct/Doc/UserGuide/SecureBootTestKeyGenerationAndSetupGuide.md). <br />
+   - `KEYS_DIR` may be defined in `common/config/systemready-dt-band-source.cfg` or overridden by the environment variable.
+   - `KEYS_DIR` must be an absolute path. Relative paths are not supported.
+   - Example: `KEYS_DIR=/absolute/path/to/your/keys`
+   - If all required files already exist in `KEYS_DIR`, the build reuses them and skips regeneration.
+   - Complete `KEYS_DIR` content is required for partner-provided or production key workflows. <br />
+
+5. To start the build of the SystemReady-devicetree band ACS live image, execute the below step <br />
  `./build-scripts/build-systemready-dt-band-live-image.sh`
 
-5. If the above steps are successful, the bootable image will be available at <br />
+6. If the above steps are successful, the bootable image will be available at <br />
    `/path-to-arm-systemready/SystemReady-devicetree-band/Yocto/meta-woden/build/tmp/deploy/images/generic-arm64/systemready-dt_acs_live_image.wic.xz`
 
 Note: The image is generated in a compressed (.xz) format. The image must be uncompressed before it is used.<br />

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bbsr-keys/bbsr-keys.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bbsr-keys/bbsr-keys.bb
@@ -15,10 +15,84 @@ inherit perlnative
 
 do_compile() {
 
-    KEYS_DIR="${S}/bbsr-keys"
-    echo "do_compile: bbsr-keys"
-    mkdir -p $KEYS_DIR
-    cd $KEYS_DIR
+    # Source the configuration file to get KEYS_DIR from systemready-dt-band-source.cfg
+    RECIPE_DIR="${FILE_DIRNAME}"
+    if [ -z "$RECIPE_DIR" ] && [ -n "$FILE" ]; then
+        RECIPE_DIR="$(dirname "$FILE")"
+    fi
+    CFG_FILE="$RECIPE_DIR/../../../../../common/config/systemready-dt-band-source.cfg"
+    echo "INFO: Checking config file at $CFG_FILE"
+    if [ -n "$CFG_FILE" ] && [ -f "$CFG_FILE" ]; then
+        . "$CFG_FILE"
+        if [ -n "$KEYS_DIR" ]; then
+            echo "INFO: Sourced KEYS_DIR from config: KEYS_DIR=$KEYS_DIR"
+        fi
+    fi
+
+    # The user can point to an external KEYS_DIR to provide partner-provided keys.
+    # KEYS_DIR can be set in systemready-dt-band-source.cfg or overridden via environment variable.
+    # If KEYS_DIR points to an existing external location, use those keys.
+    # Otherwise, generate keys in the workdir.
+    GEN_DIR="${S}/bbsr-keys"
+    ENFORCE_EXTERNAL_KEYS=0
+
+    # Remove trailing slash if present
+    KEYS_DIR="${KEYS_DIR%/}"
+
+    # KEYS_DIR must be an absolute path for external partner-provided keys.
+    if [ -n "$KEYS_DIR" ] && [ "${KEYS_DIR#/}" = "$KEYS_DIR" ]; then
+        echo "WARNING: KEYS_DIR=$KEYS_DIR is not an absolute path; will generate default test keys"
+        KEYS_DIR=""
+    fi
+
+    # Check if external KEYS_DIR exists and is a valid directory
+    if [ -n "$KEYS_DIR" ]; then
+        if [ ! -d "$KEYS_DIR" ]; then
+            echo "WARNING: KEYS_DIR=$KEYS_DIR does not exist, will generate default test keys"
+            KEYS_DIR=""
+        else
+            echo "INFO: Found KEYS_DIR at $KEYS_DIR, checking for required key files"
+            ENFORCE_EXTERNAL_KEYS=1
+        fi
+    fi
+
+    # Check if all required key files exist in KEYS_DIR
+    REQUIRED_FILES="NullPK.auth TestDB1.auth TestDB1.crt TestDB1.der TestDB1.key TestDBX1.auth TestDBX1.crt TestDBX1.der TestDBX1.key TestKEK1.auth TestKEK1.crt TestKEK1.der TestKEK1.key TestPK1.auth TestPK1.crt TestPK1.der TestPK1.key"
+    ALL_FILES_PRESENT=1
+    MISSING=""
+
+    if [ $ENFORCE_EXTERNAL_KEYS -eq 1 ]; then
+        for file in $REQUIRED_FILES; do
+            if [ ! -f "$KEYS_DIR/$file" ]; then
+                ALL_FILES_PRESENT=0
+                MISSING="$MISSING $file"
+                echo "WARNING: missing key file: $KEYS_DIR/$file"
+            fi
+        done
+    fi
+
+    if [ $ALL_FILES_PRESENT -eq 1 ] && [ $ENFORCE_EXTERNAL_KEYS -eq 1 ]; then
+        echo "do_compile: bbsr-keys: keys already present in KEYS_DIR=$KEYS_DIR"
+        # if external directory differs, copy contents into workdir
+        if [ "$KEYS_DIR" != "${S}/bbsr-keys" ]; then
+            echo "copying existing keys into build directory"
+            mkdir -p ${S}/bbsr-keys
+            cp -r "$KEYS_DIR"/* ${S}/bbsr-keys/
+        fi
+        echo "skipping key generation"
+        return 0
+    fi
+
+    # If external keys were enforced but incomplete, fail the build
+    if [ $ENFORCE_EXTERNAL_KEYS -eq 1 ] && [ $ALL_FILES_PRESENT -eq 0 ]; then
+        echo "KEYS_DIR not provided or incomplete, please generate required keys"
+        bbfatal "ERROR: missing keys in $KEYS_DIR:$MISSING; please provide all required keys or unset KEYS_DIR"
+    fi
+
+    # Generate keys in workdir
+    echo "Generating default test keys in $GEN_DIR"
+    mkdir -p "$GEN_DIR"
+    cd "$GEN_DIR"
 
     # generate TestPK1: DER and signed siglist
     NAME=TestPK1

--- a/common/config/systemready-band-source.cfg
+++ b/common/config/systemready-band-source.cfg
@@ -93,3 +93,6 @@ GCC_TOOLS_VERSION=14.3.rel1
 CROSS_COMPILER_URL=https://developer.arm.com/-/media/Files/downloads/gnu/${GCC_TOOLS_VERSION}/binrel/arm-gnu-toolchain-${GCC_TOOLS_VERSION}-x86_64-aarch64-none-linux-gnu.tar.xz
 # export Toolchain path
 GCC=tools/arm-gnu-toolchain-${GCC_TOOLS_VERSION}-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
+
+# Secure boot keys directory (absolute path without trailing slash)
+KEYS_DIR=""

--- a/common/config/systemready-dt-band-source.cfg
+++ b/common/config/systemready-dt-band-source.cfg
@@ -87,3 +87,6 @@ EDK2_LIBC_SRC_TAG=""
 # GRUB2 build tag/commit
 # SRC: https://github.com/rhboot/grub2.git
 GRUB_SRC_TAG=grub-2.06
+
+# Secure boot keys directory (absolute path without trailing slash)
+KEYS_DIR=""


### PR DESCRIPTION
- Use external KEYS_DIR if present; otherwise generate default test keys
- Add KEYS_DIR to source config files for both bands
- Document KEYS_DIR usage in README files


Change-Id: Ic771cc9fa7c323fc24fcf019bf203f08fc5f0d3a