### PR TITLE
(fix):collect dmidecode before BBSR and SCMI parsing

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -148,7 +148,7 @@ if [ $ADDITIONAL_CMD_OPTION != "noacs" ]; then
         cat /proc/iomem      > $LINUX_DUMP_DIR/iomem.log
         ls -lR /sys/firmware > $LINUX_DUMP_DIR/firmware.log
         cp -r /sys/firmware $LINUX_DUMP_DIR/
-        dmidecode  > $LINUX_DUMP_DIR/dmidecode.log
+        dmidecode  > $LINUX_DUMP_DIR/dmidecode.txt
         efibootmgr > $LINUX_DUMP_DIR/efibootmgr.log
         fwupdmgr get-devices          &> $LINUX_DUMP_DIR/fwupd_getdevices.log
         echo "0" | fwupdtool esp-list &> $LINUX_DUMP_DIR/fwupd_esplist.log

--- a/common/acs_test_framework_manifests/acs-info.yaml
+++ b/common/acs_test_framework_manifests/acs-info.yaml
@@ -281,3 +281,56 @@ suites:
           - type: file_contains
             path: "{dir}/out/acs_info.json"
             text: "\"Firmware Notes\": \"build:nightly:123\""
+
+      - name: cli_missing_dmidecode_warns_and_generates_json
+        text_files:
+          acs_config.txt: |
+            Band: SystemReady Devicetree Band
+            ACS version: 3.1.2
+        args:
+          - --dmidecode_log
+          - "{dir}/missing/dmidecode.txt"
+          - --acs_config_path
+          - "{dir}/acs_config.txt"
+          - --output_dir
+          - "{dir}/out"
+        expect_exit_code: 0
+        expect_stdout_or_stderr_contains:
+          - "WARNING: Could not read dmidecode log"
+        post_checks:
+          - type: exists
+            path: "{dir}/out/acs_info.json"
+          - type: file_contains
+            path: "{dir}/out/acs_info.json"
+            text: "\"Vendor\": \"Unknown\""
+          - type: file_contains
+            path: "{dir}/out/acs_info.json"
+            text: "\"System Name\": \"Unknown\""
+          - type: file_contains
+            path: "{dir}/out/acs_info.json"
+            text: "\"SoC Family\": \"Unknown\""
+          - type: file_contains
+            path: "{dir}/out/acs_info.json"
+            text: "\"Firmware Version\": \"Unknown\""
+          - type: file_contains
+            path: "{dir}/out/acs_info.json"
+            text: "\"Summary Generated On\""
+          - type: file_contains
+            path: "{dir}/out/acs_info.json"
+            text: "\"ACS version\": \"3.1.2\""
+
+      - name: cli_unreadable_dmidecode_warns_and_generates_json
+        args:
+          - --dmidecode_log
+          - "{dir}"
+          - --output_dir
+          - "{dir}/out"
+        expect_exit_code: 0
+        expect_stdout_or_stderr_contains:
+          - "WARNING: Could not read dmidecode log"
+        post_checks:
+          - type: exists
+            path: "{dir}/out/acs_info.json"
+          - type: file_contains
+            path: "{dir}/out/acs_info.json"
+            text: "\"Vendor\": \"Unknown\""

--- a/common/linux_scripts/scmi_init.sh
+++ b/common/linux_scripts/scmi_init.sh
@@ -29,10 +29,23 @@ echo "SCMI ACS Test Log:\n"
 cat /mnt/acs_results_template/acs_results/linux_acs/scmi_acs_app/arm_scmi_test_log.txt
 cd -
 
-# ACS log parser run
-echo "Running acs log parser tool "
 RESULTS_DIR="/mnt/acs_results_template/acs_results"
 if [ -d "$RESULTS_DIR" ]; then
+  # SCMI exits before the normal Linux dump flow. Reuse existing system
+  # information when available; otherwise collect it before parsing.
+  LINUX_DUMP_DIR="$RESULTS_DIR/linux_dump"
+  DMIDECODE_LOG="$LINUX_DUMP_DIR/dmidecode.txt"
+
+  if [ -s "$DMIDECODE_LOG" ]; then
+    echo "Using existing dmidecode log at $DMIDECODE_LOG"
+  else
+    mkdir -p "$LINUX_DUMP_DIR"
+    echo "Collecting dmidecode for SCMI results"
+    dmidecode > "$DMIDECODE_LOG" 2>&1
+  fi
+
+  # ACS log parser run
+  echo "Running acs log parser tool "
   if [ -d "$RESULTS_DIR/acs_summary" ]; then
       rm -r $RESULTS_DIR/acs_summary
   fi

--- a/common/linux_scripts/secure_init.sh
+++ b/common/linux_scripts/secure_init.sh
@@ -130,6 +130,20 @@ if [ -f "$YOCTO_FLAG" ]; then
   fi
 fi
 
+# Ensure system information is available before parsing BBSR results. Reuse an
+# existing dmidecode file; otherwise collect it because the secureboot flow
+# exits before the normal Linux dump.
+LINUX_DUMP_DIR="$RESULTS_DIR/linux_dump"
+DMIDECODE_LOG="$LINUX_DUMP_DIR/dmidecode.txt"
+
+if [ -s "$DMIDECODE_LOG" ]; then
+  echo "Using existing dmidecode log at $DMIDECODE_LOG"
+else
+  mkdir -p "$LINUX_DUMP_DIR"
+  echo "Collecting dmidecode for BBSR results"
+  dmidecode > "$DMIDECODE_LOG" 2>&1
+fi
+
 # ACS log parser run
 
 echo "Running acs log parser tool "

--- a/common/log_parser/acs_info.py
+++ b/common/log_parser/acs_info.py
@@ -37,6 +37,7 @@ def get_system_info(dmidecode_log_path):
         "SoC Family": "Unknown",
         "System Name": "Unknown",
         "Vendor": "Unknown",
+        "Summary Generated On": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     }
 
     in_bios_info = False
@@ -45,7 +46,18 @@ def get_system_info(dmidecode_log_path):
     # Regex to match key-value pairs in dmidecode output
     kv_re = re.compile(r"^\s*([A-Za-z0-9 /()._-]+)\s*:\s*(.*)\s*$")
 
-    with open(dmidecode_log_path, "r", errors="replace") as f:
+    try:
+        dmidecode_log = open(
+            dmidecode_log_path, "r", encoding="utf-8", errors="replace"
+        )
+    except OSError as exc:
+        print(
+            f"WARNING: Could not read dmidecode log '{dmidecode_log_path}': "
+            f"{exc}. System information will be reported as Unknown."
+        )
+        return system_info
+
+    with dmidecode_log as f:
         for raw in f:
             line = raw.rstrip("\n")
 
@@ -86,7 +98,6 @@ def get_system_info(dmidecode_log_path):
                 elif key == "Manufacturer" and system_info["Vendor"] == "Unknown":
                     system_info["Vendor"] = val
 
-    system_info["Summary Generated On"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     return system_info
 
 def parse_config(config_path):


### PR DESCRIPTION
	-reuse an existing non-empty dmidecode.txt in BBSR and SCMI,
	 or collect it before log parsing when unavailable
	-align the normal DT Linux dump producer with the existing
	 dmidecode.txt parser input
	-warn and continue with Unknown system information when the
	 dmidecode input is missing or unreadable
	-add regression coverage and verify BBSR and SCMI collection
	 and reuse paths without dmidecode parser exceptions


Change-Id: Ia6adf8cb784446805fb8f1b4526e158682e724d7