### PR TITLE
fix: count spaces in BSA subtest description limit

### DIFF
--- a/common/acs_test_framework_manifests/logs-to-json.yaml
+++ b/common/acs_test_framework_manifests/logs-to-json.yaml
@@ -228,7 +228,7 @@ suites:
       - common/log_parser/bsa/logs_to_json.py
 
     cases:
-      - name: limits_all_subtest_descriptions_to_49_nonspace_chars
+      - name: limits_all_subtest_descriptions_to_49_chars
         type: py_function
         function: subtest_entry_from_frame
         args:
@@ -240,7 +240,7 @@ suites:
           - "PASSED"
         expect_return:
           sub_Test_Number: "RULE : 1"
-          sub_Test_Description: "1234567890 1234567890 1234567890 1234567890 123456789"
+          sub_Test_Description: "1234567890 1234567890 1234567890 1234567890 12345"
           sub_test_result: "PASSED"
           sub_Test_Level: 1
           sub_Test_Path: "RULE : 1"

--- a/common/log_parser/bsa/logs_to_json.py
+++ b/common/log_parser/bsa/logs_to_json.py
@@ -33,7 +33,7 @@ REFERENCED_RULES_MARKER_RE = re.compile(
 )
 RULE_LINE_RE = re.compile(r'\b([A-Za-z0-9_]+)\s*:\s*(-|\d+)\s*:\s*(.*)$')
 RESULT_RE = re.compile(r'\bResult:\s*(.*)$', re.IGNORECASE)
-MAX_SUBTEST_DESCRIPTION_NONSPACE_CHARS = 49
+MAX_SUBTEST_DESCRIPTION_CHARS = 49
 
 def detect_file_encoding(file_path):
     with open(file_path, 'rb') as file:
@@ -153,17 +153,8 @@ def make_test_number(rule_id, test_index):
     return f"{rule_id} : {test_index or '-'}"
 
 def limit_subtest_description(description):
-    """Limit a description to 49 non-whitespace characters."""
-    description = (description or "").strip()
-    nonspace_count = 0
-    for index, char in enumerate(description):
-        if char.isspace():
-            continue
-        nonspace_count += 1
-        if nonspace_count > MAX_SUBTEST_DESCRIPTION_NONSPACE_CHARS:
-            return description[:index].rstrip()
-
-    return description
+    """Limit a description to 49 characters."""
+    return (description or "").strip()[:MAX_SUBTEST_DESCRIPTION_CHARS].rstrip()
 
 # A frame is one rule that has started but has not reached its Result/END line.
 # Keeping these frames on a stack lets the parser attach each completed child


### PR DESCRIPTION
Limit BSA subtest descriptions to 49 total characters instead of 49 non-whitespace characters.

Some logs append UEFI error text such as ConvertPages directly after the rule description. Counting spaces keeps the parser aligned with the intended fixed-width description field and prevents that appended text from leaking into the parsed subtest description.