### PR TITLE
fix: enforce strict ESP detection and document SCMI flow

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/acs_https_network_boot.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/acs_https_network_boot.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2025-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,24 +38,20 @@ detect_system_esp() {
     # GPT partition type GUID for EFI System Partition (ESP)
     ESP_GUID="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
 
-    # Return 0 if at least one system ESP is detected
-    if command -v lsblk >/dev/null 2>&1; then
-        ESP_LINES="$(lsblk -rno NAME,PARTTYPE,PARTLABEL,MOUNTPOINT 2>/dev/null \
-            | awk 'tolower($0) !~ /boot_acs/ && (tolower($2) ~ /'"$ESP_GUID"'/ || tolower($3) ~ /efi system partition/ || tolower($4) ~ /\/boot\/efi|\/efi/ )')"
-        if [ -n "${ESP_LINES}" ]; then
-            echo "Detected potential system ESP partition(s):"
-            echo "${ESP_LINES}"
-            return 0
-        fi
-    fi
+    # Strict: ESP exists only if a GPT partition has PARTTYPE == ESP_GUID
+    command -v lsblk >/dev/null 2>&1 || return 1
 
-    if command -v blkid >/dev/null 2>&1; then
-        ESP_BLKID="$(blkid 2>/dev/null | grep -vi 'BOOT_ACS' | grep -Ei "EFI System Partition|PARTUUID=.*$ESP_GUID")"
-        if [ -n "${ESP_BLKID}" ]; then
-            echo "Detected potential system ESP via blkid:"
-            echo "${ESP_BLKID}"
-            return 0
-        fi
+    ESP_LINES="$(lsblk -rpn -o NAME,TYPE,PARTTYPE 2>/dev/null \
+        | awk -v g="$ESP_GUID" '
+            tolower($0) !~ /boot_acs/ &&
+            $2=="part" &&
+            tolower($3)==tolower(g)
+        ')"
+
+    if [ -n "$ESP_LINES" ]; then
+        echo "Detected system ESP partition(s) by GPT type GUID:"
+        echo "$ESP_LINES"
+        return 0
     fi
 
     return 1

--- a/docs/systemready_devicetree_band_flow.md
+++ b/docs/systemready_devicetree_band_flow.md
@@ -24,6 +24,7 @@ The automation flow covers:
 | Base system architecture | BSA |
 | Platform firmware/device interface | PFDI |
 | Secure Boot compliance | BBSR |
+| System control and management | SCMI |
 | Devicetree validation | DT validation tools, DT parser, DT kernel selftests |
 | Linux device visibility | Device driver information script |
 | Network validation | UEFI ping test, HTTPS/network boot, Ethernet checks |
@@ -143,24 +144,30 @@ flowchart LR
     linkStyle default stroke:#2563eb,stroke-width:4px;
 
     A["GRUB<br/>Menu"] --> B{"Boot<br/>option"}
+
     B --> C["bbr/bsa<br/>ACS<br/><b>Automation</b>"]
     B --> D["Linux<br/>Boot"]
     B --> E["BBSR<br/>Compliance<br/><b>Automation</b>"]
+    B --> F["SCMI<br/>Compliance"]
 
-    click C "https://github.com/ARM-software/arm-systemready/blob/main/docs/systemredy_devicetree_band_flow.md#2-bbrbsa-acs-automation-flow" "Go to bbr/bsa ACS Automation Flow"
-    click D "https://github.com/ARM-software/arm-systemready/blob/main/docs/systemredy_devicetree_band_flow.md#3-linux-automation-flow" "Go to Linux Automation Flow"
-    click E "https://github.com/ARM-software/arm-systemready/blob/main/docs/systemredy_devicetree_band_flow.md#4-bbsr-automation-flow" "Go to BBSR Automation Flow"
+    click C "https://github.com/ARM-software/arm-systemready/blob/flow_docs/docs/systemready_devicetree_band_flow.md#2-bbrbsa-acs-automation-flow" "Go to bbr/bsa ACS Automation Flow"
+    click D "https://github.com/ARM-software/arm-systemready/blob/flow_docs/docs/systemready_devicetree_band_flow.md#3-linux-automation-flow" "Go to Linux Automation Flow"
+    click E "https://github.com/ARM-software/arm-systemready/blob/flow_docs/docs/systemready_devicetree_band_flow.md#4-bbsr-automation-flow" "Go to BBSR Automation Flow"
+    click F "https://github.com/ARM-software/arm-systemready/blob/flow_docs/docs/systemready_devicetree_band_flow.md#5-scmi-compliance-flow" "Go to SCMI Compliance Flow"
 
     classDef grub fill:#dbeafe,stroke:#1d4ed8,stroke-width:3px,color:#0f172a;
     classDef decision fill:#ffffff,stroke:#2563eb,stroke-width:3px,color:#0f172a;
     classDef linux fill:#dcfce7,stroke:#16a34a,stroke-width:3px,color:#0f172a;
     classDef uefi fill:#ffedd5,stroke:#ea580c,stroke-width:3px,color:#0f172a;
     classDef bbsr fill:#fef3c7,stroke:#d97706,stroke-width:3px,color:#0f172a;
+    classDef scmi fill:#e0f2fe,stroke:#0284c7,stroke-width:3px,color:#0f172a;
+
     class A grub;
     class B decision;
     class C uefi;
     class D linux;
     class E bbsr;
+    class F scmi;
 ```
 ---
 
@@ -258,8 +265,8 @@ flowchart LR
     I --> J["ACS log parser<br/><br/>(apply waivers<br/>if configured)"]
     J --> K["Print<br/>ACS summary"]
 
-    click H "https://github.com/ARM-software/arm-systemready/blob/main/docs/systemredy_devicetree_band_flow.md#network-boot" "Go to Network Boot Flow"
-    click I "https://github.com/ARM-software/arm-systemready/blob/main/docs/systemredy_devicetree_band_flow.md#capsule-update-flow" "Go to Capsule Update Flow"
+    click H "https://github.com/ARM-software/arm-systemready/blob/main/docs/systemready_devicetree_band_flow.md#network-boot" "Go to Network Boot Flow"
+    click I "https://github.com/ARM-software/arm-systemready/blob/main/docs/systemready_devicetree_band_flow.md#capsule-update-flow" "Go to Capsule Update Flow"
 
     classDef entry fill:#dbeafe,stroke:#1d4ed8,stroke-width:3px,color:#0f172a;
     classDef linux fill:#dcfce7,stroke:#16a34a,stroke-width:3px,color:#0f172a;
@@ -422,8 +429,8 @@ flowchart LR
     I --> J["ACS log parser<br/><br/>(apply waivers<br/>if configured)"]
     J --> K["Print<br/>ACS summary"]
 
-    click H "https://github.com/ARM-software/arm-systemready/blob/main/docs/systemredy_devicetree_band_flow.md#network-boot" "Go to Network Boot Flow"
-    click I "https://github.com/ARM-software/arm-systemready/blob/main/docs/systemredy_devicetree_band_flow.md#capsule-update-flow" "Go to Capsule Update Flow"
+    click H "https://github.com/ARM-software/arm-systemready/blob/main/docs/systemready_devicetree_band_flow.md#network-boot" "Go to Network Boot Flow"
+    click I "https://github.com/ARM-software/arm-systemready/blob/main/docs/systemready_devicetree_band_flow.md#capsule-update-flow" "Go to Capsule Update Flow"
 
     classDef entry fill:#dbeafe,stroke:#1d4ed8,stroke-width:3px,color:#0f172a;
     classDef linux fill:#dcfce7,stroke:#16a34a,stroke-width:3px,color:#0f172a;
@@ -499,6 +506,48 @@ flowchart LR
     class I uefi;
 ```
 ---
+### 5. SCMI Compliance Flow
+
+> This flow is executed when **SCMI Compliance** is selected from GRUB.
+
+```mermaid
+%%{init: {
+  "theme": "base",
+  "flowchart": {
+    "curve": "linear",
+    "nodeSpacing": 30,
+    "rankSpacing": 40
+  },
+  "themeVariables": {
+    "fontFamily": "Arial",
+    "fontSize": "14px",
+    "primaryBorderColor": "#0f172a",
+    "lineColor": "#2563eb",
+    "tertiaryColor": "#ffffff"
+  }
+}}%%
+
+flowchart LR
+
+    linkStyle default stroke:#2563eb,stroke-width:4px;
+
+    A["SCMI<br/>Compliance"]
+    A --> B["Boot<br/>ACS Linux"]
+    B --> C["Detect SCMI<br/>boot option"]
+    C --> D["Run SCMI<br/>ACS tests"]
+    D --> E["Collect SCMI<br/>test log"]
+    E --> F["ACS log parser<br/><br/>(apply waivers<br/>if configured)"]
+    F --> G["Print<br/>ACS summary"]
+
+    classDef scmi fill:#e0f2fe,stroke:#0284c7,stroke-width:3px,color:#0f172a;
+    classDef linux fill:#dcfce7,stroke:#16a34a,stroke-width:3px,color:#0f172a;
+    classDef result fill:#ede9fe,stroke:#7c3aed,stroke-width:3px,color:#0f172a;
+
+    class A,D,E scmi;
+    class B,C linux;
+    class F,G result;
+```
+---
 
 ## GRUB Boot Menu Options
 
@@ -507,6 +556,7 @@ flowchart LR
 | `Linux Boot` | Boots Yocto Linux environment |
 | `bbr/bsa` | Runs the main automated DT compliance flow |
 | `BBSR Compliance (Automation)` | Runs Secure Boot / BBSR compliance flow |
+| `SCMI Compliance` | Boots ACS Linux with SCMI mode and runs SCMI compliance tests |
 
 ---
 


### PR DESCRIPTION
- Use GPT PARTTYPE GUID matching for ESP detection.
- Add SCMI compliance flow in systemready_devicetree_band_flow.md.
- Fix broken flow links in DT band documentation.


Change-Id: I6549b137f3ab76fcefe4e06cce1ec8c0e9691b2f