### PR TITLE
python3-matplotlib: restore qhull source during build

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-devtools/python/python3-matplotlib_%.bbappend
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-devtools/python/python3-matplotlib_%.bbappend
@@ -1,0 +1,9 @@
+# Matplotlib expects a vendored qhull tree in ${S}/build during build_ext.
+# The unpacked auxiliary source is not present anymore by do_compile time in
+# this environment, so restore it from DL_DIR before invoking setup.py.
+do_compile:prepend() {
+    if [ ! -d ${S}/build/qhull-2020.2 ]; then
+        mkdir -p ${S}/build
+        tar -xzf ${DL_DIR}/qhull-2020-src-8.0.2.tgz -C ${S}/build
+    fi
+}


### PR DESCRIPTION
Restores the local qhull tarball into the matplotlib build tree so the Yocto build does not try to download it during do_compile.


Change-Id: Ic4850ab2367891278f2a34b142b05781f19f6be3