### PR TITLE
(fix):handle multi-digit UEFI filesystem mappings

### DIFF
--- a/common/uefi_scripts/bbsr_startup.nsh
+++ b/common/uefi_scripts/bbsr_startup.nsh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ echo -off
 
 #UpdateVars.efi is present only in the SystemReady-devicetree-band ACS image
 #The below block for UpdateVars shall be executed only for SystemReady-devicetree-band
-for %q in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %q in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%q:\acs_tests\app\UpdateVars.efi then
         FS%q:
         cp -q FS%q:\acs_tests\bbsr-keys\*.auth FS%q:\acs_tests\app\
@@ -68,7 +68,7 @@ endfor
 
 :StartTest
 # Run the config parser
-for %b in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %b in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%b:\acs_tests\parser\Parser.efi then
         if exist FS%b:\acs_tests\config\acs_run_config.ini then
             FS%b:
@@ -95,7 +95,7 @@ for %b in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
     endif
 endfor
 :DoneParser
-for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%i:\acs_tests\bbr\bbsr_SctStartup.nsh then
         # flag BBSR compliance testing is in progress
         echo "" > FS%i:\acs_tests\bbr\bbsr_inprogress.flag
@@ -122,7 +122,7 @@ endfor
 
 # Boot Linux with SecureBoot enabled
 echo "Booting Linux (SecureBoot)"
-for %l in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %l in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     # Buildroot based build (SystemReady band)
     if exist FS%l:\Image and exist FS%l:\ramdisk-buildroot.img then
         FS%l:

--- a/common/uefi_scripts/bsa.nsh
+++ b/common/uefi_scripts/bsa.nsh
@@ -18,7 +18,7 @@
 
 echo -off
 
-for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%i:\acs_results_template\acs_results then
         FS%i:
         cd FS%i:\acs_results_template\acs_results

--- a/common/uefi_scripts/capsule_update.nsh
+++ b/common/uefi_scripts/capsule_update.nsh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2024-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ echo -off
 
 #The below capsule update block shall be supported only for SystemReady-devicetree-band
 # check for capsule update
-for %r in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %r in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%r:\acs_tests\app\capsule_update.nsh then
         if exist FS%r:\acs_tests\app\capsule_update_check.flag then
             echo "press any key to test capsule update"

--- a/common/uefi_scripts/debug_dump.nsh
+++ b/common/uefi_scripts/debug_dump.nsh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 echo -off
-for %m in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %m in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%m:\acs_results_template\acs_results then
         FS%m:
         cd FS%m:\acs_results_template\acs_results

--- a/common/uefi_scripts/https_boot.nsh
+++ b/common/uefi_scripts/https_boot.nsh
@@ -71,7 +71,7 @@ echo HOSTPATH=%HTTPS_IMAGE_HOSTPATH% >> %logfile%
 # locate ledge.efi and set in-progress flag
 set rc 1
 
-for %j in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %j in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
   if exist FS%j:\acs_tests\app\ledge.efi then
     FS%j:
     echo ledge.efi found at \acs_tests\app\ledge.efi >> %logfile%

--- a/common/uefi_scripts/parser.nsh
+++ b/common/uefi_scripts/parser.nsh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2024-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2024-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 # limitations under the License.
 
 echo -off
-for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%i:\acs_tests\parser\Parser.efi then
         FS%i:
         acs_tests\parser\Parser.efi

--- a/common/uefi_scripts/pfdi.nsh
+++ b/common/uefi_scripts/pfdi.nsh
@@ -18,7 +18,7 @@
 
 echo -off
 
-for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%i:\yocto_image.flag then
         if exist FS%i:\acs_results_template\acs_results then
             FS%i:

--- a/common/uefi_scripts/sbsa.nsh
+++ b/common/uefi_scripts/sbsa.nsh
@@ -18,7 +18,7 @@
 
 echo -off
 
-for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%i:\acs_results_template\acs_results then
         if "%1" == "true" then
             FS%i:

--- a/common/uefi_scripts/startup.nsh
+++ b/common/uefi_scripts/startup.nsh
@@ -20,7 +20,7 @@ echo -off
 connect -r
 
 # check if BBSR SCT in progress, if yes resume the run.
-for %b in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %b in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%b:\acs_tests\bbr\bbsr_inprogress.flag then
         echo "BBSR compliance testing in progress, Resuming ..."
         echo " "
@@ -29,7 +29,7 @@ for %b in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
 endfor
 
 # Run the config parser
-for %y in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %y in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%y:\acs_tests\parser\Parser.efi then
         if exist FS%y:\acs_tests\config\acs_run_config.ini then
             FS%y:
@@ -60,7 +60,7 @@ endfor
 :DoneParser
 
 # Run the SCT test
-for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%i:\acs_tests\bbr\SctStartup.nsh then
         echo " "
         echo "Running SCT test"
@@ -80,7 +80,7 @@ endfor
 :DoneSCT
 
 # Run the SCRT test
-for %k in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %k in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%k:\acs_tests\bbr\ScrtStartup.nsh then
         echo " "
         echo "Running SCRT test"
@@ -100,7 +100,7 @@ endfor
 :DoneScrt
 
 # Run the Capsule dump
-for %e in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %e in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%e:\acs_results_template\acs_results then
         FS%e:
         cd FS%e:\acs_results_template\acs_results
@@ -125,7 +125,7 @@ endfor
 :DoneApp
 
 # Run the DebugDump
-for %p in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %p in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%p:\acs_tests\debug\debug_dump.nsh then
         echo " "
         echo "Running debug dump"
@@ -142,7 +142,7 @@ endfor
 :DoneDebug
 
 # Run the BSA test
-for %j in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %j in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%j:\acs_tests\bsa\bsa.nsh then
         echo " "
         echo "Running BSA test"
@@ -162,7 +162,7 @@ endfor
 :Donebsa
 
 # Run the SBSA test
-for %z in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %z in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%z:\acs_tests\bsa\sbsa\sbsa.nsh then
         echo " "
         echo "Running SBSA test"
@@ -181,7 +181,7 @@ endfor
 :Donesbsa
 
 # Boot Linux
-for %l in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %l in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%l:\Image and exist FS%l:\ramdisk-buildroot.img then
         FS%l:
         cd FS%l:\

--- a/common/uefi_scripts/startup_dt.nsh
+++ b/common/uefi_scripts/startup_dt.nsh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # @file
-# Copyright (c) 2021-2025, Arm Limited or its affiliates. All rights reserved.
+# Copyright (c) 2021-2026, Arm Limited or its affiliates. All rights reserved.
 # SPDX-License-Identifier : Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@
 echo -off
 connect -r
 
-for %x in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %x in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
   if exist FS%x:\acs_tests\bbr\boot_tolinuxprompt.flag then
       echo "Secure Boot just cleared. Skipping ACS tests and booting Linux..."
       goto BootLinux
@@ -27,7 +27,7 @@ for %x in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
 endfor
 
 #Start HTTPs Boot from uefi shell
-for %h in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %h in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
   if exist FS%h:\acs_tests\app\https_boot_pending.flag then
     FS%h:
     echo "HTTPS/HTTP network boot requested, launching https_boot.nsh..."
@@ -45,21 +45,21 @@ for %h in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
 endfor
 :DoneHTTPSBootCheck
 
-for %f in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %f in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
   if exist FS%f:\acs_tests\app\network_boot_failed.flag then
     echo "HTTPS network boot previously failed. Cleaning flag and booting Linux..."
     goto BootLinux
   endif
 endfor
 
-for %x in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %x in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
   if exist FS%x:\acs_tests\app\network_boot_success.flag then
     echo "HTTPS network boot previously completed. Skipping ACS tests and booting Linux..."
     goto BootLinux
   endif
 endfor
 
-for %y in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %y in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
   if exist FS%y:\acs_tests\app\network_boot_in_progress.flag then
     echo "WARNING: network_boot_in_progress flag found. Network boot failed,  please check logs, booting Linux..."
     goto BootLinux
@@ -67,7 +67,7 @@ for %y in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
 endfor
 
 # Clearing Secure Boot Key
-for %d in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %d in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%d:\acs_tests\bbr\clear_secureboot.flag then
         FS%d:
         cd \acs_tests\app
@@ -107,7 +107,7 @@ for %d in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
 endfor
 
 # check if BBSR SCT in progress, if yes resume the run.
-for %b in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %b in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%b:\acs_tests\bbr\bbsr_inprogress.flag then
         echo "BBSR compliance testing in progress, Resuming ..."
         echo " "
@@ -116,7 +116,7 @@ for %b in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
 endfor
 
 # Run the SCT test
-for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%i:\acs_tests\bbr\SctStartup.nsh then
         echo " "
         echo "Running SCT test"
@@ -127,7 +127,7 @@ endfor
 :DoneSCT
 
 # Run the Capsule dump
-for %e in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %e in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%e:\acs_results_template\acs_results then
         FS%e:
         cd FS%e:\acs_results_template\acs_results
@@ -150,7 +150,7 @@ endfor
 :DoneApp
 
 # Run the DebugDump 
-for %p in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %p in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%p:\acs_tests\debug\debug_dump.nsh then
         echo " "
         echo "Running debug dump"
@@ -161,7 +161,7 @@ endfor
 :DoneDebug
 
 # Run the BSA test
-for %j in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %j in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%j:\acs_tests\bsa\bsa.nsh then
         echo " "
         echo "Running BSA test"
@@ -172,7 +172,7 @@ endfor
 :Donebsa
 
 # Run the PFDI test
-for %k in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %k in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%k:\acs_tests\pfdi\pfdi.nsh then
         echo " "
         echo "Running pfdi test"
@@ -183,7 +183,7 @@ endfor
 :Donepfdi
 
 # Run the pingtest
-for %m in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %m in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%m:\acs_tests\debug\pingtest.nsh then
         FS%m:
         cd FS%m:\acs_results_template\acs_results
@@ -212,7 +212,7 @@ endfor
 :DonePing
 
 # Run the capsule update test
-for %r in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %r in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%r:\acs_tests\app\capsule_update.nsh then
         echo " "
         echo "Running capsule update test"
@@ -225,7 +225,7 @@ endfor
 goto BootLinux
 
 :BootLinux
-for %l in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %l in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%l:\Image and exist FS%l:\yocto_image.flag then
         FS%l:
         cd FS%l:\

--- a/common/uefi_scripts/startup_ee.nsh
+++ b/common/uefi_scripts/startup_ee.nsh
@@ -19,7 +19,7 @@
 echo -off
 connect -r
 
-for %i in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
+for %i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 then
     if exist FS%i:\acs_tests\parser\Parser.efi then
         FS%i:
         echo "UEFI Execution Environment can be used to run an acs test suite manually with desired options"

--- a/docs/UEFI_pingtest_guide.md
+++ b/docs/UEFI_pingtest_guide.md
@@ -42,7 +42,7 @@ Logs are stored at the following path:
 
 This script:
 
-- Scans filesystems `FS0:` through `FSF:`.
+- Scans filesystems `FS0:` through `FS20:`.
 - Looks for `pingtest.nsh` in `\acs_tests\debug\`.
 - Switches to the results directory and ensures `network_logs` exists.
 - Executes `ping 8.8.8.8` and saves output to `ping.log`.


### PR DESCRIPTION
-replace FSA through FSF with FS10 through FS15 and extend every
 UEFI filesystem scan consistently through FS20
-use the same 21-filesystem range across automatic, resume, parser,
 debug, capsule, HTTPS boot, and suite execution paths
-align the ping-test guide with the FS20 upper bound

Fixes #789 

Change-Id: I50d72dca6acee5d0baf977f3f9aa766ddb547cd1