### PR TITLE
(feat):update DT bindings source to Linux v7.1.3

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -33,7 +33,7 @@ fi
 sleep 5
 
 DT_VERSION="SystemReady devicetree band ACS v3.1.2"
-KERNEL_VERSION="6.19"
+KERNEL_VERSION="7.1.3"
 
 echo "Attempting to mount the results partition ..."
 #mount result partition
@@ -303,7 +303,7 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
           sleep 5
           echo "  Generating compatible strings - Completed"
           /usr/bin/systemready-scripts/check-sr-results.py --cache-dir /usr/bin \
-           --linux-url "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${KERNEL_VERSION}.tar.xz" --dir /mnt/acs_results_template 2>&1 | tee /mnt/acs_results_template/acs_results/post-script/post-script.log
+           --linux-url "https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-${KERNEL_VERSION}.tar.xz" --dir /mnt/acs_results_template 2>&1 | tee /mnt/acs_results_template/acs_results/post-script/post-script.log
           cd -
         fi
         sync

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/process-schema/process-schema.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/process-schema/process-schema.bb
@@ -4,13 +4,13 @@ S = "${WORKDIR}"
 
 DEPENDS = "python3-native python3-dtschema-native "
 
-SRC_URI = "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.19.tar.xz"
-SRC_URI[sha256sum] = "303079a8250b8f381f82b03f90463d12ac98d4f6b149b761ea75af1323521357"
+SRC_URI = "https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-7.1.3.tar.xz"
+SRC_URI[sha256sum] = "be41c068e88f5242a19bccdbffbe077b18c47b45f627e2325504b4fab79dd1dc"
 
 do_install(){
-    install -d ${D}${bindir}/linux-6.19/bindings
-    cp -r ${S}/linux-6.19/Documentation/devicetree/bindings ${D}/${bindir}/linux-6.19/bindings
-    dt-mk-schema -j ${D}/${bindir}/linux-6.19/bindings > processed_schema.json
+    install -d ${D}${bindir}/linux-7.1.3/bindings
+    cp -r ${S}/linux-7.1.3/Documentation/devicetree/bindings ${D}/${bindir}/linux-7.1.3/bindings
+    dt-mk-schema -j ${D}/${bindir}/linux-7.1.3/bindings > processed_schema.json
     cp -r ${S}/processed_schema.json ${D}/${bindir}/
 }
 


### PR DESCRIPTION
	-update bundled DT validation bindings source from Linux v6.19
	 to Linux v7.1.3
	-update process-schema archive URL, checksum, and installed
	 bindings path for kernel/v7.x
	-update DT runtime binding version and post-script source URL
	 to use Linux v7.1.3
	-verify Linux v7.1.3 archive checksum and dt-mk-schema
	 generation with dtschema 2025.2

Signed-off-by: Ashish Sharma ashish.sharma2@arm.com
Change-Id: If038bba75cd841f77ff1b28bbf055ff42370d287