### PR TITLE
woden-image: include linux-firmware in woden image

### DIFF
--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-images/images/woden-image.bb
@@ -8,6 +8,7 @@ WKS_FILE = "woden.wks.in"
 IMAGE_INSTALL = "packagegroup-core-boot \
                  python3 \
                  fwts \
+                 linux-firmware \
                  bsa-acs-drv \
                  bsa-acs-app \
                  mokutil \


### PR DESCRIPTION
Include the linux-firmware package in the ACS root filesystem to provide platform firmware required for device initialization.


Change-Id: I7ff9ad80b0a845420d38da334a6d3f19b2231966