### PR TITLE
(fix) Update bsa version patch to reflect latest sysarch changes

### DIFF
--- a/SystemReady-band/patches/bsa_srversion.patch
+++ b/SystemReady-band/patches/bsa_srversion.patch
@@ -1,12 +1,12 @@
 diff --git a/apps/uefi/bsa_main.c b/apps/uefi/bsa_main.c
-index eb36791..98bc11f 100644
+index 6f473d9..0e23c64 100644
 --- a/apps/uefi/bsa_main.c
 +++ b/apps/uefi/bsa_main.c
-@@ -156,6 +156,7 @@ execute_tests()
+@@ -162,6 +162,7 @@ execute_tests()
          goto exit_acs;
      }
  
 +    val_print(INFO, "\n\n SystemReady band ACS v3.1.1", 0);
      val_print(INFO, "\n\n BSA Architecture Compliance Suite");
-     val_print(INFO, "\n          Version %d.", BSA_ACS_MAJOR_VER);
+     val_print(INFO, "\n        Version %d.", BSA_ACS_MAJOR_VER);
      val_print(INFO, "%d.", BSA_ACS_MINOR_VER);


### PR DESCRIPTION
 * update patch is needed for latest sysarch format changes