### PR TITLE
(feat): upgrade Yocto Linux and DT bindings

### DIFF
--- a/SystemReady-devicetree-band/README.md
+++ b/SystemReady-devicetree-band/README.md
@@ -51,9 +51,9 @@ The SystemReady-devicetree band compliance and testing requirements are specifie
 
 | Component                                                                   | Version           |
 |-----------------------------------------------------------------------------|-------------------|
-| [Linux Kernel](https://git.yoctoproject.org/linux-yocto/)                   | v6.18             |
+| [Linux Kernel](https://git.yoctoproject.org/linux-yocto/)                   | v7.2.2             |
 | [EDK2](https://github.com/tianocore/edk2.git)                               | edk2-stable202511 |
-| [DT bindings source](https://cdn.kernel.org/pub/linux/kernel/v6.x/)         | v6.19             |
+| [DT bindings source](https://cdn.kernel.org/pub/linux/kernel/v7.x/)         | v7.2.3            |
 
 
 ### Prebuilt images

--- a/SystemReady-devicetree-band/Yocto/build-scripts/get_source.sh
+++ b/SystemReady-devicetree-band/Yocto/build-scripts/get_source.sh
@@ -77,7 +77,7 @@ copy_recipes()
     rm $TOP_DIR/meta-woden/poky/meta/recipes-kernel/linux/linux-yocto_6.6.bb
 
     #Increase the initramfs size to hold more storage drivers in ACS image
-    sed -i 's/INITRAMFS_MAXSIZE ??= "131072"/INITRAMFS_MAXSIZE ??= "196000"/' $TOP_DIR/meta-woden/poky/meta/conf/bitbake.conf
+    sed -i 's/INITRAMFS_MAXSIZE ??= "131072"/INITRAMFS_MAXSIZE ??= "256000"/' $TOP_DIR/meta-woden/poky/meta/conf/bitbake.conf
 
 
     #copy linux_yocto.bbappend with empty defconfig

--- a/SystemReady-devicetree-band/Yocto/meta-woden/conf/distro/woden.conf
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/conf/distro/woden.conf
@@ -108,7 +108,7 @@ EFI_PROVIDER = "grub-efi"
 
 # Suffixing the build directory with the libc is pointless
 TCLIBCAPPEND = ""
-PREFERRED_VERSION_linux-yocto = "6.18%"
+PREFERRED_VERSION_linux-yocto = "7.2.2%"
 PREFERRED_VERSION_fwts = "26.01.00"
 PREFERRED_VERSION_python3-dtschema = "2025.2"
 PREFERRED_VERSION_grub = "2.06"

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-drv/bsa-acs-drv.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-drv/bsa-acs-drv.bb
@@ -9,6 +9,7 @@ inherit module-base
 
 SRC_URI += "git://github.com/ARM-software/sysarch-acs;destsuffix=sysarch-acs;protocol=https;branch=main;name=sysarch-acs \
             git://git.gitlab.arm.com/linux-arm/linux-acs.git;destsuffix=linux-acs;protocol=https;branch=master;name=linux-acs \
+            file://0001-pal-linux-adapt-to-Linux-7.2-kernel-APIs.patch;patchdir=${WORKDIR}/linux-acs \
             "
 SRCREV_FORMAT = "sysarch-acs_linux-acs"
 SRCREV_sysarch-acs = "${AUTOREV}"

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-drv/files/0001-pal-linux-adapt-to-Linux-7.2-kernel-APIs.patch
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/bsa-acs-drv/files/0001-pal-linux-adapt-to-Linux-7.2-kernel-APIs.patch
@@ -1,0 +1,67 @@
+From 35a7e9bc6b96621e28cb730693b512cfa55b8342 Mon Sep 17 00:00:00 2001
+From: Sathisha S <Sathisha.Shivaramappa@arm.com>
+Date: Fri, 4 Sep 2026 11:30:00 +0000
+Subject: [PATCH] pal_linux: adapt to Linux 7.2 kernel APIs
+
+Linux 7.2 removes strncpy and struct device::dma_coherent. Use the string
+and DMA helpers supported by the current kernel API.
+
+Signed-off-by: Sathisha S <Sathisha.Shivaramappa@arm.com>
+---
+ acs-drv/files/platform/pal_linux/files/src/pal_dma.c    | 3 ++-
+ acs-drv/files/platform/pal_linux/files/src/pal_iovirt.c | 5 +++--
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/acs-drv/files/platform/pal_linux/files/src/pal_iovirt.c b/acs-drv/files/platform/pal_linux/files/src/pal_iovirt.c
+index 9d49abc..541a0c7 100644
+--- a/acs-drv/files/platform/pal_linux/files/src/pal_iovirt.c
++++ b/acs-drv/files/platform/pal_linux/files/src/pal_iovirt.c
+@@ -22,6 +22,7 @@
+ #include <linux/acpi_iort.h>
+ #include <linux/kernel.h>
+ #include <linux/pci.h>
++#include <linux/string.h>
+ #include <linux/version.h>
+ 
+ #include "include/pal_linux.h"
+@@ -266,7 +267,7 @@ iovirt_add_block(struct acpi_table_iort *iort, struct acpi_iort_node *iort_node,
+             count = &iovirt_table->num_its_groups;
+             break;
+         case ACPI_IORT_NODE_NAMED_COMPONENT:
+-            strncpy((char*)(*data).named_comp.name, (char*)&((struct acpi_iort_named_component*)node_data)->device_name[0], 16);
++            strscpy((char*)(*data).named_comp.name, (char*)&((struct acpi_iort_named_component*)node_data)->device_name[0], 16);
+             (*data).named_comp.cca = (uint32_t)(((struct acpi_iort_named_component*)node_data)->memory_properties & IOVIRT_CCA_MASK);
+             count = &iovirt_table->num_named_components;
+             break;
+@@ -564,7 +565,7 @@ acpi_status user_function(acpi_handle handle, uint32_t level,
+ 
+   buffer.length = ACPI_ALLOCATE_BUFFER;
+   status = acpi_get_name(handle, ACPI_FULL_PATHNAME, &buffer);
+-  strncpy((char *)path_buffer[count++], (char *)(buffer.pointer), 16);
++  strscpy((char *)path_buffer[count++], (char *)(buffer.pointer), 16);
+   return status;
+ }
+ 
+diff --git a/acs-drv/files/platform/pal_linux/files/src/pal_dma.c b/acs-drv/files/platform/pal_linux/files/src/pal_dma.c
+index 50d9a32..a6f7ca8 100644
+--- a/acs-drv/files/platform/pal_linux/files/src/pal_dma.c
++++ b/acs-drv/files/platform/pal_linux/files/src/pal_dma.c
+@@ -20,6 +20,7 @@
+  */
+ 
++#include <linux/dma-map-ops.h>
+ #include <linux/init.h>
+ #include <linux/module.h>
+ #include <linux/pci.h>
+ #include <linux/string.h>
+@@ -218,7 +219,7 @@ void pal_dma_create_info_table(DMA_INFO_TABLE *dma_info_table)
+                     /* if we did not get coherence attribute from ACPI/PCI, get it from FDT */
+                     if (dma_info_table->info[j].flags == 0) {
+-#if LINUX_VERSION_CODE > KERNEL_VERSION(4,19,0)
+-                        dma_info_table->info[j].flags = shost->dma_dev->dma_coherent;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7,2,0)
++                        dma_info_table->info[j].flags = dev_is_dma_coherent(shost->dma_dev);
+ #else
+                         dma_info_table->info[j].flags = shost->dma_dev->archdata.dma_coherent;
+ #endif
+

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/install-files/files/init.sh
@@ -33,7 +33,7 @@ fi
 sleep 5
 
 DT_VERSION="SystemReady devicetree band ACS v3.1.2"
-KERNEL_VERSION="7.1.3"
+KERNEL_VERSION="7.2.3"
 
 echo "Attempting to mount the results partition ..."
 #mount result partition

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/process-schema/process-schema.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-acs/process-schema/process-schema.bb
@@ -4,13 +4,13 @@ S = "${WORKDIR}"
 
 DEPENDS = "python3-native python3-dtschema-native "
 
-SRC_URI = "https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-7.1.3.tar.xz"
-SRC_URI[sha256sum] = "be41c068e88f5242a19bccdbffbe077b18c47b45f627e2325504b4fab79dd1dc"
+SRC_URI = "https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-7.2.3.tar.xz"
+SRC_URI[sha256sum] = "8ba259e8e7b13ec6ef0941c8a39ad90b24bd4a4d6c0010ba6bafb794550ecd03"
 
 do_install(){
-    install -d ${D}${bindir}/linux-7.1.3/bindings
-    cp -r ${S}/linux-7.1.3/Documentation/devicetree/bindings ${D}/${bindir}/linux-7.1.3/bindings
-    dt-mk-schema -j ${D}/${bindir}/linux-7.1.3/bindings > processed_schema.json
+    install -d ${D}${bindir}/linux-7.2.3/bindings
+    cp -r ${S}/linux-7.2.3/Documentation/devicetree/bindings ${D}/${bindir}/linux-7.2.3/bindings
+    dt-mk-schema -j ${D}/${bindir}/linux-7.2.3/bindings > processed_schema.json
     cp -r ${S}/processed_schema.json ${D}/${bindir}/
 }
 

--- a/SystemReady-devicetree-band/Yocto/meta-woden/recipes-kernel/linux/linux-yocto_7.2.bb
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/recipes-kernel/linux/linux-yocto_7.2.bb
@@ -1,0 +1,81 @@
+KBRANCH ?= "v7.2/standard/base"
+
+require recipes-kernel/linux/linux-yocto.inc
+
+# CVE exclusions
+include recipes-kernel/linux/cve-exclusion.inc
+
+# board specific branches
+KBRANCH:qemuarm  ?= "v7.2/standard/arm-versatile-926ejs"
+KBRANCH:qemuarm64 ?= "v7.2/standard/base"
+KBRANCH:qemumips ?= "v7.2/standard/mti-malta"
+KBRANCH:qemuppc  ?= "v7.2/standard/qemuppc"
+KBRANCH:qemuriscv64  ?= "v7.2/standard/base"
+KBRANCH:qemuriscv32  ?= "v7.2/standard/base"
+KBRANCH:qemux86  ?= "v7.2/standard/base"
+KBRANCH:qemux86-64 ?= "v7.2/standard/base"
+KBRANCH:qemuloongarch64  ?= "v7.2/standard/base"
+KBRANCH:qemumips64 ?= "v7.2/standard/mti-malta"
+
+SRCREV_machine:qemuarm ?= "6390ad2592faab51e5930cdcd4073805ebeb3096"
+SRCREV_machine:qemuarm64 ?= "eaf351389aa8a14680ad327afecb5abb78347081"
+SRCREV_machine:qemuloongarch64 ?= "eaf351389aa8a14680ad327afecb5abb78347081"
+SRCREV_machine:qemumips ?= "ab0e33fefa2a3d0366b2b8deb7cfb3be2d8dc436"
+SRCREV_machine:qemuppc ?= "eaf351389aa8a14680ad327afecb5abb78347081"
+SRCREV_machine:qemuriscv64 ?= "eaf351389aa8a14680ad327afecb5abb78347081"
+SRCREV_machine:qemuriscv32 ?= "eaf351389aa8a14680ad327afecb5abb78347081"
+SRCREV_machine:qemux86 ?= "eaf351389aa8a14680ad327afecb5abb78347081"
+SRCREV_machine:qemux86-64 ?= "eaf351389aa8a14680ad327afecb5abb78347081"
+SRCREV_machine:qemumips64 ?= "ab0e33fefa2a3d0366b2b8deb7cfb3be2d8dc436"
+SRCREV_machine ?= "eaf351389aa8a14680ad327afecb5abb78347081"
+SRCREV_meta ?= "48dd3364f8af7104c75e86ea3c2bd0e55352b59b"
+
+# set your preferred provider of linux-yocto to 'linux-yocto-upstream', and you'll
+# get the <version>/base branch, which is pure upstream -stable, and the same
+# meta SRCREV as the linux-yocto-standard builds. Select your version using the
+# normal PREFERRED_VERSION settings.
+BBCLASSEXTEND = "devupstream:target"
+SRCREV_machine:class-devupstream ?= "52c36105f76e96b638152a42e735f2e7767ed946"
+PN:class-devupstream = "linux-yocto-upstream"
+KBRANCH:class-devupstream = "v7.2/base"
+
+SRC_URI = "git://git.yoctoproject.org/linux-yocto.git;name=machine;branch=${KBRANCH};protocol=https \
+           git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-7.2;destsuffix=${KMETA};protocol=https \
+           file://0001-disable-psci-checker.patch;patch=1 \
+           file://0001-dt-ignore-compatibles.patch;patch=1 "
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+LINUX_VERSION ?= "7.2.2"
+
+PV = "${LINUX_VERSION}+git"
+
+KMETA = "kernel-meta"
+KCONF_BSP_AUDIT_LEVEL = "1"
+
+KERNEL_DEVICETREE:qemuarmv5 = "arm/versatile-pb.dtb"
+
+COMPATIBLE_MACHINE = "^(qemuarm|qemuarmv5|qemuarm64|qemux86|qemuppc|qemuppc64|qemumips|qemumips64|qemux86-64|qemuriscv64|qemuriscv32|qemuloongarch64)$"
+
+# Functionality flags
+KERNEL_EXTRA_FEATURES ?= "features/netfilter/netfilter.scc"
+KERNEL_FEATURES:append = " ${KERNEL_EXTRA_FEATURES}"
+KERNEL_FEATURES:append:qemuall = " cfg/virtio.scc features/drm-bochs/drm-bochs.scc cfg/net/mdio.scc"
+KERNEL_FEATURES:append:qemux86 = " cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append:qemux86-64 = " cfg/sound.scc cfg/paravirt_kvm.scc"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("TUNE_FEATURES", "mx32", " cfg/x32.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " features/scsi/scsi-debug.scc features/nf_tables/nft_test.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " features/gpio/mockup.scc features/gpio/sim.scc", "", d)}"
+KERNEL_FEATURES:append = " ${@bb.utils.contains("KERNEL_DEBUG", "True", " features/reproducibility/reproducibility.scc features/debug/debug-btf.scc", "", d)}"
+# libteam ptests from meta-oe needs it
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " features/net/team/team.scc", "", d)}"
+# openl2tp tests from meta-networking needs it
+KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "ptest", " cgl/cfg/net/l2tp.scc", "", d)}"
+KERNEL_FEATURES:append:powerpc = " arch/powerpc/powerpc-debug.scc"
+KERNEL_FEATURES:append:powerpc64 = " arch/powerpc/powerpc-debug.scc"
+KERNEL_FEATURES:append:powerpc64le = " arch/powerpc/powerpc-debug.scc"
+# Do not add debug info for riscv32, it fails during depmod
+# ERROR: modpost: __ex_table+0x17a4 references non-executable section '.debug_loclists'
+# Check again during next major version upgrade
+KERNEL_FEATURES:remove:riscv32 = "features/debug/debug-kernel.scc"
+INSANE_SKIP:kernel-vmlinux:qemuppc64 = "textrel"
+do_kernel_configcheck[noexec] = "1"

--- a/SystemReady-devicetree-band/Yocto/meta-woden/wic/woden.wks.in
+++ b/SystemReady-devicetree-band/Yocto/meta-woden/wic/woden.wks.in
@@ -1,4 +1,4 @@
-bootloader --ptable gpt --timeout=10 --append="rootfstype=ext4"
+bootloader --ptable gpt --timeout=10 --append="rootfstype=ext4 roottimeout=30"
 
 part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER}" --label BOOT_ACS --active --align 1024 --use-uuid --size 512M
 

--- a/common/config/systemready-dt-band-source.cfg
+++ b/common/config/systemready-dt-band-source.cfg
@@ -37,7 +37,7 @@
 
 # Linux kernel build tag/commit
 # SRC: https://git.yoctoproject.org/linux-yocto/
-LINUX_KERNEL_VERSION=6.18
+LINUX_KERNEL_VERSION=7.2.2
 
 # EDK2 build tag/commit
 # SRC: https://github.com/tianocore/edk2.git


### PR DESCRIPTION
Upgrade Linux to v7.2.2 and DT bindings to v7.2.3. Update linux-acs for Linux 7.2 APIs and increase initramfs size.


Change-Id: I86c7058a3e6e3fa88444e13f9c4b270c536d33d5