### PR TITLE
SR-DT: Fix GCC 13 SME build compatibility

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-uefi/bsa-acs.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-uefi/bsa-acs.bb
@@ -10,6 +10,7 @@ COMPATIBLE_MACHINE:genericarm64 = "genericarm64"
 SRC_URI += "git://github.com/ARM-software/sysarch-acs;destsuffix=edk2/ShellPkg/Application/sysarch-acs;protocol=https;branch=main;name=sysarch-acs \
             git://github.com/tianocore/edk2-libc;destsuffix=edk2/edk2-libc;protocol=https;branch=master;name=edk2-libc \
             file://bsa_dtversion.patch;patch=1;patchdir=ShellPkg/Application/sysarch-acs \
+            file://0001-bsa-Remove-SME-build-flag-for-GCC-13.patch;patch=1;patchdir=ShellPkg/Application/sysarch-acs \
             "
 
 SRCREV_sysarch-acs = "${AUTOREV}"

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-uefi/files/0001-bsa-Remove-SME-build-flag-for-GCC-13.patch
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-uefi/files/0001-bsa-Remove-SME-build-flag-for-GCC-13.patch
@@ -1,0 +1,30 @@
+diff --git a/apps/uefi/Bsa.inf b/apps/uefi/Bsa.inf
+index a50c841..a3d8957 100644
+--- a/apps/uefi/Bsa.inf
++++ b/apps/uefi/Bsa.inf
+@@ -359,4 +359,4 @@
+ 
+ [BuildOptions]
+   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.1-a
+-  GCC:*_*_*_CC_FLAGS   =  -O0 -march=armv8.6-a+sve+sve2+sme+profile+lse $(ACS_CORE_INCLUDE_FLAGS) $(ACS_GIC_INCLUDE_FLAGS) $(ACS_PCIE_INCLUDE_FLAGS) -DTARGET_UEFI
++  GCC:*_*_*_CC_FLAGS   =  -O0 -march=armv8.6-a+sve+sve2+profile+lse $(ACS_CORE_INCLUDE_FLAGS) $(ACS_GIC_INCLUDE_FLAGS) $(ACS_PCIE_INCLUDE_FLAGS) -DTARGET_UEFI
+diff --git a/val/ValLib.inf b/val/ValLib.inf
+index 09c043a..030d6cf 100644
+--- a/val/ValLib.inf
++++ b/val/ValLib.inf
+@@ -88,4 +88,4 @@
+ 
+ [BuildOptions]
+   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.6-a+sve+profile
+-  GCC:*_*_*_CC_FLAGS   =  -march=armv8.6-a+sve+sve2+sme+profile+lse $(ACS_CORE_INCLUDE_FLAGS) $(ACS_GIC_INCLUDE_FLAGS) $(ACS_PCIE_INCLUDE_FLAGS) -DTARGET_UEFI
++  GCC:*_*_*_CC_FLAGS   =  -march=armv8.6-a+sve+sve2+profile+lse $(ACS_CORE_INCLUDE_FLAGS) $(ACS_GIC_INCLUDE_FLAGS) $(ACS_PCIE_INCLUDE_FLAGS) -DTARGET_UEFI
+diff --git a/val/ValLibRB.inf b/val/ValLibRB.inf
+index 47fbc59..0ef20ce 100644
+--- a/val/ValLibRB.inf
++++ b/val/ValLibRB.inf
+@@ -93,4 +93,4 @@
+ 
+ [BuildOptions]
+   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.6-a+sve+profile
+-  GCC:*_*_*_CC_FLAGS   =  -march=armv8.6-a+sve+sve2+sme+profile+lse $(ACS_CORE_INCLUDE_FLAGS) $(ACS_GIC_INCLUDE_FLAGS) $(ACS_PCIE_INCLUDE_FLAGS) -DTARGET_UEFI -DCOMPILE_RB_EXE
++  GCC:*_*_*_CC_FLAGS   =  -march=armv8.6-a+sve+sve2+profile+lse $(ACS_CORE_INCLUDE_FLAGS) $(ACS_GIC_INCLUDE_FLAGS) $(ACS_PCIE_INCLUDE_FLAGS) -DTARGET_UEFI -DCOMPILE_RB_EXE

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/pfdi-acs/files/0001-pfdi-Remove-SME-build-flag-for-GCC-13.patch
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/pfdi-acs/files/0001-pfdi-Remove-SME-build-flag-for-GCC-13.patch
@@ -1,0 +1,20 @@
+diff --git a/val/ValLib.inf b/val/ValLib.inf
+index 09c043a..030d6cf 100644
+--- a/val/ValLib.inf
++++ b/val/ValLib.inf
+@@ -88,4 +88,4 @@
+ 
+ [BuildOptions]
+   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.6-a+sve+profile
+-  GCC:*_*_*_CC_FLAGS   =  -march=armv8.6-a+sve+sve2+sme+profile+lse $(ACS_CORE_INCLUDE_FLAGS) $(ACS_GIC_INCLUDE_FLAGS) $(ACS_PCIE_INCLUDE_FLAGS) -DTARGET_UEFI
++  GCC:*_*_*_CC_FLAGS   =  -march=armv8.6-a+sve+sve2+profile+lse $(ACS_CORE_INCLUDE_FLAGS) $(ACS_GIC_INCLUDE_FLAGS) $(ACS_PCIE_INCLUDE_FLAGS) -DTARGET_UEFI
+diff --git a/val/ValLibRB.inf b/val/ValLibRB.inf
+index 47fbc59..0ef20ce 100644
+--- a/val/ValLibRB.inf
++++ b/val/ValLibRB.inf
+@@ -93,4 +93,4 @@
+ 
+ [BuildOptions]
+   GCC:*_*_*_ASM_FLAGS  =  -march=armv8.6-a+sve+profile
+-  GCC:*_*_*_CC_FLAGS   =  -march=armv8.6-a+sve+sve2+sme+profile+lse $(ACS_CORE_INCLUDE_FLAGS) $(ACS_GIC_INCLUDE_FLAGS) $(ACS_PCIE_INCLUDE_FLAGS) -DTARGET_UEFI -DCOMPILE_RB_EXE
++  GCC:*_*_*_CC_FLAGS   =  -march=armv8.6-a+sve+sve2+profile+lse $(ACS_CORE_INCLUDE_FLAGS) $(ACS_GIC_INCLUDE_FLAGS) $(ACS_PCIE_INCLUDE_FLAGS) -DTARGET_UEFI -DCOMPILE_RB_EXE

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/pfdi-acs/pfdi-acs.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/pfdi-acs/pfdi-acs.bb
@@ -9,6 +9,7 @@ COMPATIBLE_MACHINE:genericarm64 = "genericarm64"
 SRC_URI += "git://github.com/ARM-software/sysarch-acs;destsuffix=edk2/ShellPkg/Application/sysarch-acs;protocol=https;branch=main;name=sysarch-acs \
             git://github.com/tianocore/edk2-libc;destsuffix=edk2/edk2-libc;protocol=https;branch=master;name=edk2-libc \
             file://pfdi_dtversion.patch;patch=1;patchdir=ShellPkg/Application/sysarch-acs \
+            file://0001-pfdi-Remove-SME-build-flag-for-GCC-13.patch;patch=1;patchdir=ShellPkg/Application/sysarch-acs \
             "
 
 SRCREV_sysarch-acs = "${AUTOREV}"


### PR DESCRIPTION
- Add the GCC 13 SME compatibility patch to the bsa-acs and pfdi-acs recipes.
- This ensures ACS builds successfully with GCC 13.2 by removing unsupported SME build flags and using the raw SMFR0 register encoding fallback.


Change-Id: I45bb19a6aa58b874910bd1ac0eb5f94dea1a531a