### PR TITLE
(fix):use detected filesystem for SCRT fallback

### DIFF
--- a/common/uefi_scripts/startup.nsh
+++ b/common/uefi_scripts/startup.nsh
@@ -86,7 +86,7 @@ for %k in 0 1 2 3 4 5 6 7 8 9 A B C D E F then
         echo "Running SCRT test"
         if "%config_enabled_for_automation_run%" == "" then
             echo "config_enabled_for_automation_run variable does not exist"
-            FS%i:\acs_tests\bbr\ScrtStartup.nsh false
+            FS%k:\acs_tests\bbr\ScrtStartup.nsh false
             goto DoneScrt
         endif
         if "%config_enabled_for_automation_run%" == "true" then


### PR DESCRIPTION
-use the SCRT loop variable when automation configuration is
 unavailable, preventing use of the SCT filesystem index


Change-Id: I232e744193b560db3cd3950d8bb19d24790662a3