### PR TITLE
SystemReady-DT: enable additional GRUB console commands

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/grub/grub-efi_%.bbappend
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/grub/grub-efi_%.bbappend
@@ -1,8 +1,9 @@
-# add chainloader
+# Add DT-band GRUB console/debug commands used during ACS bring-up.
 
 GRUB_BUILDIN = "boot linux ext2 fat serial part_msdos part_gpt normal \
                 pgp gcry_sha512 gcry_rsa ntfs ntfscomp hfsplus help \
                 terminal terminfo tpm lsefi gettext read search_fs_file \
                 search_fs_uuid search_label \
-                efi_gop iso9660 configfile search loadenv test chain"
+                efi_gop iso9660 configfile search loadenv test chain \
+                efifwsetup halt lsefimmap lsefisystab minicmd reboot"
 


### PR DESCRIPTION
Add the missing GRUB built-in modules in the Devicetree band Yocto recipe so more commands are available from the GRUB console during ACS debugging.

Add modules for:
- dump
- halt
- lsefimmap
- lsefisystab
- exit via minicmd
- reboot


Change-Id: Iab9007f8ccdab36b31b2e2b452dec736b4da7b14