### PR TITLE
SystemReady: Run PCIe option ROM audit app on SR image

### DIFF
--- a/SystemReady-band/build-scripts/build-all.sh
+++ b/SystemReady-band/build-scripts/build-all.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +33,7 @@ source ./build-scripts/build-uefi.sh $@
 source ./build-scripts/build-bsaefi.sh $@
 source ./build-scripts/build-sbsaefi.sh $@
 source ./build-scripts/build-sct.sh SBBR $2
-source ./build-scripts/build-uefi-apps.sh $@
+source ./build-scripts/build-uefi-apps.sh SBBR $PACKAGE
 source ./build-scripts/build-linux.sh $@
 source ./build-scripts/build-linux-bsa.sh $@
 source ./build-scripts/build-grub.sh $@

--- a/SystemReady-band/build-scripts/make_image.sh
+++ b/SystemReady-band/build-scripts/make_image.sh
@@ -103,6 +103,7 @@ create_fatpart ()
     mcopy -i $fatpart_name ${TOP_DIR}/bbsr-keys/*.auth ::/acs_tests/bbsr-keys
 
     mcopy -i $fatpart_name ${UEFI_APPS_PATH}/CapsuleApp.efi ::/acs_tests/app
+    mcopy -i $fatpart_name ${UEFI_APPS_PATH}/PcieOptionRomArchAudit.efi ::/acs_tests/app
     mcopy -i $fatpart_name $OUTDIR/Parser.efi  ::/acs_tests/parser
     mcopy -i $fatpart_name $CONFIG_PARSER_FILE  ::/acs_tests/parser
     mcopy -i $fatpart_name $CONFIG_PARSER_PYTHON_FILE  ::/acs_tests/parser

--- a/common/uefi_scripts/startup.nsh
+++ b/common/uefi_scripts/startup.nsh
@@ -130,6 +130,12 @@ for %p in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
         echo " "
         echo "Running debug dump"
         FS%p:\acs_tests\debug\debug_dump.nsh
+
+        # Run the Standalone PCIe option ROM architecture audit app
+        if exist FS%p:\acs_tests\app\PcieOptionRomArchAudit.efi then
+            echo "Running PcieOptionRomArchAudit standalone app"
+            FS%p:\acs_tests\app\PcieOptionRomArchAudit.efi
+        endif
         goto DoneDebug
     endif
 endfor


### PR DESCRIPTION
Copy PcieOptionRomArchAudit.efi to the EFI partition under acs_tests/app and run it from the SystemReady startup flow.


Change-Id: I07baf1ce594ece6d0c3aae3884fcd17292786c42