### PR TITLE
meta-woden(dt): Add dosfstools to woden image

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
@@ -220,6 +220,7 @@ IMAGE_INSTALL:append = "systemd-init-install \
                         python3-webencodings \
                         tar \
                         scmi-acs \
+                        dosfstools \
 "
 
 addtask dir_deploy before do_populate_lic_deploy after do_image_complete


### PR DESCRIPTION
  - Include the dosfstools package in the ACS-DT Linux image to provide FAT filesystem utilities

Change-Id: Id976787b6d069edc6c2fffc3df46390f7b70527b