### PR TITLE
Add sbmr level config and init.sh change

### DIFF
--- a/common/config/acs_run_config.ini
+++ b/common/config/acs_run_config.ini
@@ -64,3 +64,5 @@ automation_bbsr_tpm_run = false
 [SBMR]
 # This variable Enable/Disable SBMR in-band run(Valid values true or false).
 automation_sbmr_in_band_run = false
+# SBMR ACS level. Leave empty to use sbmr-acs default behavior.
+sbmr_level = M2.1

--- a/common/linux_scripts/init.sh
+++ b/common/linux_scripts/init.sh
@@ -82,6 +82,7 @@ if [ "$automation_enabled" == "True" ]; then
   sbsa_enabled="`python3 /mnt/acs_tests/parser/Parser.py -automation_sbsa_run`"
 
   sbmr_enabled="`python3 /mnt/acs_tests/parser/Parser.py -automation_sbmr_in_band_run`"
+  sbmr_level="`python3 /mnt/acs_tests/parser/Parser.py -sbmr_level`"
 fi
 
 if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
@@ -150,7 +151,11 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
       cd /usr/bin
       python redfish-finder
       cd sbmr-acs
-      ./run-sbmr-acs.sh linux
+      if [ -n "$sbmr_level" ]; then
+        ./run-sbmr-acs.sh linux --level "$sbmr_level"
+      else
+        ./run-sbmr-acs.sh linux
+      fi
       mkdir -p ${LOG_DIR}/sbmr
       cp -r logs ${LOG_DIR}/sbmr/sbmr_in_band_logs
       cd /

--- a/common/linux_scripts/sbmr.sh
+++ b/common/linux_scripts/sbmr.sh
@@ -20,24 +20,29 @@
 LOG_DIR="/mnt/acs_results_template/acs_results"
 
 automation_enabled="`python3 /mnt/acs_tests/parser/Parser.py -automation`"
-if [ "$automation_enabled" == "True" ]; then
-    sbmr_enabled="`python3 /mnt/acs_tests/parser/Parser.py -automation_sbmr_in_band_run`"
-fi
+sbmr_enabled="`python3 /mnt/acs_tests/parser/Parser.py -automation_sbmr_in_band_run`"
+sbmr_level="`python3 /mnt/acs_tests/parser/Parser.py -sbmr_level`"
 
 run_sbmr_in_band(){
     echo "Call SBMR ACS in-band test"
     cd /usr/bin
     python redfish-finder
     cd sbmr-acs
-    ./run-sbmr-acs.sh linux
+    if [ -n "$sbmr_level" ]; then
+        ./run-sbmr-acs.sh linux --level "$sbmr_level"
+    else
+        ./run-sbmr-acs.sh linux
+    fi
     mkdir -p ${LOG_DIR}/sbmr
     cp -r logs ${LOG_DIR}/sbmr/sbmr_in_band_logs
     cd /
     echo "SBMR ACS in-band run is completed\n"
 }
 
-  # Run SBMR-ACS In-Band Tests if run with grub option
-if [ "$automation_enabled" == "True" ] &&  [ "$sbmr_enabled" == "False" ]; then
+  # Run SBMR-ACS In-Band Tests if automation and SBMR are enabled in config file
+if [ "$automation_enabled" == "False" ]; then
+    echo "********* Automation run is disabled in config file**************"
+elif [ "$sbmr_enabled" == "False" ]; then
     echo "********* SBMR in-band test is disabled in config file**************"
 else
     run_sbmr_in_band

--- a/common/parser/Parser.py
+++ b/common/parser/Parser.py
@@ -111,6 +111,7 @@ def main():
     parser.add_argument('-automation_bbsr_tpm_run', action='store_true', help='Check if BBSR TPM is enabled')
     parser.add_argument('--config', default='/mnt/acs_tests/config/acs_run_config.ini', help='Path to the config file')
     parser.add_argument('-automation_sbmr_in_band_run', action='store_true', help='Check if SBMR is enabled')
+    parser.add_argument('-sbmr_level', action='store_true', help='Get SBMR ACS level')
 
     args = parser.parse_args()
 
@@ -151,6 +152,9 @@ def main():
     elif args.automation_sbmr_in_band_run:
         enabled = check_section_enable(config, 'SBMR', 'automation_sbmr_in_band_run')
         print(enabled)
+    elif args.sbmr_level:
+        level = config.get('SBMR', 'sbmr_level', fallback='')
+        print(level)
     else:
         print("Please specify a valid command or use --help for more information.")
         return


### PR DESCRIPTION
- Add sbmr_level config with M2.1 as the default value as per SRS v3.1.1
- Pass --level to SBMR ACS inband testing.

Change-Id: I676b33596c709c657727c3d5f8daa80f13cdf7b4