### PR TITLE
(feat):add PSCI version reporting in DT system info

### DIFF
--- a/common/log_parser/acs_info.py
+++ b/common/log_parser/acs_info.py
@@ -149,11 +149,27 @@ def get_bmc_firmware_version(ipmitool_log_path):
     value = extract_bmc_firmware_from_ipmitool_log(ipmitool_log_path)
     return value if value else "Unknown"
 
+def get_psci_version(psci_kernel_log_path):
+    """Return PSCI version from kernel log or Unknown if missing."""
+    if not psci_kernel_log_path or not os.path.isfile(psci_kernel_log_path):
+        return "Unknown"
+
+    version_re = re.compile(r"psci:\s+PSCIv([\d.]+)\s+detected in firmware\.", re.IGNORECASE)
+    with open(psci_kernel_log_path, "r", errors="replace") as f:
+        for raw in f:
+            match = version_re.search(raw.strip())
+            if match:
+                return f"PSCI v{match.group(1)}"
+    return "Unknown"
+
 def is_systemready_band(acs_conf):
     # Return True only for SystemReady (not DeviceTree) band.
     band_val = (acs_conf or {}).get("Band", "").strip().lower()
     return band_val == "systemready band"
 
+def is_systemready_dt_band(acs_conf):
+    band_val = (acs_conf or {}).get("Band", "").strip().lower()
+    return band_val == "systemready devicetree band"
 
 
 def main():
@@ -167,6 +183,7 @@ def main():
     parser.add_argument("--dmidecode_log", default=".", help="Path to dmidecode log")
     parser.add_argument("--output_dir", default=".", help="Directory where acs_info.txt and acs_info.json will be created.")
     parser.add_argument("--ipmitool_log", default="", help="Path to ipmitool mc info log for BMC firmware extraction")
+    parser.add_argument("--psci_kernel_log", default="", help="Path to psci_kernel.log for PSCI version extraction")
     args = parser.parse_args()
 
     # Gather system info from dmidecode
@@ -187,6 +204,8 @@ def main():
     uefi_ver = get_uefi_version(args.uefi_version_log)
     if uefi_ver != 'Unknown':
         system_info['UEFI Version'] = uefi_ver
+    if is_systemready_dt_band(acs_conf):
+        system_info['PSCI version'] = get_psci_version(args.psci_kernel_log)
     if is_systemready_band(acs_conf):
         system_info['BMC Firmware Version'] = get_bmc_firmware_version(args.ipmitool_log)
 

--- a/common/log_parser/generate_acs_summary.py
+++ b/common/log_parser/generate_acs_summary.py
@@ -959,6 +959,8 @@ if __name__ == "__main__":
     acs_info_system = read_acs_info_system_info(args.acs_info_json)
     if isinstance(acs_info_system, dict) and "BMC Firmware Version" in acs_info_system:
         system_info["BMC Firmware Version"] = acs_info_system.get("BMC Firmware Version", "N/A")
+    if isinstance(acs_info_system, dict) and "PSCI version" in acs_info_system:
+        system_info["PSCI version"] = acs_info_system.get("PSCI version", "Unknown")
 
     # 4) Extract summary date from system_info
     summary_generated_date = system_info.pop('Summary Generated On Date/time', 'Unknown')

--- a/common/log_parser/main_log_parser.sh
+++ b/common/log_parser/main_log_parser.sh
@@ -82,12 +82,14 @@ mkdir -p "$JSONS_DIR"
 
 #echo "Gathering ACS info into acs_info.txt and acs_info.json..."
 IPMITOOL_LOG="$LOGS_PATH/linux_dump/ipmitool.txt"
+PSCI_KERNEL_LOG="$LOGS_PATH/linux_tools/psci/psci_kernel.log"
 python3 "$SCRIPTS_PATH/acs_info.py" \
     --acs_config_path "$ACS_CONFIG_PATH" \
     --system_config_path "$SYSTEM_CONFIG_PATH" \
     --uefi_version_log "$LOGS_PATH/uefi_dump/uefi_version.log" \
     --dmidecode_log "$LOGS_PATH/linux_dump/dmidecode.txt" \
     --ipmitool_log "$IPMITOOL_LOG" \
+    --psci_kernel_log "$PSCI_KERNEL_LOG" \
     --output_dir "$JSONS_DIR"
 echo ""
 printf "Test category: %s\n\n" "$test_category"

--- a/common/tools/acs-results-schema.json
+++ b/common/tools/acs-results-schema.json
@@ -1221,6 +1221,9 @@
         "PFDI version": {
           "type": "string"
         },
+        "PSCI version": {
+          "type": "string"
+        },
         "product website": {
           "type": "string"
         },
@@ -1276,7 +1279,8 @@
               "SCMI version",
               "Device Tree Version",
               "EBBR version",
-              "PFDI version"
+              "PFDI version",
+              "PSCI version"
             ]
           }
         },


### PR DESCRIPTION
	-extract PSCI version from linux_tools/psci/psci_kernel.log during ACS info generation
	-add DT band detection from acs_config Band field to include PSCI version only for SystemReady Devicetree band
	-pass psci_kernel.log path from main_log_parser.sh into acs_info.py
	-propagate PSCI version from acs_info.json into the generated ACS summary system information
	-update ACS results schema to allow and require PSCI version for SystemReady Devicetree band system info

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com

Change-Id: I3462ef37e6c2f53886cf9f18efcb79da5d5e41e5