### PR TITLE
(improv): limit BSA subtest descriptions to 49 characters

### DIFF
--- a/common/acs_test_framework_manifests/logs-to-json.yaml
+++ b/common/acs_test_framework_manifests/logs-to-json.yaml
@@ -220,6 +220,33 @@ suites:
 
 
 # =========================
+# BSA LOGS TO JSON
+# =========================
+
+  - name: bsa_logs_to_json_specific
+    files:
+      - common/log_parser/bsa/logs_to_json.py
+
+    cases:
+      - name: limits_all_subtest_descriptions_to_49_nonspace_chars
+        type: py_function
+        function: subtest_entry_from_frame
+        args:
+          - number: "RULE : 1"
+            description: "1234567890 1234567890 1234567890 1234567890 1234567890"
+            level: 1
+            path:
+              - "RULE : 1"
+          - "PASSED"
+        expect_return:
+          sub_Test_Number: "RULE : 1"
+          sub_Test_Description: "1234567890 1234567890 1234567890 1234567890 123456789"
+          sub_test_result: "PASSED"
+          sub_Test_Level: 1
+          sub_Test_Path: "RULE : 1"
+
+
+# =========================
 # EDK2 LOGS TO JSON
 # =========================
 

--- a/common/log_parser/bsa/logs_to_json.py
+++ b/common/log_parser/bsa/logs_to_json.py
@@ -33,6 +33,7 @@ REFERENCED_RULES_MARKER_RE = re.compile(
 )
 RULE_LINE_RE = re.compile(r'\b([A-Za-z0-9_]+)\s*:\s*(-|\d+)\s*:\s*(.*)$')
 RESULT_RE = re.compile(r'\bResult:\s*(.*)$', re.IGNORECASE)
+MAX_SUBTEST_DESCRIPTION_NONSPACE_CHARS = 49
 
 def detect_file_encoding(file_path):
     with open(file_path, 'rb') as file:
@@ -151,6 +152,19 @@ def extract_status_text(status_text):
 def make_test_number(rule_id, test_index):
     return f"{rule_id} : {test_index or '-'}"
 
+def limit_subtest_description(description):
+    """Limit a description to 49 non-whitespace characters."""
+    description = (description or "").strip()
+    nonspace_count = 0
+    for index, char in enumerate(description):
+        if char.isspace():
+            continue
+        nonspace_count += 1
+        if nonspace_count > MAX_SUBTEST_DESCRIPTION_NONSPACE_CHARS:
+            return description[:index].rstrip()
+
+    return description
+
 # A frame is one rule that has started but has not reached its Result/END line.
 # Keeping these frames on a stack lets the parser attach each completed child
 # rule to the nearest still-open parent rule.
@@ -195,7 +209,9 @@ def subtest_entry_from_frame(frame, formatted_result):
     # log branch so a partner can compare JSON/HTML directly with the log.
     entry = {
         "sub_Test_Number": frame.get("number", make_test_number(frame.get("rule_id"), frame.get("index"))),
-        "sub_Test_Description": frame.get("description", ""),
+        "sub_Test_Description": limit_subtest_description(
+            frame.get("description", "")
+        ),
         "sub_test_result": formatted_result,
         "sub_Test_Level": frame.get("level", 1),
         "sub_Test_Path": " / ".join(frame.get("path", []))


### PR DESCRIPTION
- Limit BSA subtest descriptions to 49 non-whitespace characters.

- Preserve spaces while excluding them from the character limit.

- Add a generic YAML check for the shared subtest JSON builder.


Change-Id: I0859b57bca5ef7f1a865f629752ff765aa498011